### PR TITLE
fix(carga-masiva): fecha -1 día y "dejar sin asignar" categorías (TAR-380)

### DIFF
--- a/src/components/movimientos/cargaMasiva/BatchValidationForm.js
+++ b/src/components/movimientos/cargaMasiva/BatchValidationForm.js
@@ -19,8 +19,8 @@ import {
   getOptionsFromContext,
 } from 'src/components/movementFieldsConfig';
 import { formatNumberWithThousands, parsearMonto } from 'src/utils/celulandia/separacionMiles';
-import { formatTimestamp } from 'src/utils/formatters';
 import { normalizarNombre } from 'src/utils/normalizarNombre';
+import { toDateInputValue } from './cargaMasivaMap';
 
 const MONEY_FIELDS = new Set([
   'total',
@@ -127,7 +127,9 @@ const BatchValidationForm = ({
   );
 
   const shouldShowProyecto = Boolean(camposConfig.proyecto);
-  const formatFecha = (val) => formatTimestamp(val) || '';
+  // input type="date" requiere YYYY-MM-DD. toDateInputValue normaliza con componentes UTC
+  // (evita el -1 día que daba formatTimestamp con getters locales en UTC-3).
+  const formatFecha = (val) => toDateInputValue(val);
 
   const handleFieldChange = (name, value) => onFormChange({ ...form, [name]: value });
 

--- a/src/components/movimientos/cargaMasiva/__tests__/cargaMasivaMap.test.js
+++ b/src/components/movimientos/cargaMasiva/__tests__/cargaMasivaMap.test.js
@@ -1,10 +1,4 @@
-jest.mock(
-  'src/utils/formatters',
-  () => ({ formatTimestamp: (v) => (typeof v === 'string' ? v : '') }),
-  { virtual: true },
-);
-
-import { copyShareableFields, SHAREABLE_FIELDS } from '../cargaMasivaMap';
+import { copyShareableFields, SHAREABLE_FIELDS, toDateInputValue } from '../cargaMasivaMap';
 
 const baseForm = () => ({
   type: '',
@@ -132,5 +126,34 @@ describe('copyShareableFields', () => {
         'etapa',
       ]),
     );
+  });
+});
+
+describe('toDateInputValue', () => {
+  test('YYYY-MM-DD se devuelve tal cual', () => {
+    expect(toDateInputValue('2026-05-07')).toBe('2026-05-07');
+  });
+
+  test('DD/MM/YYYY se reordena a YYYY-MM-DD', () => {
+    expect(toDateInputValue('7/5/2026')).toBe('2026-05-07');
+    expect(toDateInputValue('07/05/2026')).toBe('2026-05-07');
+  });
+
+  test('ISO a medianoche UTC NO corre un día (bug -1)', () => {
+    // En UTC-3 los getters locales devolvían el día anterior (06). Debe ser 07.
+    expect(toDateInputValue('2026-05-07T00:00:00.000Z')).toBe('2026-05-07');
+  });
+
+  test('Firestore Timestamp ({seconds}) usa el día calendario UTC', () => {
+    // 2026-05-07 13:30:00 UTC -> ancla mediodía, día estable
+    const seconds = Math.floor(Date.UTC(2026, 4, 7, 13, 30, 0) / 1000);
+    expect(toDateInputValue({ seconds })).toBe('2026-05-07');
+    expect(toDateInputValue({ _seconds: seconds })).toBe('2026-05-07');
+  });
+
+  test('valores vacíos devuelven string vacío', () => {
+    expect(toDateInputValue('')).toBe('');
+    expect(toDateInputValue(null)).toBe('');
+    expect(toDateInputValue(undefined)).toBe('');
   });
 });

