### PR TITLE
feat(proveedores): estado de pago por default por proveedor + autocomplete en carga

### DIFF
--- a/src/components/ProveedorDrawer.js
+++ b/src/components/ProveedorDrawer.js
@@ -85,12 +85,13 @@ const estadoChipColor = (estado) => {
 
 // ─── Tab: Datos ───────────────────────────────────────────────────────────────
 
-function TabDatos({ proveedor, empresaId, categoriasEmpresa, onSaved, onArchived }) {
+function TabDatos({ proveedor, empresaId, categoriasEmpresa, estadoDefaultEmpresa = 'Pagado', onSaved, onArchived }) {
   const provId = proveedor?._id || proveedor?.id;
 
   const [form, setForm] = useState({
     nombre: '', razon_social: '', cuit: '', direccion: '',
     tipo: 'materiales', tiene_cuenta_corriente: true, alias: [], categorias: [],
+    estado_inicial: null,
   });
   const [aliasInput, setAliasInput] = useState('');
   const [saving, setSaving] = useState(false);
@@ -110,6 +111,7 @@ function TabDatos({ proveedor, empresaId, categoriasEmpresa, onSaved, onArchived
       tiene_cuenta_corriente: proveedor.tiene_cuenta_corriente !== false,
       alias: proveedor.alias || [],
       categorias: proveedor.categorias || [],
+      estado_inicial: proveedor.estado_inicial ?? null,
     });
   }, [proveedor]);
 
@@ -127,6 +129,7 @@ function TabDatos({ proveedor, empresaId, categoriasEmpresa, onSaved, onArchived
         tiene_cuenta_corriente: form.tiene_cuenta_corriente,
         alias: form.alias,
         categorias: form.categorias,
+        estado_inicial: form.estado_inicial,
       });
       onSaved?.();
     } catch {
@@ -192,6 +195,19 @@ function TabDatos({ proveedor, empresaId, categoriasEmpresa, onSaved, onArchived
           >
             <MenuItem value="materiales">Materiales</MenuItem>
             <MenuItem value="mano_de_obra">Mano de obra</MenuItem>
+          </Select>
+        </FormControl>
+
+        <FormControl fullWidth>
+          <InputLabel>Estado por defecto de movimientos</InputLabel>
+          <Select
+            value={form.estado_inicial ?? ''}
+            label="Estado por defecto de movimientos"
+            onChange={e => setForm(f => ({ ...f, estado_inicial: e.target.value === '' ? null : e.target.value }))}
+          >
+            <MenuItem value="">Usar default de empresa ({estadoDefaultEmpresa})</MenuItem>
+            <MenuItem value="Pendiente">Siempre Pendiente</MenuItem>
+            <MenuItem value="Pagado">Siempre Pagado</MenuItem>
           </Select>
         </FormControl>
 
@@ -1154,7 +1170,7 @@ function TabPresupuestos({ presupuestos = [], loading, onRegistrarPresupuesto, p
 
 // ─── ProveedorDrawer ──────────────────────────────────────────────────────────
 
-function ProveedorDrawer({ open, onClose, proveedorId, proveedorNombreHint, empresaId, categoriasEmpresa, onUpdate }) {
+function ProveedorDrawer({ open, onClose, proveedorId, proveedorNombreHint, empresaId, categoriasEmpresa, estadoDefaultEmpresa, onUpdate }) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const router = useRouter();
@@ -1369,6 +1385,7 @@ function ProveedorDrawer({ open, onClose, proveedorId, proveedorNombreHint, empr
             proveedor={proveedor}
             empresaId={empresaId}
             categoriasEmpresa={categoriasEmpresa}
+            estadoDefaultEmpresa={estadoDefaultEmpresa}
             onSaved={() => { fetchData(); onUpdate?.(); }}
             onArchived={() => { onClose(); onUpdate?.(); }}
           />
@@ -1469,7 +1486,7 @@ function ProveedorDrawer({ open, onClose, proveedorId, proveedorNombreHint, empr
 
 // ─── Provider ─────────────────────────────────────────────────────────────────
 
-export function ProveedorDrawerProvider({ children, empresaId, categoriasEmpresa, onUpdate }) {
+export function ProveedorDrawerProvider({ children, empresaId, categoriasEmpresa, estadoDefaultEmpresa, onUpdate }) {
   const [open, setOpen] = useState(false);
   const [proveedorId, setProveedorId] = useState(null);
 
@@ -1491,6 +1508,7 @@ export function ProveedorDrawerProvider({ children, empresaId, categoriasEmpresa
         proveedorId={proveedorId}
         empresaId={empresaId}
         categoriasEmpresa={categoriasEmpresa}
+        estadoDefaultEmpresa={estadoDefaultEmpresa}
         onUpdate={onUpdate}
       />
     </ProveedorDrawerContext.Provider>

--- a/src/pages/movementForm.js
+++ b/src/pages/movementForm.js
@@ -237,6 +237,8 @@ const MovementFormPage = () => {
   const [movimiento, setMovimiento] = useState(null);
   const [categorias, setCategorias] = useState([]);
   const [proveedores, setProveedores] = useState([]);
+  // nombre de proveedor → estado_inicial ('Pendiente' | 'Pagado' | null = usar default empresa)
+  const [proveedoresEstadoMap, setProveedoresEstadoMap] = useState({});
   const [comprobante_info, setComprobanteInfo] = useState([]);
   const [ingreso_info, setIngresoInfo] = useState({});
   const [categoriaSeleccionada, setCategoriaSeleccionada] = useState(null);
@@ -508,7 +510,11 @@ const MovementFormPage = () => {
       );
       setProyectos(proyectosData);
       const cates = [...empresa.categorias, { name: 'Ingreso dinero', subcategorias: [] }, { name: 'Ajuste', subcategorias: ['Ajuste'] }];
-      const provs = await proveedorService.getNombres(empresa.id);
+      const provsFull = await proveedorService.getByEmpresa(empresa.id);
+      const provs = provsFull.map((p) => p.nombre).sort();
+      const estadoMap = {};
+      provsFull.forEach((p) => { if (p?.nombre) estadoMap[p.nombre] = p.estado_inicial ?? null; });
+      setProveedoresEstadoMap(estadoMap);
       setComprobanteInfo(empresa.comprobante_info || []);
       setIngresoInfo(empresa.ingreso_info || {});
       setCategorias(cates);
@@ -976,6 +982,21 @@ const createdAtStr = (() => {
       setParcialMonto('');
     }
   }, [formik.values.estado, formik.values.type]);
+
+  // Autocompletar el estado según el proveedor elegido. Regla:
+  // proveedor.estado_inicial ('Pendiente'|'Pagado') > default de empresa
+  // (con_estados ? estado_default_movimiento : 'Pagado'). "Autocompletar siempre":
+  // cada cambio de proveedor reescribe el estado. No aplica en edición ni a ingresos.
+  useEffect(() => {
+    if (isEditMode || !empresa || formik.values.type !== 'egreso') return;
+    const override = proveedoresEstadoMap[formik.values.nombre_proveedor];
+    const defaultEmpresa = empresa.con_estados ? (empresa.estado_default_movimiento || 'Pendiente') : 'Pagado';
+    const resuelto = (override === 'Pendiente' || override === 'Pagado') ? override : defaultEmpresa;
+    if (resuelto !== formik.values.estado) {
+      formik.setFieldValue('estado', resuelto);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formik.values.nombre_proveedor, formik.values.type, empresa, proveedoresEstadoMap, isEditMode]);
 
   const handleParcialMontoChange = (value) => {
     setParcialMonto(value);

--- a/src/pages/proveedores.js
+++ b/src/pages/proveedores.js
@@ -708,6 +708,7 @@ const Page = () => {
       <ProveedorDrawerProvider
         empresaId={empresa?.id}
         categoriasEmpresa={empresa?.categorias || []}
+        estadoDefaultEmpresa={empresa?.con_estados ? (empresa?.estado_default_movimiento || 'Pendiente') : 'Pagado'}
         onUpdate={() => setRefreshKey((k) => k + 1)}
       >
         <ProveedoresContent empresa={empresa} refreshKey={refreshKey} />

--- a/src/sections/empresa/proveedoresDetails.js
+++ b/src/sections/empresa/proveedoresDetails.js
@@ -361,26 +361,24 @@ export const ProveedoresDetails = ({ empresa }) => {
               )}
             />
 
-            {empresa.con_estados && (
-              <FormControl fullWidth sx={{ mt: 2 }}>
-                <InputLabel>Estado inicial de movimientos</InputLabel>
-                <Select
-                  name="estado_inicial"
-                  value={formik.values.estado_inicial}
-                  label="Estado inicial de movimientos"
-                  onChange={formik.handleChange}
-                >
-                  <MenuItem value="">
-                    Usar default de la empresa ({empresa.estado_default_movimiento || 'Pendiente'})
-                  </MenuItem>
-                  <MenuItem value="Pendiente">Siempre Pendiente</MenuItem>
-                  <MenuItem value="Pagado">Siempre Pagado (se cierra al instante)</MenuItem>
-                </Select>
-                <FormHelperText>
-                  Cuando cargues un movimiento de este proveedor, ¿con qué estado debe arrancar?
-                </FormHelperText>
-              </FormControl>
-            )}
+            <FormControl fullWidth sx={{ mt: 2 }}>
+              <InputLabel>Estado inicial de movimientos</InputLabel>
+              <Select
+                name="estado_inicial"
+                value={formik.values.estado_inicial}
+                label="Estado inicial de movimientos"
+                onChange={formik.handleChange}
+              >
+                <MenuItem value="">
+                  Usar default de la empresa ({empresa.con_estados ? (empresa.estado_default_movimiento || 'Pendiente') : 'Pagado'})
+                </MenuItem>
+                <MenuItem value="Pendiente">Siempre Pendiente</MenuItem>
+                <MenuItem value="Pagado">Siempre Pagado (se cierra al instante)</MenuItem>
+              </Select>
+              <FormHelperText>
+                Cuando cargues un movimiento de este proveedor, ¿con qué estado debe arrancar?
+              </FormHelperText>
+            </FormControl>
           </DialogContent>
           <DialogActions>
             <Button onClick={cancelarEdicion}>Cancelar</Button>


### PR DESCRIPTION
## Qué resuelve
Frontend de la configuración de estado de pago por default por proveedor. Acompaña al PR de backend `sorby_bot_wa#218`.

## Cambios
- **`ProveedorDrawer.js`** (drawer activo en `pages/proveedores`): nuevo select **"Estado por defecto de movimientos"**, visible siempre, con opción *"Usar default de empresa (&lt;resuelto&gt;)"*, *"Siempre Pendiente"* y *"Siempre Pagado"*. El default resuelto se pasa desde `pages/proveedores` (`con_estados ? estado_default_movimiento : 'Pagado'`).
- **`proveedoresDetails.js`** (UI de proveedor en `configuracionBasica`): el select de `estado_inicial` deja de estar gateado por `con_estados` (el override aplica igual) y el label muestra `'Pagado'` como default cuando `con_estados` está apagado.
- **`movementForm.js`**: al elegir proveedor se **autocompleta siempre** el estado según la regla `proveedor.estado_inicial ?? default empresa`. No aplica en edición ni a ingresos. Se cargan los proveedores con `estado_inicial` (`getByEmpresa`) para resolver en el front.

## Verificación
`eslint` limpio en los 4 archivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)