### PR TITLE
fix(control-presupuesto): export PDF dinámico por moneda/indexación

### DIFF
--- a/src/components/PresupuestoDrawer.js
+++ b/src/components/PresupuestoDrawer.js
@@ -2636,20 +2636,29 @@ const PresupuestoDrawer = ({
                         documentType="control_presupuesto"
                         fileName={`control-presupuesto-${presupuesto.nombre || presupuesto.categoria || presupuesto.id}`}
                         defaultDocumentLoader={loadDefaultControlPresupuestoDoc}
-                        buildData={() => {
+                        tituloEditable
+                        defaultTitulo={presupuesto.tipo === 'ingreso' ? 'RECIBO DE INGRESOS' : 'RECIBO DE PAGOS'}
+                        buildData={(opts) => {
                           const obra = proyectos.find((p) => p.id === proyectoId)?.nombre || '';
                           const label = presupuesto.label || presupuesto.nombre || presupuesto.categoria || 'Presupuesto';
                           const contratista = presupuesto.proveedores?.[0]?.nombre || presupuesto.categoria || '';
                           const esIngreso = presupuesto.tipo === 'ingreso';
                           return buildControlPresupuestoData({
                             movimientos: movimientosFiltrados,
-                            titulo: esIngreso ? 'RECIBO DE INGRESOS' : 'RECIBO DE PAGOS',
+                            titulo: opts?.titulo || (esIngreso ? 'RECIBO DE INGRESOS' : 'RECIBO DE PAGOS'),
                             presupuestoLabel: label,
                             contratista,
                             obra,
                             empresaNombre,
-                            moneda: presupuesto.moneda_display || presupuesto.moneda || 'ARS',
-                            presupuestado: Number(presupuesto.monto || presupuesto.monto_ingresado || 0),
+                            // Contexto del presupuesto → moneda/indexación dinámica en el PDF.
+                            indexacion: presupuesto.indexacion || null,
+                            monedaPresupuesto: presupuesto.moneda || 'ARS',
+                            cacTipo: presupuesto.cac_tipo || null,
+                            baseCalculo: presupuesto.base_calculo || 'total',
+                            presupuestadoNativo: Number(presupuesto.monto != null ? presupuesto.monto : presupuesto.monto_ingresado || 0),
+                            montoIngresado: presupuesto.monto_ingresado != null ? Number(presupuesto.monto_ingresado) : null,
+                            cacIndiceActual: cacActualEfectivo || cacEfectivo,
+                            tipoCambioActual: dolarEfectivo,
                             tipo: esIngreso ? 'ingresos' : 'gastos',
                           });
                         }}

--- a/src/components/plantillasPdf/ExportarPdfMenu.js
+++ b/src/components/plantillasPdf/ExportarPdfMenu.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import {
   Chip,
@@ -12,6 +12,7 @@ import {
   Box,
   Typography,
   Tooltip,
+  TextField,
 } from '@mui/material';
 import PictureAsPdfRoundedIcon from '@mui/icons-material/PictureAsPdfRounded';
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
@@ -26,6 +27,9 @@ import { useExportarPdf } from './useExportarPdf';
  * - Lista las plantillas personalizadas de la empresa para el `documentType` (la
  *   principal primero, marcada con ⭐).
  * - Ofrece "Crear plantilla personalizada" que redirige a /plantillas-pdf.
+ * - Si `tituloEditable`, muestra un campo de título (default `defaultTitulo`) cuyo
+ *   valor se pasa al `buildData({ titulo })` → el usuario controla el encabezado del
+ *   PDF desde el export (no depende de la plantilla del agente).
  *
  * La lógica (listar + render) vive en el hook useExportarPdf, compartido con
  * ExportarPdfDialog. Genérico por `documentType`.
@@ -39,13 +43,19 @@ export default function ExportarPdfMenu({
   fileName = 'documento',
   disabled = false,
   onError,
+  tituloEditable = false,
+  defaultTitulo = '',
 }) {
   const router = useRouter();
   const [anchorEl, setAnchorEl] = useState(null);
+  const [titulo, setTitulo] = useState(defaultTitulo);
   const open = Boolean(anchorEl);
   const { plantillas, loadingList, generating, cargarOpciones, exportar } = useExportarPdf({
     empresaId, empresaNombre, documentType, buildData, defaultDocumentLoader, fileName, onError,
   });
+
+  // Mantener el título sincronizado con el default cuando cambia el contexto (ej. otro presupuesto).
+  useEffect(() => { setTitulo(defaultTitulo); }, [defaultTitulo]);
 
   const abrir = (e) => {
     setAnchorEl(e.currentTarget);
@@ -55,7 +65,8 @@ export default function ExportarPdfMenu({
 
   const handleExportar = (plantilla) => {
     cerrar();
-    exportar(plantilla);
+    const opts = tituloEditable ? { titulo: (titulo || '').trim() || defaultTitulo } : undefined;
+    exportar(plantilla, opts);
   };
 
   return (
@@ -84,6 +95,23 @@ export default function ExportarPdfMenu({
         <ListSubheader sx={{ lineHeight: '32px', fontWeight: 700, color: 'text.secondary' }}>
           Exportar como PDF
         </ListSubheader>
+
+        {tituloEditable && (
+          <Box
+            sx={{ px: 2, pt: 0.5, pb: 1 }}
+            onKeyDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <TextField
+              label="Título del documento"
+              value={titulo}
+              onChange={(e) => setTitulo(e.target.value)}
+              size="small"
+              fullWidth
+              variant="outlined"
+            />
+          </Box>
+        )}
 
         {loadingList ? (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: 2, py: 1.5 }}>

--- a/src/components/plantillasPdf/useExportarPdf.js
+++ b/src/components/plantillasPdf/useExportarPdf.js
@@ -10,11 +10,12 @@ import { loadImageAsDataUrl } from 'src/utils/presupuestos/loadLogoForPdf';
  * (ExportarPdfMenu en los drawers, ExportarPdfDialog en movementForm, …).
  *
  * - cargarOpciones(): trae plantillas (por document_type) + logos de la empresa.
- * - exportar(plantilla|null): arma los datos (buildData puede ser async), resuelve
- *   el componente (default vs custom), carga el logo y dispara la descarga.
+ * - exportar(plantilla|null, opts): arma los datos (buildData puede ser async),
+ *   resuelve el componente (default vs custom), carga el logo y dispara la descarga.
  *
- * `buildData` se `await`-ea: soporta builders sync (control_presupuesto) y async
- * (comprobante de movimiento, que carga la imagen adjunta).
+ * `buildData(opts)` se `await`-ea y recibe las opciones del disparador (ej. `{ titulo }`
+ * cuando el menú ofrece título editable). Soporta builders sync (control_presupuesto)
+ * y async (comprobante de movimiento, que carga la imagen adjunta).
  */
 export function useExportarPdf({
   empresaId,
@@ -57,10 +58,10 @@ export function useExportarPdf({
     return loadImageAsDataUrl(logo.url);
   };
 
-  const exportar = async (plantilla) => {
+  const exportar = async (plantilla, opts) => {
     setGenerating(true);
     try {
-      const data = await (typeof buildData === 'function' ? buildData() : buildData);
+      const data = await (typeof buildData === 'function' ? buildData(opts) : buildData);
       let Component;
       let logoId = null;
       if (plantilla) {

--- a/src/pages/control-presupuestos.js
+++ b/src/pages/control-presupuestos.js
@@ -2344,24 +2344,33 @@ const ControlPresupuestosPage = () => {
                 fileName={`movimientos-${proyectoActual?.nombre || 'proyecto'}-${movDrawer.label}`}
                 defaultDocumentLoader={loadDefaultControlPresupuestoDoc}
                 onError={(message) => setAlert({ open: true, message, severity: 'error' })}
-                buildData={() => {
+                tituloEditable
+                defaultTitulo={
+                  movDrawer.tipo === 'egreso' ? 'RECIBO DE PAGOS'
+                    : movDrawer.tipo === 'ingreso' ? 'RECIBO DE INGRESOS'
+                      : 'ESTADO DE CUENTA'
+                }
+                buildData={(opts) => {
                   const totales = calcularTotales();
                   const presupuestado =
                     movDrawer.tipo === 'egreso' ? totales.egresos.total
                       : movDrawer.tipo === 'ingreso' ? totales.ingresos.total
                         : 0;
-                  const titulo =
+                  const titulo = opts?.titulo || (
                     movDrawer.tipo === 'egreso' ? 'RECIBO DE PAGOS'
                       : movDrawer.tipo === 'ingreso' ? 'RECIBO DE INGRESOS'
-                        : 'ESTADO DE CUENTA';
+                        : 'ESTADO DE CUENTA'
+                  );
+                  // Export a nivel proyecto: presupuestos mixtos, sin indexación única.
+                  // El builder cae al modo "moneda de vista" (sin columna de equivalencia).
                   return buildControlPresupuestoData({
                     movimientos: movDrawerData,
                     titulo,
                     presupuestoLabel: movDrawer.label,
                     obra: proyectoActual?.nombre || '',
                     empresaNombre: empresa?.nombre || '',
-                    moneda,
-                    presupuestado,
+                    monedaPresupuesto: moneda,
+                    presupuestadoNativo: presupuestado,
                     tipo: movDrawer.tipo === 'ingreso' ? 'ingresos' : 'gastos',
                   });
                 }}

--- a/src/utils/controlPresupuesto/PdfControlPresupuestoDocument.js
+++ b/src/utils/controlPresupuesto/PdfControlPresupuestoDocument.js
@@ -3,36 +3,64 @@ import { Document, Page, Text, View, Image, StyleSheet } from '@react-pdf/render
 
 /**
  * Plantilla POR DEFECTO de Control de Presupuesto (RECIBO DE PAGOS).
- * Documento sobrio y claro, fiel al recibo de referencia. Se usa como preview
- * base cuando el usuario todavía no generó una plantilla custom con IA.
+ * Documento financiero sobrio y editorial, fiel al recibo de referencia. Se usa como
+ * preview base cuando el usuario todavía no generó una plantilla custom con IA.
+ *
+ * Dinámico por moneda/indexación (ver buildControlPresupuestoData):
+ *  - `mostrar_equiv` + `equiv_label`: presupuesto indexado → muestra columna de
+ *    equivalencia (CAC / USD) al lado de los pesos, y subtexto en el resumen.
+ *  - `moneda` 'USD': presupuesto en dólares nativo → solo dólares.
+ *  - Bloque resumen Presupuestado / Ejecutado / Saldo + barra de avance.
  *
  * Props: { data, logoDataUrl, empresaNombre }
  */
+const INK = '#1f2733';
+const HAIRLINE = '#cfd6df';
+const ACCENT = '#1f6f5c';      // verde sobrio: avance / saldo a favor
+const OVER = '#b3261e';        // rojo: sobre-ejecución / saldo negativo
+const SOFT = '#f2f4f7';
+
 const styles = StyleSheet.create({
-  page: { paddingTop: 28, paddingBottom: 32, paddingHorizontal: 32, fontFamily: 'Helvetica', fontSize: 10, color: '#1f2733', backgroundColor: '#ffffff' },
-  headerBox: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', borderWidth: 1, borderColor: '#1f2733', paddingVertical: 14, paddingHorizontal: 16 },
-  headerTitle: { fontSize: 15, fontFamily: 'Helvetica-Bold', color: '#1f2733', letterSpacing: 1 },
+  page: { paddingTop: 28, paddingBottom: 36, paddingHorizontal: 32, fontFamily: 'Helvetica', fontSize: 10, color: INK, backgroundColor: '#ffffff' },
+
+  headerBox: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', borderWidth: 1, borderColor: INK, paddingVertical: 14, paddingHorizontal: 16 },
+  headerTitle: { fontSize: 15, fontFamily: 'Helvetica-Bold', color: INK, letterSpacing: 1.5 },
   logoImg: { maxWidth: 150, maxHeight: 48, objectFit: 'contain' },
-  metaBox: { borderWidth: 1, borderTopWidth: 0, borderColor: '#1f2733', paddingVertical: 8, paddingHorizontal: 16 },
+
+  metaBox: { borderWidth: 1, borderTopWidth: 0, borderColor: INK, paddingVertical: 8, paddingHorizontal: 16 },
   metaRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 2 },
-  metaLabel: { fontSize: 9, fontFamily: 'Helvetica-Bold', color: '#1f2733' },
-  metaValue: { fontSize: 9, color: '#1f2733' },
-  presupBar: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', borderWidth: 1, borderTopWidth: 0, borderColor: '#1f2733', backgroundColor: '#f2f4f7', paddingVertical: 7, paddingHorizontal: 16 },
-  presupLabel: { fontSize: 9.5, fontFamily: 'Helvetica-Bold', color: '#1f2733' },
-  presupValue: { fontSize: 10, fontFamily: 'Helvetica-Bold', color: '#1f2733' },
-  tableHead: { flexDirection: 'row', borderWidth: 1, borderTopWidth: 0, borderColor: '#1f2733', backgroundColor: '#e7ebf0' },
-  th: { fontSize: 8.5, fontFamily: 'Helvetica-Bold', color: '#1f2733', paddingVertical: 5, paddingHorizontal: 6 },
-  tr: { flexDirection: 'row', borderWidth: 1, borderTopWidth: 0, borderColor: '#cfd6df' },
-  td: { fontSize: 8.5, color: '#1f2733', paddingVertical: 4, paddingHorizontal: 6 },
-  cNum: { width: 28, textAlign: 'center' },
-  cFecha: { width: 64 },
+  metaLabel: { fontSize: 8.5, fontFamily: 'Helvetica-Bold', color: INK, letterSpacing: 0.3 },
+  metaValue: { fontSize: 8.5, color: '#41505f' },
+
+  // ── Resumen Presupuestado / Ejecutado / Saldo ──
+  resumenWrap: { borderWidth: 1, borderTopWidth: 0, borderColor: INK, backgroundColor: SOFT },
+  resumenRow: { flexDirection: 'row' },
+  resumenCell: { flex: 1, paddingVertical: 9, paddingHorizontal: 14 },
+  resumenCellMid: { borderLeftWidth: 1, borderRightWidth: 1, borderColor: HAIRLINE },
+  resumenLabel: { fontSize: 7.5, fontFamily: 'Helvetica-Bold', color: '#6b7785', letterSpacing: 0.6, marginBottom: 3 },
+  resumenValue: { fontSize: 12.5, fontFamily: 'Helvetica-Bold', color: INK },
+  resumenEquiv: { fontSize: 7.5, color: '#6b7785', marginTop: 1 },
+
+  // ── Barra de avance ──
+  barRow: { flexDirection: 'row', alignItems: 'center', borderTopWidth: 1, borderColor: HAIRLINE, paddingVertical: 7, paddingHorizontal: 14 },
+  barTrack: { flex: 1, height: 7, borderRadius: 4, backgroundColor: '#dfe4ea', marginRight: 10 },
+  barFill: { height: 7, borderRadius: 4 },
+  barPct: { fontSize: 9, fontFamily: 'Helvetica-Bold', width: 78, textAlign: 'right' },
+
+  // ── Tabla de movimientos ──
+  tableHead: { flexDirection: 'row', borderWidth: 1, borderTopWidth: 0, borderColor: INK, backgroundColor: '#e7ebf0' },
+  th: { fontSize: 8, fontFamily: 'Helvetica-Bold', color: INK, paddingVertical: 5, paddingHorizontal: 6, letterSpacing: 0.3 },
+  tr: { flexDirection: 'row', borderWidth: 1, borderTopWidth: 0, borderColor: HAIRLINE },
+  trAlt: { backgroundColor: '#fafbfc' },
+  td: { fontSize: 8.5, color: INK, paddingVertical: 4, paddingHorizontal: 6 },
+  tdMuted: { color: '#6b7785' },
+  cNum: { width: 26, textAlign: 'center' },
+  cFecha: { width: 60 },
   cDetalle: { flex: 1 },
-  cMonto: { width: 86, textAlign: 'right' },
-  cAcum: { width: 90, textAlign: 'right' },
-  totalsRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', borderWidth: 1, borderColor: '#1f2733', backgroundColor: '#f2f4f7', paddingVertical: 7, paddingHorizontal: 16, marginTop: 10 },
-  saldoRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', borderWidth: 1, borderTopWidth: 0, borderColor: '#1f2733', paddingVertical: 7, paddingHorizontal: 16 },
-  totalsLabel: { fontSize: 10, fontFamily: 'Helvetica-Bold', color: '#1f2733' },
-  totalsValue: { fontSize: 11, fontFamily: 'Helvetica-Bold', color: '#1f2733' },
+  cMonto: { width: 84, textAlign: 'right' },
+  cEquiv: { width: 78, textAlign: 'right' },
+  cAcum: { width: 88, textAlign: 'right' },
+
   footer: { position: 'absolute', bottom: 18, left: 32, right: 32, textAlign: 'center', fontSize: 7.5, color: '#9aa3af' },
 });
 
@@ -43,9 +71,25 @@ function fmtMoney(n, moneda) {
   return sign + v.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
+function fmtEquiv(n, label) {
+  let v = Number(n);
+  if (!Number.isFinite(v)) v = 0;
+  const dec = label === 'USD' ? 2 : 2;
+  return `${v.toLocaleString('es-AR', { minimumFractionDigits: dec, maximumFractionDigits: dec })} ${label}`;
+}
+
 export function PdfControlPresupuestoDocument({ data, logoDataUrl, empresaNombre = '' }) {
   const d = data || {};
   const movs = Array.isArray(d.movimientos) ? d.movimientos : [];
+  const moneda = d.moneda || 'ARS';
+  const mostrarEquiv = !!d.mostrar_equiv;
+  const equivLabel = d.equiv_label || '';
+  const pct = Number(d.avance_pct) || 0;
+  const sobre = pct > 100;
+  const saldoNeg = Number(d.saldo) < 0;
+  const barColor = sobre ? OVER : ACCENT;
+  const equivSub = (v) => (mostrarEquiv && v != null ? fmtEquiv(v, equivLabel) : null);
+
   return (
     <Document>
       <Page size="A4" style={styles.page}>
@@ -54,61 +98,85 @@ export function PdfControlPresupuestoDocument({ data, logoDataUrl, empresaNombre
           {logoDataUrl ? (
             <Image src={logoDataUrl} style={styles.logoImg} />
           ) : (
-            <Text style={{ fontSize: 13, fontFamily: 'Helvetica-Bold', color: '#1f2733' }}>{empresaNombre || ''}</Text>
+            <Text style={{ fontSize: 13, fontFamily: 'Helvetica-Bold', color: INK }}>{empresaNombre || ''}</Text>
           )}
         </View>
 
         <View style={styles.metaBox}>
           <View style={styles.metaRow}>
-            <Text style={styles.metaLabel}>FECHA DE EMISIÓN:</Text>
+            <Text style={styles.metaLabel}>FECHA DE EMISIÓN</Text>
             <Text style={styles.metaValue}>{d.fecha_emision || ''}</Text>
           </View>
+          {d.presupuesto_label ? (
+            <View style={styles.metaRow}>
+              <Text style={styles.metaLabel}>PRESUPUESTO</Text>
+              <Text style={styles.metaValue}>{d.presupuesto_label}</Text>
+            </View>
+          ) : null}
           {d.domicilio ? (
             <View style={styles.metaRow}>
-              <Text style={styles.metaLabel}>DOMICILIO:</Text>
+              <Text style={styles.metaLabel}>DOMICILIO</Text>
               <Text style={styles.metaValue}>{d.domicilio}</Text>
             </View>
           ) : null}
           <View style={styles.metaRow}>
-            <Text style={styles.metaLabel}>CONTRATISTA / PROVEEDOR:</Text>
+            <Text style={styles.metaLabel}>CONTRATISTA / PROVEEDOR</Text>
             <Text style={styles.metaValue}>{d.contratista || '-'}</Text>
           </View>
           <View style={styles.metaRow}>
-            <Text style={styles.metaLabel}>OBRA:</Text>
+            <Text style={styles.metaLabel}>OBRA</Text>
             <Text style={styles.metaValue}>{d.obra || '-'}</Text>
           </View>
         </View>
 
-        <View style={styles.presupBar}>
-          <Text style={styles.presupLabel}>{(d.presupuesto_label || 'PRESUPUESTO').toUpperCase()}</Text>
-          <Text style={styles.presupValue}>{fmtMoney(d.presupuestado, d.moneda)}</Text>
+        {/* ── Resumen: Presupuestado / Ejecutado / Saldo ── */}
+        <View style={styles.resumenWrap}>
+          <View style={styles.resumenRow}>
+            <View style={styles.resumenCell}>
+              <Text style={styles.resumenLabel}>PRESUPUESTADO</Text>
+              <Text style={styles.resumenValue}>{fmtMoney(d.presupuestado, moneda)}</Text>
+              {equivSub(d.presupuestado_equiv) ? <Text style={styles.resumenEquiv}>{equivSub(d.presupuestado_equiv)}</Text> : null}
+            </View>
+            <View style={[styles.resumenCell, styles.resumenCellMid]}>
+              <Text style={styles.resumenLabel}>{d.tipo === 'ingresos' ? 'INGRESADO' : 'EJECUTADO'}</Text>
+              <Text style={styles.resumenValue}>{fmtMoney(d.ejecutado, moneda)}</Text>
+              {equivSub(d.ejecutado_equiv) ? <Text style={styles.resumenEquiv}>{equivSub(d.ejecutado_equiv)}</Text> : null}
+            </View>
+            <View style={styles.resumenCell}>
+              <Text style={styles.resumenLabel}>SALDO</Text>
+              <Text style={[styles.resumenValue, { color: saldoNeg ? OVER : INK }]}>{fmtMoney(d.saldo, moneda)}</Text>
+              {equivSub(d.saldo_equiv) ? <Text style={styles.resumenEquiv}>{equivSub(d.saldo_equiv)}</Text> : null}
+            </View>
+          </View>
+          <View style={styles.barRow}>
+            <View style={styles.barTrack}>
+              <View style={[styles.barFill, { width: `${Math.min(Math.max(pct, 0), 100)}%`, backgroundColor: barColor }]} />
+            </View>
+            <Text style={[styles.barPct, { color: barColor }]}>{pct.toLocaleString('es-AR', { maximumFractionDigits: 1 })}% avance</Text>
+          </View>
         </View>
 
-        <View style={styles.tableHead}>
+        {/* ── Detalle de movimientos ── */}
+        <View style={[styles.tableHead, { marginTop: 10 }]}>
           <Text style={[styles.th, styles.cNum]}>N°</Text>
           <Text style={[styles.th, styles.cFecha]}>FECHA</Text>
           <Text style={[styles.th, styles.cDetalle]}>DETALLE</Text>
-          <Text style={[styles.th, styles.cMonto]}>MONTO</Text>
+          <Text style={[styles.th, styles.cMonto]}>{moneda === 'USD' ? 'MONTO USD' : 'MONTO $'}</Text>
+          {mostrarEquiv ? <Text style={[styles.th, styles.cEquiv]}>{equivLabel}</Text> : null}
           <Text style={[styles.th, styles.cAcum]}>ACUMULADO</Text>
         </View>
         {movs.map((m, i) => (
-          <View style={styles.tr} key={i} wrap={false}>
-            <Text style={[styles.td, styles.cNum]}>{String(m.numero != null ? m.numero : i + 1)}</Text>
+          <View style={[styles.tr, i % 2 === 1 ? styles.trAlt : null]} key={i} wrap={false}>
+            <Text style={[styles.td, styles.cNum, styles.tdMuted]}>{String(m.numero != null ? m.numero : i + 1)}</Text>
             <Text style={[styles.td, styles.cFecha]}>{m.fecha || ''}</Text>
             <Text style={[styles.td, styles.cDetalle]}>{m.detalle || m.proveedor || '-'}</Text>
-            <Text style={[styles.td, styles.cMonto]}>{fmtMoney(m.monto, d.moneda)}</Text>
-            <Text style={[styles.td, styles.cAcum]}>{fmtMoney(m.acumulado, d.moneda)}</Text>
+            <Text style={[styles.td, styles.cMonto]}>{fmtMoney(m.monto, moneda)}</Text>
+            {mostrarEquiv ? <Text style={[styles.td, styles.cEquiv, styles.tdMuted]}>{m.monto_equiv != null ? fmtEquiv(m.monto_equiv, equivLabel) : '—'}</Text> : null}
+            <Text style={[styles.td, styles.cAcum]}>{fmtMoney(m.acumulado, moneda)}</Text>
           </View>
         ))}
 
-        <View style={styles.totalsRow}>
-          <Text style={styles.totalsLabel}>TOTAL ENTREGADO</Text>
-          <Text style={styles.totalsValue}>{fmtMoney(d.ejecutado, d.moneda)}</Text>
-        </View>
-        <View style={styles.saldoRow}>
-          <Text style={styles.totalsLabel}>SALDO</Text>
-          <Text style={styles.totalsValue}>{fmtMoney(d.saldo, d.moneda)}</Text>
-        </View>
+        <Text style={styles.footer}>{(empresaNombre ? empresaNombre + ' — ' : '')}Documento no válido como factura{mostrarEquiv ? ` · Pesos a la fecha de emisión (equivalencia en ${equivLabel})` : ''}</Text>
       </Page>
     </Document>
   );

--- a/src/utils/controlPresupuesto/__tests__/buildControlPresupuestoData.test.js
+++ b/src/utils/controlPresupuesto/__tests__/buildControlPresupuestoData.test.js
@@ -1,0 +1,126 @@
+import buildControlPresupuestoData from '../buildControlPresupuestoData';
+
+const mov = (seconds, total, moneda, eq) => ({
+  fecha_factura: { seconds },
+  total,
+  moneda,
+  nombre_proveedor: 'Proveedor',
+  equivalencias: eq ? { total: eq } : undefined,
+});
+
+describe('buildControlPresupuestoData', () => {
+  describe('presupuesto indexado por CAC', () => {
+    const movimientos = [
+      mov(200, 700000, 'ARS', { ars: 700000, cac: 1400, usd_blue: 580 }),
+      mov(100, 300000, 'ARS', { ars: 300000, cac: 600, usd_blue: 250 }),
+    ];
+    const data = buildControlPresupuestoData({
+      movimientos,
+      titulo: 'RECIBO DE PAGOS',
+      indexacion: 'CAC',
+      monedaPresupuesto: 'CAC',
+      cacTipo: 'general',
+      presupuestadoNativo: 3000, // CAC units
+      cacIndiceActual: 500,
+    });
+
+    test('flags y moneda primaria', () => {
+      expect(data.moneda).toBe('ARS');
+      expect(data.indexacion).toBe('CAC');
+      expect(data.mostrar_equiv).toBe(true);
+      expect(data.equiv_label).toBe('CAC');
+    });
+
+    test('ejecutado coherente: CAC nativo y pesos a hoy (= nativo × índice)', () => {
+      expect(data.ejecutado_equiv).toBe(2000); // 600 + 1400
+      expect(data.ejecutado).toBe(1000000); // 2000 × 500
+    });
+
+    test('presupuestado en ambas unidades', () => {
+      expect(data.presupuestado_equiv).toBe(3000);
+      expect(data.presupuestado).toBe(1500000); // 3000 × 500
+    });
+
+    test('saldo NUNCA mezcla pesos − CAC (mismo nivel en cada unidad)', () => {
+      expect(data.saldo).toBe(500000); // 1.5M − 1M
+      expect(data.saldo_equiv).toBe(1000); // 3000 − 2000
+    });
+
+    test('avance_pct = ejecutado / presupuestado', () => {
+      expect(data.avance_pct).toBeCloseTo((1000000 / 1500000) * 100, 5);
+    });
+
+    test('movimientos ordenados cronológicamente con monto + equivalencia', () => {
+      expect(data.movimientos.map((m) => m.numero)).toEqual([1, 2]);
+      expect(data.movimientos[0]).toMatchObject({ monto: 300000, monto_equiv: 600, acumulado: 300000, acumulado_equiv: 600 });
+      expect(data.movimientos[1]).toMatchObject({ monto: 700000, monto_equiv: 1400, acumulado: 1000000, acumulado_equiv: 2000 });
+    });
+  });
+
+  test('regresión del bug: presupuestado pesos − ejecutado CAC daría basura', () => {
+    const data = buildControlPresupuestoData({
+      movimientos: [mov(100, 0, 'ARS', { ars: 30000, cac: 60 })],
+      indexacion: 'CAC',
+      monedaPresupuesto: 'CAC',
+      presupuestadoNativo: 100, // CAC
+      cacIndiceActual: 500,
+    });
+    expect(data.presupuestado).toBe(50000); // 100 × 500
+    expect(data.ejecutado).toBe(30000); // 60 × 500
+    expect(data.saldo).toBe(20000); // coherente
+    expect(data.saldo).not.toBe(50000 - 60); // el bug viejo
+  });
+
+  test('cac_tipo mano_obra → equiv_label "CAC MO"', () => {
+    const data = buildControlPresupuestoData({
+      movimientos: [mov(100, 0, 'ARS', { ars: 1000, cac: 2 })],
+      indexacion: 'CAC',
+      cacTipo: 'mano_obra',
+      presupuestadoNativo: 10,
+      cacIndiceActual: 500,
+    });
+    expect(data.equiv_label).toBe('CAC MO');
+  });
+
+  test('presupuesto en dólares nativo → solo USD, sin equivalencia', () => {
+    const data = buildControlPresupuestoData({
+      movimientos: [
+        mov(100, 200, 'USD', { ars: 250000, usd_blue: 200 }),
+        mov(200, 300000, 'ARS', { ars: 300000, usd_blue: 250 }),
+      ],
+      monedaPresupuesto: 'USD',
+      presupuestadoNativo: 1000,
+    });
+    expect(data.moneda).toBe('USD');
+    expect(data.mostrar_equiv).toBe(false);
+    expect(data.ejecutado).toBe(450); // 200 (USD nativo) + 250 (eq.usd_blue del ARS)
+    expect(data.presupuestado).toBe(1000);
+    expect(data.saldo).toBe(550);
+  });
+
+  test('presupuesto en pesos plano → solo pesos', () => {
+    const data = buildControlPresupuestoData({
+      movimientos: [
+        mov(100, 300000, 'ARS', { ars: 300000 }),
+        mov(200, 400000, 'ARS', { ars: 400000 }),
+      ],
+      monedaPresupuesto: 'ARS',
+      presupuestadoNativo: 1000000,
+    });
+    expect(data.moneda).toBe('ARS');
+    expect(data.mostrar_equiv).toBe(false);
+    expect(data.ejecutado).toBe(700000);
+    expect(data.saldo).toBe(300000);
+    expect(data.avance_pct).toBeCloseTo(70, 5);
+  });
+
+  test('fallback a nivel proyecto (presupuestado compat) sigue funcionando', () => {
+    const data = buildControlPresupuestoData({
+      movimientos: [mov(100, 500000, 'ARS')],
+      presupuestado: 800000, // firma vieja, sin nativo
+    });
+    expect(data.moneda).toBe('ARS');
+    expect(data.ejecutado).toBe(500000);
+    expect(data.saldo).toBe(300000);
+  });
+});

--- a/src/utils/controlPresupuesto/buildControlPresupuestoData.js
+++ b/src/utils/controlPresupuesto/buildControlPresupuestoData.js
@@ -3,10 +3,19 @@ import dayjs from 'dayjs';
 /**
  * Construye el objeto `data` que consumen las plantillas de Control de Presupuesto
  * (la default `PdfControlPresupuestoDocument` y las custom generadas con IA) a partir
- * de los movimientos que abrió un drawer + el contexto disponible.
+ * de los movimientos que abrió un drawer + el contexto del presupuesto.
  *
- * Mismo contrato que `sampleData.js`. Los movimientos llegan con el shape del backend
- * (`total`, `moneda`, `fecha_factura`, `nombre_proveedor`, `categoria`, `type`…).
+ * MONEDA / INDEXACIÓN (espejo de PresupuestoItem y la pestaña Movimientos del
+ * PresupuestoDrawer, que es la lógica ya validada):
+ *  - Presupuesto indexado (CAC o dólar): la unidad NATIVA (CAC / USD) es la base de
+ *    comparación coherente. Mostramos PESOS A HOY = nativo × índice actual, y la
+ *    equivalencia en la unidad nativa al lado. Así presupuestado/ejecutado/saldo
+ *    quedan SIEMPRE en la misma unidad (nunca pesos − CAC).
+ *  - Presupuesto en dólares (nativo, sin indexar): solo dólares.
+ *  - Presupuesto en pesos plano: solo pesos.
+ *
+ * Cada movimiento trae `equivalencias.total.{ars, usd_blue, cac}` (y `.subtotal` si
+ * el presupuesto compara por neto). De ahí salen las equivalencias por fila.
  */
 
 const fechaSecs = (m) => m?.fecha_factura?._seconds || m?.fecha_factura?.seconds || 0;
@@ -18,15 +27,28 @@ const fechaStr = (m) => {
   return '';
 };
 
-const monedaDominante = (movs) => {
-  const counts = {};
-  movs.forEach((m) => {
-    const k = m.moneda || 'ARS';
-    counts[k] = (counts[k] || 0) + 1;
-  });
-  return Object.keys(counts).sort((a, b) => counts[b] - counts[a])[0] || 'ARS';
+const num = (v) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
 };
 
+const cacLabel = (cacTipo) =>
+  cacTipo === 'mano_obra' ? 'CAC MO' : cacTipo === 'materiales' ? 'CAC MAT' : 'CAC';
+
+/**
+ * @param {Object} opts
+ * @param {Array}  opts.movimientos          Movimientos con shape de backend.
+ * @param {string} opts.titulo               Título del documento (editable en el export).
+ * @param {string} [opts.indexacion]         'CAC' | 'USD' | null (indexación del presupuesto en pesos).
+ * @param {string} [opts.monedaPresupuesto]  Moneda nativa del presupuesto: 'ARS' | 'USD' | 'CAC'.
+ * @param {string} [opts.cacTipo]            'general' | 'mano_obra' | 'materiales'.
+ * @param {string} [opts.baseCalculo]        'total' | 'subtotal'.
+ * @param {number} [opts.presupuestadoNativo] Monto presupuestado en unidad nativa (CAC units / USD / ARS).
+ * @param {number} [opts.presupuestado]      Compat: monto ya en moneda de vista (export a nivel proyecto).
+ * @param {number} [opts.montoIngresado]     Pesos originales (fallback si falta el nativo).
+ * @param {number} [opts.cacIndiceActual]    Índice CAC de hoy (según cacTipo).
+ * @param {number} [opts.tipoCambioActual]   Dólar de hoy.
+ */
 export function buildControlPresupuestoData({
   movimientos = [],
   titulo = 'RECIBO DE PAGOS',
@@ -35,33 +57,106 @@ export function buildControlPresupuestoData({
   obra = '',
   empresaNombre = '',
   domicilio = '',
-  moneda = null,
-  presupuestado = 0,
   tipo = 'gastos',
+  indexacion = null,
+  monedaPresupuesto = null,
+  cacTipo = null,
+  baseCalculo = 'total',
+  presupuestadoNativo = null,
+  presupuestado = 0,
+  montoIngresado = null,
+  cacIndiceActual = null,
+  tipoCambioActual = null,
 } = {}) {
-  // Orden cronológico ascendente para que el acumulado tenga sentido.
   const orden = [...movimientos].sort((a, b) => fechaSecs(a) - fechaSecs(b));
-  const monedaDoc = moneda || monedaDominante(orden);
+  const campo = baseCalculo === 'subtotal' ? 'subtotal' : 'total';
+  const eqOf = (m) => (m?.equivalencias?.[campo] || m?.equivalencias?.total || {});
 
-  let acum = 0;
+  // Cotización vigente y clave de equivalencia según el tipo de presupuesto.
+  const cotiz = indexacion === 'CAC' ? num(cacIndiceActual)
+    : indexacion === 'USD' ? num(tipoCambioActual)
+      : null;
+  const indexado = (indexacion === 'CAC' || indexacion === 'USD') && cotiz > 0;
+  const usdNativo = !indexado && monedaPresupuesto === 'USD';
+
+  // Por movimiento: valor en la unidad PRIMARIA (lo que se muestra) y en la EQUIVALENTE.
+  let primaryOf;   // pesos a hoy (indexado/ARS) o USD (nativo)
+  let equivOf;     // unidad nativa CAC/USD (solo indexado) o null
+
+  if (indexado) {
+    const equivKey = indexacion === 'CAC' ? 'cac' : 'usd_blue';
+    // nativo: equivalencia guardada; si falta, lo derivamos del valor en pesos.
+    equivOf = (m) => {
+      const eq = eqOf(m);
+      if (eq[equivKey] != null) return num(eq[equivKey]);
+      const pesos = num(eq.ars) || num(m.total);
+      return cotiz > 0 ? pesos / cotiz : 0;
+    };
+    primaryOf = (m) => equivOf(m) * cotiz; // pesos a hoy
+  } else if (usdNativo) {
+    equivOf = null;
+    primaryOf = (m) => {
+      const eq = eqOf(m);
+      if ((m.moneda || 'ARS') === 'USD') return num(m.total);
+      return num(eq.usd_blue);
+    };
+  } else {
+    // Pesos plano / fallback a nivel proyecto (presupuestos mixtos).
+    equivOf = null;
+    primaryOf = (m) => {
+      const eq = eqOf(m);
+      if ((m.moneda || 'ARS') === 'USD') return num(eq.ars) || num(m.total);
+      return num(m.total);
+    };
+  }
+
+  let acumPrimary = 0;
+  let acumEquiv = 0;
   const movs = orden.map((m, i) => {
-    const monto = Number(m.total) || 0;
-    acum += monto;
-    const detalle = m.nombre_proveedor || m.categoria || m.observacion || 'Movimiento';
+    const monto = primaryOf(m);
+    const montoEquiv = equivOf ? equivOf(m) : null;
+    acumPrimary += monto;
+    if (equivOf) acumEquiv += montoEquiv;
     return {
       numero: i + 1,
       fecha: fechaStr(m),
-      detalle,
+      detalle: m.nombre_proveedor || m.categoria || m.observacion || 'Movimiento',
       proveedor: m.nombre_proveedor || '',
       categoria: m.categoria || '',
       monto,
-      acumulado: acum,
+      acumulado: acumPrimary,
+      monto_equiv: equivOf ? montoEquiv : null,
+      acumulado_equiv: equivOf ? acumEquiv : null,
     };
   });
 
-  const ejecutado = acum;
-  const presup = Number(presupuestado) || 0;
-  const saldo = presup ? presup - ejecutado : 0;
+  // ── Totales en unidad coherente ──────────────────────────────────────────────
+  const ejecutadoEquiv = equivOf ? acumEquiv : null;            // unidad nativa
+  const ejecutado = acumPrimary;                                // unidad primaria
+
+  // Presupuestado nativo: provisto, o derivado de los pesos originales.
+  const nativo = presupuestadoNativo != null
+    ? num(presupuestadoNativo)
+    : (montoIngresado != null && cotiz > 0 ? num(montoIngresado) / cotiz : null);
+
+  let presupuestadoPrimary;
+  let presupuestadoEquiv;
+  if (indexado) {
+    presupuestadoEquiv = nativo != null ? nativo : (ejecutadoEquiv || 0);
+    presupuestadoPrimary = presupuestadoEquiv * cotiz;          // pesos a hoy
+  } else {
+    presupuestadoEquiv = null;
+    presupuestadoPrimary = presupuestadoNativo != null ? num(presupuestadoNativo) : num(presupuestado);
+  }
+
+  const saldo = presupuestadoPrimary - ejecutado;
+  const saldoEquiv = equivOf ? (presupuestadoEquiv - ejecutadoEquiv) : null;
+  const avance_pct = presupuestadoPrimary ? (ejecutado / presupuestadoPrimary) * 100 : 0;
+
+  const moneda = usdNativo ? 'USD' : 'ARS';
+  const equiv_label = indexacion === 'CAC' ? cacLabel(cacTipo)
+    : indexacion === 'USD' ? 'USD'
+      : '';
 
   return {
     titulo,
@@ -72,11 +167,17 @@ export function buildControlPresupuestoData({
     obra,
     presupuesto_label: presupuestoLabel,
     tipo,
-    moneda: monedaDoc,
-    presupuestado: presup,
+    moneda,
+    indexacion: indexado ? indexacion : null,
+    mostrar_equiv: !!equivOf,
+    equiv_label,
+    presupuestado: presupuestadoPrimary,
     ejecutado,
     saldo,
-    avance_pct: presup ? (ejecutado / presup) * 100 : 0,
+    avance_pct,
+    presupuestado_equiv: presupuestadoEquiv,
+    ejecutado_equiv: ejecutadoEquiv,
+    saldo_equiv: saldoEquiv,
     movimientos: movs,
   };
 }

--- a/src/utils/controlPresupuesto/sampleData.js
+++ b/src/utils/controlPresupuesto/sampleData.js
@@ -1,8 +1,11 @@
 /**
  * Datos de muestra para previsualizar plantillas de Control de Presupuesto.
- * Mismo shape que el objeto `data` que recibirá la plantilla en el export real
- * (el builder de datos reales se implementa en una etapa posterior).
- * Basado en el recibo de referencia (RECIBO DE PAGOS).
+ * Mismo shape que el objeto `data` que produce `buildControlPresupuestoData`.
+ *
+ * Caso elegido: presupuesto en PESOS INDEXADO POR CAC → muestra la unidad primaria
+ * (pesos a hoy) + la columna de equivalencia (CAC), el bloque resumen
+ * Presupuestado/Ejecutado/Saldo y la barra de avance. Así el preview ejercita el
+ * render dinámico completo.
  */
 const CONTROL_PRESUPUESTO_SAMPLE_DATA = {
   titulo: 'RECIBO DE PAGOS',
@@ -14,20 +17,26 @@ const CONTROL_PRESUPUESTO_SAMPLE_DATA = {
   presupuesto_label: 'Albañilería 1° etapa',
   tipo: 'gastos',
   moneda: 'ARS',
+  indexacion: 'CAC',
+  mostrar_equiv: true,
+  equiv_label: 'CAC',
   presupuestado: 8750000,
   ejecutado: 7250000,
   saldo: 1500000,
   avance_pct: 82.86,
+  presupuestado_equiv: 17500,
+  ejecutado_equiv: 14500,
+  saldo_equiv: 3000,
   movimientos: [
-    { numero: 1, fecha: '27/3/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 300000, acumulado: 300000 },
-    { numero: 2, fecha: '28/3/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 400000, acumulado: 700000 },
-    { numero: 3, fecha: '10/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1050000, acumulado: 1750000 },
-    { numero: 4, fecha: '17/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 600000, acumulado: 2350000 },
-    { numero: 5, fecha: '24/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 900000, acumulado: 3250000 },
-    { numero: 6, fecha: '30/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 4250000 },
-    { numero: 7, fecha: '8/5/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 5250000 },
-    { numero: 8, fecha: '15/5/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 6250000 },
-    { numero: 9, fecha: '22/5/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 7250000 },
+    { numero: 1, fecha: '27/3/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 300000, acumulado: 300000, monto_equiv: 600, acumulado_equiv: 600 },
+    { numero: 2, fecha: '28/3/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 400000, acumulado: 700000, monto_equiv: 800, acumulado_equiv: 1400 },
+    { numero: 3, fecha: '10/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1050000, acumulado: 1750000, monto_equiv: 2100, acumulado_equiv: 3500 },
+    { numero: 4, fecha: '17/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 600000, acumulado: 2350000, monto_equiv: 1200, acumulado_equiv: 4700 },
+    { numero: 5, fecha: '24/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 900000, acumulado: 3250000, monto_equiv: 1800, acumulado_equiv: 6500 },
+    { numero: 6, fecha: '30/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 4250000, monto_equiv: 2000, acumulado_equiv: 8500 },
+    { numero: 7, fecha: '8/5/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 5250000, monto_equiv: 2000, acumulado_equiv: 10500 },
+    { numero: 8, fecha: '15/5/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 6250000, monto_equiv: 2000, acumulado_equiv: 12500 },
+    { numero: 9, fecha: '22/5/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 7250000, monto_equiv: 2000, acumulado_equiv: 14500 },
   ],
 };
 


### PR DESCRIPTION
Correcciones al export PDF de **Control de presupuesto** (reportadas al probar el export de un presupuesto indexado).

## Qué arregla
1. **Título editable** — `ExportarPdfMenu` ahora tiene un campo de título (default según tipo). Lo que escribís manda sobre `data.titulo`; ya no depende de la plantilla del agente.
2. **Saldo coherente** — `buildControlPresupuestoData` reescrito: para presupuestos indexados trabaja en la unidad nativa (CAC/USD) y muestra **pesos a hoy = nativo × índice actual**. Presupuestado/ejecutado/saldo quedan siempre en la misma unidad → ya no resta pesos − CAC.
3. **Comparación presupuestado vs ejecutado** — bloque resumen Presupuestado / Ejecutado / Saldo + **barra de avance** (%).
4. **Dinámico por moneda** (espejo de `PresupuestoItem`/`PresupuestoDrawer`): pesos indexado CAC/USD → pesos + columna de equivalencia; dólares nativo → solo USD; pesos plano → solo pesos.

## Archivos
- `src/utils/controlPresupuesto/buildControlPresupuestoData.js` (reescritura) + tests
- `src/utils/controlPresupuesto/PdfControlPresupuestoDocument.js` (plantilla default dinámica + resumen + barra)
- `src/utils/controlPresupuesto/sampleData.js` (sample indexado para el preview)
- `src/components/plantillasPdf/ExportarPdfMenu.js`, `useExportarPdf.js` (título editable)
- `src/components/PresupuestoDrawer.js`, `src/pages/control-presupuestos.js` (wiring del contexto del presupuesto)

## Tests
- `npx jest src/utils/controlPresupuesto` → 11 tests del builder (saldo coherente, equivalencias, USD nativo, pesos plano, regresión del bug). Suite completa: 71/71.
- ESLint limpio en los archivos tocados.

## Notas
- Para presupuesto indexado por **dólar** se usa el dólar de fecha-presupuesto (igual que el resumen del `PresupuestoDrawer`), para no divergir de lo que ya se ve ahí.
- Acompaña al cambio del agente de plantillas en el backend (PR de sorby_bot_wa) — _link abajo_.

## Checklist manual
- [ ] Editar el título → se refleja en el PDF (default y plantilla custom)
- [ ] Presupuesto CAC: pesos + columna CAC, saldo coherente, barra de avance
- [ ] Presupuesto USD nativo: solo dólares
- [ ] Presupuesto pesos plano: solo pesos
- [ ] Export a nivel proyecto (Egresos/Ingresos) sigue funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)