### PR TITLE
fix(acopio): persistir instrucciones_extraccion al crear acopio (TAR-407)

### DIFF
--- a/src/pages/crearAcopio.js
+++ b/src/pages/crearAcopio.js
@@ -619,6 +619,7 @@ const guardarAcopio = async () => {
       proyecto_id: proyecto,
       proyecto_nombre,
       descripcion: descripcion || '',
+      instrucciones_extraccion: instruccionesExtraccion || '',
       valorTotal: Number(valorTotal) || 0,
       url_imagen_compra: urls || [],
       productos: finalRows.map((r) => ({


### PR DESCRIPTION
## Contexto

Parte frontend del ticket **TAR-407** — Las aclaraciones del acopio no se aplicaban al interpretar remitos.

El fix principal es backend (ver más abajo). Este PR cierra un **hueco secundario**: el wizard de creación de acopio (`crearAcopio.js`) usaba las aclaraciones del usuario solo para el OCR de creación, pero **no las persistía** en el objeto acopio. Un acopio creado por el wizard nacía sin las "Aclaraciones para el análisis de documentos", aunque el usuario las hubiera escrito, hasta que se reeditaba por `editarAcopio.js`.

## Cambio

- `crearAcopio.js` — agrega `instrucciones_extraccion: instruccionesExtraccion || ''` al objeto `acopio` que se manda a `crearAcopio`/`editarAcopio`. El estado `instruccionesExtraccion` ya existía.

> `editarAcopio.js`, `movimientosAcopio.js` y `acopios.js` ya mandaban el campo correctamente — no se tocan.

## PR relacionado (fix principal, backend)

https://github.com/fedemaidan/sorby_bot_wa/pull/213

## Cómo probar

1. Crear un acopio nuevo con aclaraciones en el wizard.
2. Reabrirlo en `editarAcopio.js` → el campo "Aclaraciones para el análisis de documentos" debe quedar persistido (hoy aparece vacío).

🤖 Generated with [Claude Code](https://claude.com/claude-code)