### PR TITLE
fix(acopio): persistir valor acopiado manual en edición

### DIFF
--- a/src/pages/editarAcopio.js
+++ b/src/pages/editarAcopio.js
@@ -456,10 +456,13 @@ const goNext = () => setCurrentIdx((i) => (i + 1) % (urls?.length || 0));
       }
       
       // 4. Actualizar campos del acopio (PATCH) - tipo, url_image
-      // Nota: valor_acopio ya NO se envía — el backend lo calcula atómicamente con $inc
+      // En modo automático el backend ya calculó valor_acopio atómicamente con $inc al sincronizar
+      // productos, así que NO lo enviamos. En modo manual el usuario fijó un valor independiente
+      // de la suma de productos, por lo que lo persistimos de forma absoluta (override).
       const camposAcopio = {
         tipo: tipoLista,
         url_image: urls,
+        ...(actualizacionAutomatica ? {} : { valor_acopio: toNumber(valorTotal) }),
       };
       
       console.log('3. Actualizando campos del acopio:', camposAcopio);


### PR DESCRIPTION
## Problema
Editar el **Valor acopiado** en modo **✏️ Manual** no guardaba los cambios. El valor manual nunca se persistía: en `guardarCambios` el PATCH no enviaba `valor_acopio` (se había removido en un refactor previo que delegó el cálculo al `$inc` del backend).

## Cambio (frontend)
En `editarAcopio.js > guardarCambios`, el PATCH ahora incluye `valor_acopio: toNumber(valorTotal)` **solo en modo manual**. En automático no se envía (el backend ya lo calcula con `$inc` al sincronizar productos).

## PR relacionado (backend)
fedemaidan/sorby_bot_wa rama `fix/acopio-valor-manual-no-persiste` (agrega `valor_acopio` al allowlist del PATCH). **Mergear ambos juntos.**

## Prueba manual
1. Modo Manual + cambiar Valor acopiado (sin tocar productos) → Guardar → recargar: persiste y queda en modo manual.
2. Modo Manual + editar también un producto → total = valor manual.
3. Modo Auto (regresión): total = suma de productos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)