--- a/src/components/movimientos/cargaMasiva/cargaMasivaMap.js
+++ b/src/components/movimientos/cargaMasiva/cargaMasivaMap.js
@@ -1,27 +1,40 @@
-import { formatTimestamp } from 'src/utils/formatters';
-
 /**
  * Normaliza a YYYY-MM-DD para input type="date".
+ *
+ * Usa componentes UTC para los timestamps/ISO: las fechas de movimientos se persisten
+ * ancladas a las 13:30 (mediodía), así que el día calendario en UTC es estable y evita
+ * el corrimiento de -1 día que daban los getters locales en zonas negativas (UTC-3) cuando
+ * la fecha venía como medianoche UTC / ISO desde el OCR de fotos.
  */
 export function toDateInputValue(v) {
   if (!v && v !== 0) return '';
+  // Ya viene como YYYY-MM-DD
   if (typeof v === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(v)) return v;
-  const ft = formatTimestamp(v);
-  if (ft && /^\d{4}-\d{2}-\d{2}$/.test(ft)) return ft;
+  // DD/MM/YYYY
   if (typeof v === 'string' && /^\d{1,2}\/\d{1,2}\/\d{4}$/.test(v.trim())) {
     const [d, m, y] = v.trim().split('/');
     return `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
   }
-  if (typeof v === 'string') {
-    const d = new Date(v);
-    if (!Number.isNaN(d.getTime())) {
-      const y = d.getFullYear();
-      const mo = String(d.getMonth() + 1).padStart(2, '0');
-      const da = String(d.getDate()).padStart(2, '0');
-      return `${y}-${mo}-${da}`;
+  // Firestore Timestamp ({seconds}/{_seconds} o .toDate()), ISO string, Date o epoch ms
+  let ms = null;
+  if (typeof v === 'object') {
+    if (typeof v.toDate === 'function') ms = v.toDate().getTime();
+    else {
+      const seconds = v.seconds !== undefined ? v.seconds : v._seconds;
+      if (seconds !== undefined) ms = seconds * 1000;
     }
+  } else if (typeof v === 'string') {
+    const parsed = Date.parse(v);
+    if (!Number.isNaN(parsed)) ms = parsed;
+  } else if (typeof v === 'number') {
+    ms = v;
   }
-  return '';
+  if (ms === null) return '';
+  const d = new Date(ms);
+  const y = d.getUTCFullYear();
+  const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const da = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${mo}-${da}`;
 }
 
 /**

--- a/src/sections/importMovimientos/PasoControlEntidadesOcr.js
+++ b/src/sections/importMovimientos/PasoControlEntidadesOcr.js
@@ -49,7 +49,7 @@ function buildFilas(items, getValor, catalogo, getNombreCatalogo, excluidas) {
   });
 }
 
-function FilaTabla({ fila, onAccionChange }) {
+function FilaTabla({ fila, onAccionChange, permitirSinAsignar = false }) {
   const chipColor = fila.estado === 'nueva' ? 'warning' : fila.estado === 'variante' ? 'info' : 'success';
   const chipLabel =
     fila.estado === 'variante'
@@ -65,6 +65,9 @@ function FilaTabla({ fila, onAccionChange }) {
           { value: 'usar_existente', label: `✓ Usar "${fila.coincidencia}"` },
           { value: 'crear_nueva', label: `✨ Crear como "${fila.detectado}"` },
         ];
+  if (permitirSinAsignar) {
+    opciones.push({ value: 'dejar_sin_asignar', label: '⏸️ Dejar sin asignar' });
+  }
 
   return (
     <TableRow>
@@ -142,7 +145,10 @@ const PasoControlEntidadesOcr = forwardRef(
         submitStep: async () => {
           const mapeoCat = new Map();
           filasCategorias.forEach((f) => {
-            const final = f.accion === 'usar_existente' && f.coincidencia ? f.coincidencia : f.detectado;
+            let final;
+            if (f.accion === 'dejar_sin_asignar') final = '';
+            else if (f.accion === 'usar_existente' && f.coincidencia) final = f.coincidencia;
+            else final = f.detectado;
             mapeoCat.set(f.detectadoNorm, final);
           });
           const mapeoProv = new Map();
@@ -156,7 +162,9 @@ const PasoControlEntidadesOcr = forwardRef(
               if (it.omitido) return it;
               const cat = it.form?.categoria;
               const prov = it.form?.nombre_proveedor;
-              const catFinal = cat ? mapeoCat.get(normalizarNombre(cat)) || cat : cat;
+              const catNorm = cat ? normalizarNombre(cat) : null;
+              // Usar .has() para respetar '' (dejar sin asignar), que con `|| cat` volvería a la original.
+              const catFinal = catNorm && mapeoCat.has(catNorm) ? mapeoCat.get(catNorm) : cat;
               const provFinal = prov ? mapeoProv.get(normalizarNombre(prov)) || prov : prov;
               if (catFinal === cat && provFinal === prov) return it;
               return {
@@ -201,7 +209,12 @@ const PasoControlEntidadesOcr = forwardRef(
                   </TableHead>
                   <TableBody>
                     {filasCategorias.map((f) => (
-                      <FilaTabla key={f.detectadoNorm} fila={f} onAccionChange={onAccionCategoria} />
+                      <FilaTabla
+                        key={f.detectadoNorm}
+                        fila={f}
+                        onAccionChange={onAccionCategoria}
+                        permitirSinAsignar
+                      />
                     ))}
                   </TableBody>
                 </Table>

--- a/src/sections/importMovimientos/PasoRevisarCategorias.js
+++ b/src/sections/importMovimientos/PasoRevisarCategorias.js
@@ -664,7 +664,7 @@ const PasoRevisarCategorias = forwardRef(({
                                   ? `Variante de "${categoria.mapeoA}"`
                                   : categoria.estado === 'nueva'
                                     ? 'Nueva - Se creará'
-                                    : 'Existe en Sorby'
+                                    : 'Ya existe'
                             }
                             color={
                               categoria.accion === 'mapear_a_existente'


### PR DESCRIPTION
## Contexto
Ticket **TAR-380** — Carga masiva (flujo OCR/foto): validación de categorías detectadas y fecha corrida un día.
https://www.notion.so/36650a1e534180819e90f7b58f6c9235

## Cambios

### 1. Fecha "un día menos" (bug timezone) — el principal
El backend devuelve `fecha_factura` correcta (ej. `"2025-06-05"`), pero `BatchValidationForm` re-formateaba el valor del `input type="date"` con el `formatTimestamp` **compartido**, que hace `new Date("2025-06-05")` (medianoche UTC) y lee con getters **locales** → en UTC-3 devuelve `"2025-06-04"`.
- `BatchValidationForm.js`: `formatFecha` ahora usa `toDateInputValue` (componentes UTC).
- `cargaMasivaMap.js`: `toDateInputValue` reescrito UTC-safe (sin depender de `formatTimestamp`).
- **Acotado a carga masiva** — no se toca el `formatTimestamp` global (tiene el mismo −1 latente en otras pantallas → posible ticket aparte).

### 2. Opción "Dejar sin asignar" categorías
`PasoControlEntidadesOcr.js`: nueva acción **⏸️ Dejar sin asignar** por categoría detectada. El movimiento queda **sin categoría** (`form.categoria = ''`), no se crea nada en el catálogo. Incluye fix de `mapeoCat` con `.has()` para respetar el string vacío (antes `|| cat` lo ignoraba).

### 3. Wording
`PasoRevisarCategorias.js`: chip "Existe en Sorby" → **"Ya existe"** (despeja la duda del ticket sobre "categorías globales"; se verificó que el match/prompt usan las categorías de la empresa, no un catálogo global).

## Verificación
- Reproducido con el dato crudo del backend: `new Date("2025-06-05").getDate()` = 4 en UTC-3; `toDateInputValue("2025-06-05")` = `"2025-06-05"`.
- ESLint limpio. Tests: 12/12 en `cargaMasivaMap.test.js` (agregados casos de medianoche UTC / timestamp / dd-mm-yyyy).

## Checklist manual
- [ ] Foto con fecha conocida (ej. día 5) → "Fecha de la Factura" muestra el día 5 (no 4). Editar manual → guarda el día elegido.
- [ ] Categoría "No existe" → dropdown muestra "⏸️ Dejar sin asignar" → el comprobante queda sin categoría al confirmar.
- [ ] Regresión: match exacto/variante sigue ofreciendo "Usar"/"Crear"; proveedores sin cambios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)