### PR TITLE
fix(control-presupuestos): ejecutado en CAC mal calculado/visualizado (TAR-392)

### DIFF
--- a/src/pages/control-presupuestos.js
+++ b/src/pages/control-presupuestos.js
@@ -885,8 +885,16 @@ const ControlPresupuestosPage = () => {
 
     if (items.length === 1) {
       const item = items[0];
-      const ej = ejecutadoDelBucket();
-      const ejecutadoReal = ej != null ? ej : (item.ejecutado || 0);
+      // Ejecutado en la MISMA unidad que item.monto (moneda nativa del presupuesto),
+      // SIN convertir a la moneda de vista. Para indexados (CAC/USD) item.moneda es la
+      // unidad indexada y monto/ejecutado deben compararse en esa unidad; usar el bucket
+      // convertido (ejecutadoDelBucket) mezclaba ARS con CAC en la card.
+      const bucketKey = tipoAgrupacion === 'categoria' ? 'porCategoria'
+        : tipoAgrupacion === 'proveedor' ? 'porProveedor' : null;
+      const ejNativo = bucketKey
+        ? resumen?.egresosPorMoneda?.[item.moneda || 'ARS']?.[bucketKey]?.[valor]?.ejecutado
+        : null;
+      const ejecutadoReal = ejNativo != null ? ejNativo : (item.ejecutado || 0);
       return {
         presupuesto: item.monto,
         ejecutado: ejecutadoReal,


### PR DESCRIPTION
## Problema (TAR-392)

En **Control de Presupuestos**, las cards por categoría/proveedor de un presupuesto indexado por CAC mostraban el **Ejecutado en CAC** mal: tomaban el monto en pesos (ARS) etiquetándolo como CAC, con avance y saldo disparatados. El Presupuestado en CAC estaba bien.

## Causa raíz

Asimetría de unidades en `getPresupuestoPorAgrupacion` (caso 1 item):
- `presupuesto: item.monto` → unidad **nativa** del presupuesto (CAC), sin convertir ✅
- `ejecutado: ejecutadoBucketCategoria/Proveedor()` → pasaba por `convertir()` a la **moneda de vista** (ARS) ❌

`PresupuestoItem` renderiza el indexado en su unidad nativa (`fmtUnidad`) y calcula `ejec * indiceActual`, por lo que el ejecutado en ARS quedaba mal etiquetado como CAC y re-multiplicado por el índice. El backend (resumen) y el `PresupuestoDrawer` ya entregaban/usaban el ejecutado en CAC nativo — la card quedaba inconsistente con el modal.

## Fix

Para el caso de 1 item, tomar el ejecutado **crudo del bucket del backend en la moneda nativa** (`resumen.egresosPorMoneda[item.moneda][porCategoria|porProveedor][valor].ejecutado`), quedando en la misma unidad que `item.monto`. Sin tocar backend, `PresupuestoItem`, `PresupuestoDrawer`, ni los casos N>1 / sin-item (que renderizan en moneda de vista). Cambio de 1 archivo.

## Validación (chrome-devtools, proyecto Tigre)

- **Mano de obra** (idx USD): card `Ejec: 8.521,72 USD · 15.6%`; modal `USD 8.521,72 · Avance 15.6%` → **coinciden**. (Antes: mostraría el nominal ARS como USD con % gigante.)
- **Ingreso general** (idx CAC): `Cobrado: 3.576,03 CAC · 68.7% · $73.283.583 ARS` (3.576,03 × 20.493 = 73.283.583 ✓).
- **Materiales** (ARS, no indexado): sin cambios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)