### PR TITLE
feat(presupuestos-profesionales): plantillas con valor/cantidad/unidad por ítem (TAR-404)

### DIFF
--- a/src/components/presupuestosProfesionales/PlantillaFormDialog.js
+++ b/src/components/presupuestosProfesionales/PlantillaFormDialog.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import {
   Box,
   Button,
+  Chip,
   CircularProgress,
   Dialog,
   DialogActions,
@@ -10,6 +11,7 @@ import {
   Divider,
   FormControlLabel,
   IconButton,
+  InputAdornment,
   Paper,
   Stack,
   Switch,
@@ -21,12 +23,26 @@ import AddIcon from '@mui/icons-material/Add';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import DeleteIcon from '@mui/icons-material/Delete';
+import { formatNumberForInput, parseNumberInput } from './constants';
 
 const sumaIncidenciasPlantilla = (rubros) =>
   (rubros || []).reduce((s, r) => s + (Number(r.incidencia_pct_sugerida) || 0), 0);
 
 const sumaIncidenciasSubrubros = (tareas) =>
   (tareas || []).reduce((s, t) => s + (Number(t.incidencia_pct_sugerida) || 0), 0);
+
+// Σ (cantidad || 1) × valor unitario de los subrubros. Si > 0, el monto del
+// rubro es derivado; si es 0, el rubro suelto puede llevar un monto propio.
+const sumaEfectivaTareas = (tareas) =>
+  (tareas || []).reduce(
+    (s, t) => s + (Number(t.cantidad) || 1) * (Number(t.monto) || 0),
+    0
+  );
+
+const formatMontoPlantilla = (value) => {
+  const n = Number(value) || 0;
+  return `$ ${n.toLocaleString('es-AR', { minimumFractionDigits: 0, maximumFractionDigits: 2 })}`;
+};
 
 const PlantillaFormDialog = ({
   open,
@@ -40,10 +56,14 @@ const PlantillaFormDialog = ({
   removeRubro,
   updateRubroNombre,
   updateRubroIncidencia,
+  updateRubroMonto,
   addTarea,
   removeTarea,
   updateTarea,
   updateTareaIncidencia,
+  updateTareaMonto,
+  updateTareaCantidad,
+  updateTareaUnidad,
   moveTarea,
   focusRef,
 }) => {
@@ -162,6 +182,47 @@ const PlantillaFormDialog = ({
                 sx={{ width: 100 }}
                 inputProps={{ min: 0, max: 100, step: 0.1 }}
               />
+              {(() => {
+                // Monto del rubro: derivado (chip) si los subrubros tienen valor;
+                // editable si es un rubro suelto sin desglose con valor.
+                const suma = sumaEfectivaTareas(rubro.tareas);
+                if (suma > 0) {
+                  return (
+                    <Tooltip title="Calculado a partir de los subrubros" placement="top" arrow>
+                      <Chip
+                        label={formatMontoPlantilla(rubro.monto)}
+                        size="small"
+                        sx={{
+                          minWidth: 110,
+                          height: 32,
+                          bgcolor: 'action.hover',
+                          fontWeight: 600,
+                          '& .MuiChip-label': { px: 1.25 },
+                        }}
+                      />
+                    </Tooltip>
+                  );
+                }
+                return (
+                  <TextField
+                    size="small"
+                    label="Monto (opc.)"
+                    value={formatNumberForInput(rubro.monto, 2)}
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      if (raw === '') {
+                        updateRubroMonto?.(ri, '');
+                        return;
+                      }
+                      const v = parseNumberInput(raw);
+                      if (v !== null) updateRubroMonto?.(ri, v);
+                    }}
+                    sx={{ width: 130 }}
+                    InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                    inputProps={{ inputMode: 'decimal', autoComplete: 'off' }}
+                  />
+                );
+              })()}
               <Tooltip title="Eliminar rubro">
                 <IconButton size="small" color="error" onClick={() => removeRubro(ri)}>
                   <DeleteIcon fontSize="small" />
@@ -216,6 +277,93 @@ const PlantillaFormDialog = ({
                       }
                     }}
                   />
+                  {(() => {
+                    const cantidadNum = Number(tarea.cantidad) || 1;
+                    const efectivo = cantidadNum * (Number(tarea.monto) || 0);
+                    const tieneValor = (Number(tarea.monto) || 0) > 0 || tarea.cantidad != null;
+                    return (
+                      <>
+                        <TextField
+                          size="small"
+                          label="Unidad"
+                          placeholder="ej: m²"
+                          value={tarea.unidad || ''}
+                          onChange={(e) => updateTareaUnidad?.(ri, ti, e.target.value)}
+                          sx={{ width: 76 }}
+                          inputProps={{ autoComplete: 'off', maxLength: 12 }}
+                        />
+                        <Stack
+                          direction="row"
+                          alignItems="center"
+                          spacing={0.5}
+                          sx={{
+                            border: '1px solid',
+                            borderStyle: tieneValor ? 'solid' : 'dashed',
+                            borderColor: tieneValor ? 'primary.main' : 'action.disabledBackground',
+                            borderRadius: 1,
+                            px: 0.75,
+                            py: 0.25,
+                          }}
+                        >
+                          <TextField
+                            size="small"
+                            label="Cant."
+                            placeholder="1"
+                            value={tarea.cantidad != null ? formatNumberForInput(tarea.cantidad, 2) : ''}
+                            onChange={(e) => {
+                              const raw = e.target.value;
+                              if (raw === '') {
+                                updateTareaCantidad?.(ri, ti, '');
+                                return;
+                              }
+                              const v = parseNumberInput(raw);
+                              if (v !== null) updateTareaCantidad?.(ri, ti, v);
+                            }}
+                            sx={{ width: 62 }}
+                            inputProps={{ inputMode: 'decimal', autoComplete: 'off' }}
+                          />
+                          <Typography variant="caption" color="text.disabled" sx={{ px: 0.25 }}>
+                            ×
+                          </Typography>
+                          <TextField
+                            size="small"
+                            label={cantidadNum > 1 ? 'Val. unit.' : 'Precio'}
+                            placeholder="opcional"
+                            value={tarea.monto == null ? '' : formatNumberForInput(tarea.monto, 2)}
+                            onChange={(e) => {
+                              const raw = e.target.value;
+                              if (raw === '') {
+                                updateTareaMonto?.(ri, ti, '');
+                                return;
+                              }
+                              const v = parseNumberInput(raw);
+                              if (v !== null) updateTareaMonto?.(ri, ti, v);
+                            }}
+                            sx={{ width: 110 }}
+                            InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                            inputProps={{ inputMode: 'decimal', autoComplete: 'off' }}
+                          />
+                          {cantidadNum > 1 && efectivo > 0 && (
+                            <>
+                              <Typography variant="caption" color="text.secondary">=</Typography>
+                              <Chip
+                                label={formatMontoPlantilla(efectivo)}
+                                size="small"
+                                sx={{
+                                  fontWeight: 700,
+                                  fontSize: '0.68rem',
+                                  height: 22,
+                                  bgcolor: 'primary.main',
+                                  color: 'primary.contrastText',
+                                  '& .MuiChip-label': { px: 1 },
+                                }}
+                              />
+                            </>
+                          )}
+                        </Stack>
+                      </>
+                    );
+                  })()}
                   <TextField
                     size="small"
                     label="% rubro"

--- a/src/components/presupuestosProfesionales/README.md
+++ b/src/components/presupuestosProfesionales/README.md
@@ -86,6 +86,20 @@ Los handlers viven en `presupuestosHandlers.js` como funciones puras:
 Los handlers `pp*` en `src/pages/presupuestosProfesionales.js` son thin
 wrappers que invocan estas funciones puras en `setPpForm((f) => ...)`.
 
+## Plantillas con valores preestablecidos
+
+Las plantillas (`PlantillaFormDialog` y el import por archivo) pueden, de forma
+**opcional**, preestablecer por subrubro `cantidad`, `monto` (valor unitario) y
+`unidad` — la misma estructura que usa el presupuesto. El rubro suelto (sin
+subrubros con valor) puede llevar un `monto` propio. Todos son opcionales: si no
+se completan, la plantilla funciona igual que antes (solo nombre + incidencia).
+
+Al aplicar la plantilla (`plantillaRubrosToPresupuestoRubros`), esos valores se
+transfieren al presupuesto y quedan **editables** antes de guardar. El backend
+(`importPresupuestoService`) intenta extraer columnas de precio/cantidad/unidad
+del archivo importado (Excel/PDF/imagen). No se inventan campos que el modelo de
+presupuesto no tenga.
+
 ## Largest remainder (Hamilton) en `incidenciaHelpers.js`
 
 Las funciones `distribuirMontosPorIncidencia` y

--- a/src/components/presupuestosProfesionales/__tests__/incidenciaHelpers.test.js
+++ b/src/components/presupuestosProfesionales/__tests__/incidenciaHelpers.test.js
@@ -129,6 +129,32 @@ describe('plantillaRubrosToPresupuestoRubros', () => {
     const result = plantillaRubrosToPresupuestoRubros(plantilla);
     expect(result[0].incidencia_objetivo_pct).toBeNull();
   });
+
+  test('transfiere valor unitario, cantidad y unidad preestablecidos de los subrubros', () => {
+    const plantilla = [
+      {
+        nombre: 'Mampostería',
+        tareas: [
+          { descripcion: 'Pared', cantidad: 10, monto: 5000, unidad: 'm²' },
+          { descripcion: 'Dintel', monto: 2000 },
+        ],
+      },
+    ];
+    const result = plantillaRubrosToPresupuestoRubros(plantilla);
+    expect(result[0].tareas[0]).toMatchObject({ cantidad: 10, monto: 5000, unidad: 'm²' });
+    expect(result[0].tareas[1]).toMatchObject({ cantidad: null, monto: 2000, unidad: '' });
+    // El monto del rubro es derivado: 10×5000 + 1×2000 = 52000
+    expect(result[0].monto).toBe(52000);
+  });
+
+  test('usa el monto del rubro suelto cuando los subrubros no tienen valor', () => {
+    const plantilla = [
+      { nombre: 'Varios', monto: 30000, tareas: [{ descripcion: 'Ajustes' }] },
+    ];
+    const result = plantillaRubrosToPresupuestoRubros(plantilla);
+    expect(result[0].monto).toBe(30000);
+    expect(result[0].tareas[0].monto).toBeNull();
+  });
 });
 
 describe('sumaIncidenciasObjetivo', () => {

--- a/src/components/presupuestosProfesionales/incidenciaHelpers.js
+++ b/src/components/presupuestosProfesionales/incidenciaHelpers.js
@@ -55,18 +55,34 @@ function repartirLargestRemainder(totalCentavos, items) {
 const aCentavos = (n) => Math.round((Number(n) || 0) * 100);
 const deCentavos = (c) => Math.round(c) / 100;
 
+const numOrNull = (v) =>
+  v != null && v !== '' && !Number.isNaN(Number(v)) ? Number(v) : null;
+
 export function plantillaRubrosToPresupuestoRubros(rubros = []) {
-  return (rubros || []).map((r) => ({
-    nombre: r.nombre || '',
-    monto: 0,
-    incidencia_objetivo_pct: parseIncidenciaSugerida(r.incidencia_pct_sugerida),
-    tareas: (r.tareas || []).map((t) => ({
+  return (rubros || []).map((r) => {
+    const tareas = (r.tareas || []).map((t) => ({
       descripcion: t.descripcion || '',
-      monto: null,
-      cantidad: t.cantidad || null,
+      // Valor unitario, cantidad y unidad preestablecidos en la plantilla
+      // (quedan editables en el presupuesto antes de guardar).
+      monto: numOrNull(t.monto),
+      cantidad: numOrNull(t.cantidad),
+      unidad: typeof t.unidad === 'string' ? t.unidad : '',
       incidencia_objetivo_pct: parseIncidenciaSugerida(t.incidencia_pct_sugerida),
-    })),
-  }));
+    }));
+    // El monto del rubro es derivado si los subrubros tienen valor; si no, se usa
+    // el monto preestablecido del rubro suelto.
+    const sumaEfectiva = tareas.reduce(
+      (s, t) => s + (Number(t.cantidad) || 1) * (Number(t.monto) || 0),
+      0
+    );
+    const montoRubro = sumaEfectiva > 0 ? sumaEfectiva : numOrNull(r.monto) || 0;
+    return {
+      nombre: r.nombre || '',
+      monto: montoRubro,
+      incidencia_objetivo_pct: parseIncidenciaSugerida(r.incidencia_pct_sugerida),
+      tareas,
+    };
+  });
 }
 
 export function sumaIncidenciasObjetivo(rubros) {

--- a/src/hooks/presupuestosProfesionales/usePlantillaImport.js
+++ b/src/hooks/presupuestosProfesionales/usePlantillaImport.js
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import PresupuestoProfesionalService from 'src/services/presupuestoProfesional/presupuestoProfesionalService';
 
+const numOrNull = (v) =>
+  v != null && v !== '' && !Number.isNaN(Number(v)) ? Number(v) : null;
+
 const mapRubrosImportados = (rubros = []) => {
   return (rubros || []).map((r) => ({
     nombre: r.nombre || '',
@@ -8,12 +11,16 @@ const mapRubrosImportados = (rubros = []) => {
       r.incidencia_pct_sugerida != null && !Number.isNaN(Number(r.incidencia_pct_sugerida))
         ? Number(r.incidencia_pct_sugerida)
         : null,
+    monto: numOrNull(r.monto),
     tareas: (r.tareas || []).map((t) => ({
       descripcion: t.descripcion || '',
       incidencia_pct_sugerida:
         t.incidencia_pct_sugerida != null && !Number.isNaN(Number(t.incidencia_pct_sugerida))
           ? Number(t.incidencia_pct_sugerida)
           : null,
+      monto: numOrNull(t.monto),
+      cantidad: numOrNull(t.cantidad),
+      unidad: typeof t.unidad === 'string' ? t.unidad : '',
     })),
   }));
 };

--- a/src/pages/presupuestosProfesionales.js
+++ b/src/pages/presupuestosProfesionales.js
@@ -167,6 +167,27 @@ const emptyPlantilla = {
   notas: '',
 };
 
+// Helpers de valores preestablecidos en plantillas (misma semántica que el
+// presupuesto: monto = valor unitario, cantidad, unidad; el monto del rubro es
+// derivado si sus subrubros tienen valor).
+const plSumaEfectivaTareas = (tareas) =>
+  (tareas || []).reduce(
+    (s, t) => s + (Number(t.cantidad) || 1) * (Number(t.monto) || 0),
+    0
+  );
+
+const plParseMonto = (raw) => {
+  if (raw === '' || raw == null) return null;
+  const n = Number(raw);
+  return Number.isNaN(n) ? null : Math.max(0, Math.round(n * 100) / 100);
+};
+
+const plParseCantidad = (raw) => {
+  if (raw === '' || raw == null) return null;
+  const n = Math.max(0, Number(raw) || 0);
+  return n || null;
+};
+
 /* ================================================================
    Componente principal
    ================================================================ */
@@ -1167,12 +1188,16 @@ const PresupuestosProfesionales = () => {
           incidencia_pct_sugerida: r.incidencia_pct_sugerida != null && !Number.isNaN(Number(r.incidencia_pct_sugerida))
             ? Number(r.incidencia_pct_sugerida)
             : null,
+          monto: r.monto != null && !Number.isNaN(Number(r.monto)) ? Number(r.monto) : null,
           tareas: (r.tareas || []).map((t) => ({
             descripcion: t.descripcion || '',
             incidencia_pct_sugerida:
               t.incidencia_pct_sugerida != null && !Number.isNaN(Number(t.incidencia_pct_sugerida))
                 ? Number(t.incidencia_pct_sugerida)
                 : null,
+            monto: t.monto != null && !Number.isNaN(Number(t.monto)) ? Number(t.monto) : null,
+            cantidad: t.cantidad != null && !Number.isNaN(Number(t.cantidad)) ? Number(t.cantidad) : null,
+            unidad: typeof t.unidad === 'string' ? t.unidad : '',
           })),
         })),
       });
@@ -1223,6 +1248,7 @@ const PresupuestosProfesionales = () => {
             incidencia_pct_sugerida: r.incidencia_pct_sugerida != null && !Number.isNaN(Number(r.incidencia_pct_sugerida))
               ? Number(r.incidencia_pct_sugerida)
               : null,
+            monto: r.monto != null && !Number.isNaN(Number(r.monto)) ? Number(r.monto) : null,
             tareas: (r.tareas || [])
               .filter((t) => t.descripcion?.trim())
               .map((t) => ({
@@ -1231,6 +1257,9 @@ const PresupuestosProfesionales = () => {
                   t.incidencia_pct_sugerida != null && !Number.isNaN(Number(t.incidencia_pct_sugerida))
                     ? Number(t.incidencia_pct_sugerida)
                     : null,
+                monto: t.monto != null && !Number.isNaN(Number(t.monto)) ? Number(t.monto) : null,
+                cantidad: t.cantidad != null && !Number.isNaN(Number(t.cantidad)) ? Number(t.cantidad) : null,
+                unidad: t.unidad?.trim() || null,
               })),
           })),
       };
@@ -1275,7 +1304,7 @@ const PresupuestosProfesionales = () => {
       plFocusRef.current = { type: 'rubro', rubroIdx: f.rubros.length };
       return {
         ...f,
-        rubros: [...f.rubros, { nombre: '', tareas: [], incidencia_pct_sugerida: null }],
+        rubros: [...f.rubros, { nombre: '', tareas: [], incidencia_pct_sugerida: null, monto: null }],
       };
     });
   };
