### PR TITLE
feat(carga-masiva): detalle de movimientos rechazados en el resumen (TAR-284)

### DIFF
--- a/src/sections/importMovimientos/PasoResumen.js
+++ b/src/sections/importMovimientos/PasoResumen.js
@@ -43,6 +43,30 @@ import importMovimientosService from 'src/services/importMovimientosService';
 import { useAuthContext } from 'src/contexts/auth-context';
 import { getProyectosByEmpresa } from 'src/services/proyectosService';
 
+// Las filas rechazadas traen los datos crudos de la planilla, cuyas columnas
+// varían según el archivo (Excel/CSV/PDF/imagen). Buscamos los campos clave
+// por patrón de nombre para armar un resumen legible; si no aparece, queda "—".
+const buscarCampoFila = (datos, patrones) => {
+  if (!datos || typeof datos !== 'object') return '';
+  const claves = Object.keys(datos);
+  for (const patron of patrones) {
+    const clave = claves.find((k) => patron.test(k));
+    const valor = clave != null ? datos[clave] : undefined;
+    if (valor !== null && valor !== undefined && String(valor).trim() !== '') {
+      return String(valor).trim();
+    }
+  }
+  return '';
+};
+
+const resumirFilaRechazada = (datos) => ({
+  fecha: buscarCampoFila(datos, [/fecha/i]),
+  importe: buscarCampoFila(datos, [/importe/i, /monto/i, /total/i, /valor/i]),
+  detalle:
+    buscarCampoFila(datos, [/proveedor/i]) ||
+    buscarCampoFila(datos, [/descrip/i, /detalle/i, /concepto/i, /observ/i, /glosa/i]),
+});
+
 const PasoResumen = ({
   empresa,
   wizardData,
@@ -354,7 +378,8 @@ const PasoResumen = ({
   }
 
   if (resultadoImport) {
-    const { total, exitosos, fallidos, codigo } = resultadoImport;
+    const { total, exitosos, fallidos, codigo, detalles } = resultadoImport;
+    const filasRechazadas = Array.isArray(detalles?.fallidos) ? detalles.fallidos : [];
     
     return (
       <Box>
@@ -379,10 +404,77 @@ const PasoResumen = ({
           </Alert>
         )}
 
-        {fallidos > 0 && (
+        {fallidos > 0 && filasRechazadas.length === 0 && (
           <Alert severity="warning" sx={{ mb: 3 }}>
             {formatNumber(fallidos)} movimientos no se pudieron importar
           </Alert>
+        )}
+
+        {filasRechazadas.length > 0 && (
+          <Card
+            variant="outlined"
+            sx={{ mb: 3, borderColor: 'warning.light', overflow: 'hidden' }}
+          >
+            <Box
+              sx={{
+                px: 2.5,
+                py: 1.75,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+                bgcolor: 'rgba(237,108,2,0.06)',
+                borderBottom: '1px solid',
+                borderColor: 'warning.light',
+              }}
+            >
+              <WarningIcon color="warning" />
+              <Box sx={{ minWidth: 0 }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 700, lineHeight: 1.2 }}>
+                  {formatNumber(filasRechazadas.length)} movimientos no se importaron
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Revisá el motivo, corregilos en tu planilla y volvé a importarlos.
+                </Typography>
+              </Box>
+            </Box>
+            <TableContainer sx={{ maxHeight: 360 }}>
+              <Table size="small" stickyHeader>
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ fontWeight: 700, width: 64 }}>Fila</TableCell>
+                    <TableCell sx={{ fontWeight: 700 }}>Fecha</TableCell>
+                    <TableCell sx={{ fontWeight: 700 }} align="right">Importe</TableCell>
+                    <TableCell sx={{ fontWeight: 700 }}>Proveedor / Detalle</TableCell>
+                    <TableCell sx={{ fontWeight: 700 }}>Motivo</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {filasRechazadas.map((item, idx) => {
+                    const r = resumirFilaRechazada(item.datos);
+                    const motivo = item.motivo || item.error || 'No se pudo importar';
+                    return (
+                      <TableRow key={`${item.fila ?? 'fila'}-${idx}`} hover>
+                        <TableCell sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}>
+                          {item.fila ?? '—'}
+                        </TableCell>
+                        <TableCell sx={{ whiteSpace: 'nowrap' }}>{r.fecha || '—'}</TableCell>
+                        <TableCell align="right" sx={{ whiteSpace: 'nowrap', fontVariantNumeric: 'tabular-nums' }}>
+                          {r.importe || '—'}
+                        </TableCell>
+                        <TableCell
+                          title={r.detalle || undefined}
+                          sx={{ maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                        >
+                          {r.detalle || '—'}
+                        </TableCell>
+                        <TableCell sx={{ color: 'warning.dark' }}>{motivo}</TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Card>
         )}
 
         {/* Lista de proyectos simplificada */}

--- a/src/sections/importMovimientos/PasoValidarMovimientosImport.js
+++ b/src/sections/importMovimientos/PasoValidarMovimientosImport.js
@@ -270,12 +270,16 @@ const PasoValidarMovimientosImport = forwardRef(
         setError('Incluí al menos un movimiento (no podés continuar con todos excluidos).');
         throw new Error('Sin movimientos');
       }
+      // Las filas incompletas NO se bloquean: se envían igual y el backend las
+      // rechaza, apareciendo en el resumen final con su motivo (ticket TAR-284).
+      // Solo avisamos para que el usuario sepa que no se importarán.
       const invalidos = incluidos.filter((r) => !rowIsValid(r, requiereProyecto));
       if (invalidos.length > 0) {
         setError(
-          `Hay ${invalidos.length} movimiento(s) con datos incompletos. Corregilos o excluílos antes de continuar.`,
+          `${invalidos.length} movimiento(s) con datos incompletos no se importarán y aparecerán como rechazados en el resumen.`,
         );
-        throw new Error('Validación');
+      } else {
+        setError('');
       }
 
       const payload = incluidos.map((r) => ({


### PR DESCRIPTION
## TAR-284 — Mostrar detalle de movimientos rechazados en carga masiva (web)

Al finalizar una **carga masiva por planilla (Excel/CSV)** desde el dashboard (Cajas → Acciones → Importar → Carga masiva → Planilla), el resumen ahora **lista los movimientos que no se importaron con su motivo**, en lugar de solo `X de Y importados`.

### Cambios (frontend)
- **`PasoResumen.js`** — nueva tabla de rechazados: `Fila · Fecha · Importe · Proveedor/Detalle · Motivo`, leyendo `detalles.fallidos`. Helpers puros (`buscarCampoFila`/`resumirFilaRechazada`) hacen extracción best-effort de la fila cruda (las columnas varían por archivo); si no se encuentra, muestra `—`.
- **`PasoValidarMovimientosImport.js`** — ⚠️ **cambio de comportamiento:** las filas incompletas **ya no bloquean** el avance; se envían y aparecen como rechazadas en el resumen (intención del ticket). Antes obligaban a excluirlas, por lo que nunca llegaban al resumen.

### Backend
Requiere el PR de `sorby_bot_wa`: **fedemaidan/sorby_bot_wa → `feat/tar-284-detalle-rechazados-carga-masiva`** (enriquece `fallidos` con `motivo` + `datos`).

### Pruebas
- Validado end-to-end por la entrada correcta con un CSV de 8 filas (5 válidas + 3 nota/total) → resumen: **5 de 8 importados · 3 rechazados** con motivo *"Falta el importe o tiene un formato inválido"*.
- Helpers de extracción y clasificador verificados como funciones puras; lint OK.

### Nota / fuera de alcance
- El caso **imagen/PDF (OCR)** no se toca (la etapa de Validación ya muestra la imagen; inputs vacíos si no detecta).
- Se detectó un **bug preexistente, ajeno a este PR**: "Eliminar Importación" (`DELETE /importar-movimientos/eliminar/:codigoSync`) no encuentra los movimientos por `codigo_sync` (`find` devuelve `[]`). Conviene ticket aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)