### PR TITLE
[2 tickets] TAR-405: impuestos no se eliminan/aplican (frontend) + Movimientos: Guardar y exportar PDF sin volver a cajas

### DIFF
--- a/src/pages/empresa.js
+++ b/src/pages/empresa.js
@@ -486,7 +486,7 @@ const EmpresaPage = () => {
                 {currentTab === 'configuracion' && <ConfiguracionGeneral empresa={empresa} updateEmpresaData={updateEmpresaDetails} hasPermission={hasPermission}/>}
                 {currentTab === 'permisos' && <PermisosUsuarios empresa={empresa} />}
                 {currentTab === 'medios_pago' && <MediosPagoDetails empresa={empresa} />}
-                {currentTab === 'impuestos' && <ImpuestosDetails empresa={empresa} />}
+                {currentTab === 'impuestos' && <ImpuestosDetails empresa={empresa} refreshEmpresa={() => empresaId && getEmpresaById(empresaId).then(setEmpresa)} />}
                 {currentTab === 'obras' && <ObrasDetails empresa={empresa} />}
               </>
             )}

--- a/src/pages/movementForm.js
+++ b/src/pages/movementForm.js
@@ -263,6 +263,8 @@ const MovementFormPage = () => {
   const pendingExtraccionRef = useRef(false);
   const returnAfterSaveRef = useRef(false);
   const exportAfterSaveRef = useRef(false);
+  // "Guardar y exportar": tras cerrar el diálogo de PDF, volver a la página anterior (cajas).
+  const returnAfterExportRef = useRef(false);
   const [createdUser, setCreatedUser] = useState(null);
   const [comprobanteModalOpen, setComprobanteModalOpen] = useState(false);
   const [imagenModal, setImagenModal] = useState('');
@@ -374,6 +376,7 @@ const MovementFormPage = () => {
         showGlobalAlert({ message: 'Movimiento guardado con éxito!', severity: 'success' });
         pushBack(router, lastPageUrl, '/');
       } else if (exportAfterSaveRef.current) {
+        returnAfterExportRef.current = true;
         setExportPdfOpen(true);
       }
     } catch (err) {
@@ -1871,7 +1874,13 @@ const createdAtStr = (() => {
 
         <ExportarPdfDialog
           open={exportPdfOpen}
-          onClose={() => setExportPdfOpen(false)}
+          onClose={() => {
+            setExportPdfOpen(false);
+            if (returnAfterExportRef.current) {
+              returnAfterExportRef.current = false;
+              pushBack(router, lastPageUrl, '/');
+            }
+          }}
           empresaId={empresa?.id}
           empresaNombre={empresa?.nombre || ''}
           documentType="comprobante_movimiento"

--- a/src/pages/movementForm.js
+++ b/src/pages/movementForm.js
@@ -262,6 +262,7 @@ const MovementFormPage = () => {
   const fileInputRef = useRef(null);
   const pendingExtraccionRef = useRef(false);
   const returnAfterSaveRef = useRef(false);
+  const exportAfterSaveRef = useRef(false);
   const [createdUser, setCreatedUser] = useState(null);
   const [comprobanteModalOpen, setComprobanteModalOpen] = useState(false);
   const [imagenModal, setImagenModal] = useState('');
@@ -372,11 +373,14 @@ const MovementFormPage = () => {
       if (returnAfterSaveRef.current) {
         showGlobalAlert({ message: 'Movimiento guardado con éxito!', severity: 'success' });
         pushBack(router, lastPageUrl, '/');
+      } else if (exportAfterSaveRef.current) {
+        setExportPdfOpen(true);
       }
     } catch (err) {
       setAlert({ open: true, message: err.message, severity: 'error' });
     } finally {
       returnAfterSaveRef.current = false;
+      exportAfterSaveRef.current = false;
       setIsLoading(false);
       setConfirmOpen(false);
       setPendingPayload(null);
@@ -790,6 +794,12 @@ const createdAtStr = (() => {
     handleSubmitForm();
   };
 
+  // Guarda y, al crear, abre el diálogo de exportar PDF sin salir de la página.
+  const handleSaveAndExport = () => {
+    exportAfterSaveRef.current = true;
+    handleSubmitForm();
+  };
+
   const formik = useFormik({
     initialValues: {
       fecha_factura: getTodayLocalDate(),
@@ -1066,9 +1076,6 @@ const createdAtStr = (() => {
         break;
       case 'auditoria':
         setAuditOpen(true);
-        break;
-      case 'exportarPdf':
-        setExportPdfOpen(true);
         break;
       case 'completarPago':
         setCompletarPagoDialogOpen(true);
@@ -1494,6 +1501,16 @@ const createdAtStr = (() => {
                   {isExtractingData ? 'Extrayendo…' : 'Extraer datos de archivo'}
                 </button>
               )}
+              {isEditMode && (
+                <button
+                  type="button"
+                  onClick={() => setExportPdfOpen(true)}
+                  className="inline-flex items-center gap-1 rounded-lg border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-800 shadow-sm hover:bg-neutral-50"
+                >
+                  <DocumentArrowDownIcon className="h-4 w-4" aria-hidden />
+                  Exportar PDF
+                </button>
+              )}
               <div className="relative" ref={accionesRef}>
                 <button
                   type="button"
@@ -1552,16 +1569,6 @@ const createdAtStr = (() => {
                     >
                       <DocumentTextIcon className="h-4 w-4 text-neutral-600" />
                       Ver auditoría
-                    </button>
-                    <button
-                      type="button"
-                      role="menuitem"
-                      disabled={!isEditMode}
-                      onClick={() => handleAccionesMenuItemClick('exportarPdf')}
-                      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-neutral-50 disabled:opacity-40"
-                    >
-                      <DocumentArrowDownIcon className="h-4 w-4 text-neutral-600" />
-                      Exportar PDF
                     </button>
                     {mostrarCompletarPago && (
                       <button
@@ -1628,11 +1635,24 @@ const createdAtStr = (() => {
               </button>
               <button
                 type="button"
-                onClick={handleSubmitForm}
+                onClick={isEditMode ? handleSubmitForm : handleSaveAndExport}
                 disabled={isLoading}
-                className="inline-flex min-w-[5.5rem] items-center justify-center rounded-lg border border-primary-main bg-white px-4 py-1.5 text-sm font-semibold text-primary-dark shadow-sm hover:bg-primary-lightest disabled:opacity-50"
+                className="inline-flex min-w-[5.5rem] items-center justify-center gap-1 rounded-lg border border-primary-main bg-white px-4 py-1.5 text-sm font-semibold text-primary-dark shadow-sm hover:bg-primary-lightest disabled:opacity-50"
               >
-                {isLoading && !returnAfterSaveRef.current ? <ArrowPathIcon className="h-5 w-5 animate-spin" aria-label="Cargando" /> : (isEditMode ? 'Guardar' : 'Crear')}
+                {isEditMode ? (
+                  isLoading && !returnAfterSaveRef.current ? (
+                    <ArrowPathIcon className="h-5 w-5 animate-spin" aria-label="Cargando" />
+                  ) : (
+                    'Guardar'
+                  )
+                ) : isLoading && exportAfterSaveRef.current ? (
+                  <ArrowPathIcon className="h-5 w-5 animate-spin" aria-label="Cargando" />
+                ) : (
+                  <>
+                    <DocumentArrowDownIcon className="h-4 w-4" aria-hidden />
+                    Guardar y exportar
+                  </>
+                )}
               </button>
               <button
                 type="button"

--- a/src/sections/empresa/impuestosDetails.js
+++ b/src/sections/empresa/impuestosDetails.js
@@ -1,5 +1,5 @@
 // src/sections/empresa/impuestosDetails.js
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Card, CardHeader, CardContent, CardActions, Divider,
   List, ListItem, ListItemText,
@@ -49,6 +49,19 @@ export const ImpuestosDetails = ({ empresa, refreshEmpresa }) => {
   });
 
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
+
+  // Siembra al primer ingreso: si la empresa nunca configuró impuestos, persistir los
+  // sugeridos para que pasen a ser registros reales (y así se puedan borrar/usar de verdad).
+  // Sin esto, los defaults se mostraban pero no existían en la DB, y al borrar "reaparecían".
+  const seededRef = useRef(false);
+  useEffect(() => {
+    const yaConfigurados = Array.isArray(empresa.impuestos_data) && empresa.impuestos_data.length > 0;
+    if (yaConfigurados || seededRef.current) return;
+    seededRef.current = true;
+    updateEmpresaDetails(empresa.id, { impuestos_data: impuestosDefault })
+      .then(() => refreshEmpresa?.());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [empresa.id]);
 
   const reset = () => {
     setForm({


### PR DESCRIPTION
**Ticket Notion:** [TAR-405 — Impuestos no se eliminan y no se aplican al crear movimientos](https://app.notion.com/p/37350a1e534180a7b962dc24315bea84)

Este PR cubre el lado del **dashboard** (síntoma 1: no se pueden eliminar impuestos en Configuración → Impuestos). El lado del bot (síntoma 2) va en el PR linkeado de `sorby_bot_wa`.

PR backend relacionado: fedemaidan/sorby_bot_wa#215

## Causa raíz
El borrado **sí** persistía en Mongo, pero:
1. `empresa.js` no le pasaba `refreshEmpresa` a `ImpuestosDetails` (a diferencia de `asignados`), así que el `empresa` del padre nunca se re-sincronizaba y al cambiar de tab y volver reaparecía la lista vieja.
2. `impuestosDetails.js` mostraba 7 impuestos "por defecto" que **no estaban guardados**, por lo que al borrar volvían.

## Cambios
- **`src/pages/empresa.js`** — pasar `refreshEmpresa={() => empresaId && getEmpresaById(empresaId).then(setEmpresa)}` a `ImpuestosDetails` (mismo patrón que `asignados`). Ahora guardar/eliminar/mover re-sincronizan el estado.
- **`src/sections/empresa/impuestosDetails.js`** — siembra al primer ingreso: si la empresa no tiene impuestos configurados, persiste los sugeridos (con `updateEmpresaDetails`) para que pasen a ser registros reales, guardado por `useRef` para no re-disparar. Los defaults dejan de ser "fantasma" → el borrado funciona y persiste.

## Decisión de UX
Estado vacío = **sembrar al primer ingreso** (los sugeridos pasan a ser reales). Tradeoff: borrar *todos* los impuestos los re-siembra en el próximo ingreso (una empresa nunca queda con cero). Sin UI nueva (la siembra es invisible).

## Pruebas
- ✅ `npx eslint` limpio en ambos archivos. No hay tests del componente.

### Checklist manual sugerido
- [ ] Empresa con impuestos configurados → borrar uno → desaparece y **sigue** desaparecido tras cambiar de tab y volver / recargar.
- [ ] Empresa sin impuestos → al abrir la pestaña, los sugeridos quedan guardados (recargar y siguen ahí).
- [ ] Editar / reordenar un impuesto persiste igual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