@@ -1311,7 +1340,10 @@ const PresupuestosProfesionales = () => {
       plFocusRef.current = { type: 'tarea', rubroIdx, tareaIdx: newTareaIdx };
       rubros[rubroIdx] = {
         ...rubros[rubroIdx],
-        tareas: [...(rubros[rubroIdx].tareas || []), { descripcion: '', incidencia_pct_sugerida: null }],
+        tareas: [
+          ...(rubros[rubroIdx].tareas || []),
+          { descripcion: '', incidencia_pct_sugerida: null, monto: null, cantidad: null, unidad: '' },
+        ],
       };
       return { ...f, rubros };
     });
@@ -1320,10 +1352,62 @@ const PresupuestosProfesionales = () => {
   const plRemoveTarea = (rubroIdx, tareaIdx) => {
     setPlForm((f) => {
       const rubros = [...f.rubros];
-      rubros[rubroIdx] = {
-        ...rubros[rubroIdx],
-        tareas: rubros[rubroIdx].tareas.filter((_, i) => i !== tareaIdx),
-      };
+      const tareas = rubros[rubroIdx].tareas.filter((_, i) => i !== tareaIdx);
+      const suma = plSumaEfectivaTareas(tareas);
+      rubros[rubroIdx] =
+        suma > 0
+          ? { ...rubros[rubroIdx], tareas, monto: suma }
+          : { ...rubros[rubroIdx], tareas };
+      return { ...f, rubros };
+    });
+  };
+
+  // Monto del rubro suelto (solo editable si los subrubros no tienen valor).
+  const plUpdateRubroMonto = (idx, raw) => {
+    setPlForm((f) => {
+      const rubros = [...f.rubros];
+      const rubro = rubros[idx];
+      if (plSumaEfectivaTareas(rubro.tareas) > 0) return f; // derivado: no-op
+      rubros[idx] = { ...rubro, monto: plParseMonto(raw) };
+      return { ...f, rubros };
+    });
+  };
+
+  // Valor unitario de un subrubro. Recalcula el monto del rubro si hay valor.
+  const plUpdateTareaMonto = (rubroIdx, tareaIdx, raw) => {
+    setPlForm((f) => {
+      const rubros = [...f.rubros];
+      const tareas = [...rubros[rubroIdx].tareas];
+      tareas[tareaIdx] = { ...tareas[tareaIdx], monto: plParseMonto(raw) };
+      const suma = plSumaEfectivaTareas(tareas);
+      rubros[rubroIdx] =
+        suma > 0
+          ? { ...rubros[rubroIdx], tareas, monto: suma }
+          : { ...rubros[rubroIdx], tareas };
+      return { ...f, rubros };
+    });
+  };
+
+  const plUpdateTareaCantidad = (rubroIdx, tareaIdx, raw) => {
+    setPlForm((f) => {
+      const rubros = [...f.rubros];
+      const tareas = [...rubros[rubroIdx].tareas];
+      tareas[tareaIdx] = { ...tareas[tareaIdx], cantidad: plParseCantidad(raw) };
+      const suma = plSumaEfectivaTareas(tareas);
+      rubros[rubroIdx] =
+        suma > 0
+          ? { ...rubros[rubroIdx], tareas, monto: suma }
+          : { ...rubros[rubroIdx], tareas };
+      return { ...f, rubros };
+    });
+  };
+
+  const plUpdateTareaUnidad = (rubroIdx, tareaIdx, value) => {
+    setPlForm((f) => {
+      const rubros = [...f.rubros];
+      const tareas = [...rubros[rubroIdx].tareas];
+      tareas[tareaIdx] = { ...tareas[tareaIdx], unidad: value };
+      rubros[rubroIdx] = { ...rubros[rubroIdx], tareas };
       return { ...f, rubros };
     });
   };
@@ -1667,10 +1751,14 @@ const PresupuestosProfesionales = () => {
         removeRubro={plRemoveRubro}
         updateRubroNombre={plUpdateRubroNombre}
         updateRubroIncidencia={plUpdateRubroIncidencia}
+        updateRubroMonto={plUpdateRubroMonto}
         addTarea={plAddTarea}
         removeTarea={plRemoveTarea}
         updateTarea={plUpdateTarea}
         updateTareaIncidencia={plUpdateTareaIncidencia}
+        updateTareaMonto={plUpdateTareaMonto}
+        updateTareaCantidad={plUpdateTareaCantidad}
+        updateTareaUnidad={plUpdateTareaUnidad}
         moveTarea={plMoveTarea}
         focusRef={plFocusRef}
       />


### PR DESCRIPTION
## TAR-404 — Plantillas con valor/cantidad por rubro/tarea (frontend)

Las plantillas (form manual + import) ahora preestablecen, de forma **opcional**, valor unitario, cantidad y unidad por subrubro y monto por rubro suelto, **replicando `PresupuestoFormDialog`**. Al aplicar la plantilla, los valores se transfieren al presupuesto y quedan **editables** antes de guardar.

### Cambios
- **`PlantillaFormDialog`**: inputs **Unidad** + bloque **Cant. × Precio** por subrubro y **Monto** por rubro (chip derivado si los subrubros tienen valor; editable si es rubro suelto), igual que el presupuesto. Sin modo distribuir.
- **`pages/presupuestosProfesionales`**: defaults, handlers (`plUpdateTarea{Monto,Cantidad,Unidad}`, `plUpdateRubroMonto`), carga en edición y payload de guardado.
- **`incidenciaHelpers.plantillaRubrosToPresupuestoRubros`**: transfiere `monto`/`cantidad`/`unidad` al presupuesto (editables); monto de rubro derivado de subrubros.
- **`usePlantillaImport.mapRubrosImportados`**: preserva los campos del import.
- README del módulo + tests de mapping (`incidenciaHelpers.test.js`).

### Modelo
- **Rubro**: solo `monto` (igual que el presupuesto — el rubro no tiene cantidad/unidad).
- **Subrubro**: `cantidad` + `monto` (valor unit.) + `unidad`. Todos opcionales.

### Validación
E2E en dashboard local con screenshots: form con Cant×Precio reactivo (10 m² × $5.000 = $50.000), guardado, **persistencia confirmada** y export PDF OK.

PR backend (par): fedemaidan/sorby_bot_wa#206

🤖 Generated with [Claude Code](https://claude.com/claude-code)