### PR TITLE
feat(caja-chica): prorrateo de egreso entre proyectos desde caja chica (TAR-402)

### DIFF
--- a/src/components/ProrrateoDialog.js
+++ b/src/components/ProrrateoDialog.js
@@ -170,11 +170,25 @@ const ProrrateoDialog = ({
   const distribuirEquitativamente = () => {
     const montoPorProyecto = (totales.montoBase / distribuciones.length).toFixed(2);
     const porcentajePorProyecto = (100 / distribuciones.length).toFixed(2);
-    
+
     setDistribuciones(prev => prev.map(d => ({
       ...d,
       monto: montoPorProyecto,
       porcentaje: porcentajePorProyecto
+    })));
+  };
+
+  // Crear una distribución por cada proyecto disponible y repartir el total en partes iguales.
+  const seleccionarTodosLosProyectos = () => {
+    if (proyectos.length === 0) return;
+    const montoPorProyecto = (totales.montoBase / proyectos.length).toFixed(2);
+    const porcentajePorProyecto = (100 / proyectos.length).toFixed(2);
+    setDistribuciones(proyectos.map((p, index) => ({
+      id: index + 1,
+      proyecto_id: p.id,
+      proyecto_nombre: p.nombre,
+      monto: montoPorProyecto,
+      porcentaje: porcentajePorProyecto,
     })));
   };
 
@@ -326,9 +340,17 @@ const ProrrateoDialog = ({
         </Paper>
 
         {/* Botones de acceso rápido */}
-        <Stack direction="row" spacing={2} sx={{ mb: 3 }}>
-          <Button 
-            variant="outlined" 
+        <Stack direction="row" spacing={2} sx={{ mb: 3 }} flexWrap="wrap" useFlexGap>
+          <Button
+            variant="outlined"
+            onClick={seleccionarTodosLosProyectos}
+            startIcon={<PieChartIcon />}
+            disabled={proyectos.length === 0}
+          >
+            Seleccionar todos los proyectos
+          </Button>
+          <Button
+            variant="outlined"
             onClick={distribuirEquitativamente}
             startIcon={<CalculateIcon />}
           >

--- a/src/components/ProrrateoDialog.js
+++ b/src/components/ProrrateoDialog.js
@@ -28,12 +28,13 @@ import {
   PieChart as PieChartIcon
 } from '@mui/icons-material';
 
-const ProrrateoDialog = ({ 
-  open, 
-  onClose, 
-  datosBase, 
+const ProrrateoDialog = ({
+  open,
+  onClose,
+  datosBase,
   proyectos = [],
-  onSuccess 
+  proyectosPreseleccionados = [],
+  onSuccess
 }) => {
   const [distribuciones, setDistribuciones] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -41,6 +42,21 @@ const ProrrateoDialog = ({
 
   // Inicializar con el proyecto actual si existe
   useEffect(() => {
+    // Si vienen proyectos preseleccionados (ej: viene del step de multi-select previo),
+    // arrancamos con una fila por cada uno y split equitativo del total.
+    if (open && proyectosPreseleccionados.length > 0) {
+      const total = Number(datosBase?.total || 0);
+      const montoPorProyecto = Number((total / proyectosPreseleccionados.length).toFixed(2));
+      const porcentajePorProyecto = Number((100 / proyectosPreseleccionados.length).toFixed(2));
+      setDistribuciones(proyectosPreseleccionados.map((p, index) => ({
+        id: index + 1,
+        proyecto_id: p.id,
+        proyecto_nombre: p.nombre,
+        monto: montoPorProyecto,
+        porcentaje: porcentajePorProyecto,
+      })));
+      return;
+    }
     if (open && proyectos.length > 0) {
       // Intentar encontrar el proyecto actual por ID o por nombre
       let proyectoActual = null;
@@ -87,7 +103,7 @@ const ProrrateoDialog = ({
         porcentaje: 0
       }]);
     }
-  }, [open, datosBase, proyectos]);
+  }, [open, datosBase, proyectos, proyectosPreseleccionados]);
 
   // Calcular totales
   const totales = useMemo(() => {

--- a/src/components/cajaChica/MovimientoCajaChicaModal.js
+++ b/src/components/cajaChica/MovimientoCajaChicaModal.js
@@ -1,5 +1,5 @@
 // components/cajaChica/MovimientoCajaChicaModal.js
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -17,11 +17,13 @@ import {
 } from '@mui/material';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
+import PieChartOutlineIcon from '@mui/icons-material/PieChartOutline';
 
 const MovimientoCajaChicaModal = ({
   open,
   onClose,
   onSubmit,
+  onProrratear,
   proyectos = [],
   categorias = [],
   proveedores = [],
@@ -40,6 +42,23 @@ const MovimientoCajaChicaModal = ({
   });
 
   const [errors, setErrors] = useState({});
+
+  // Resetear el form cada vez que el modal se abre, para que arranque limpio sin importar
+  // cómo se cerró antes (incluido el camino de prorrateo, que cierra desde el padre).
+  useEffect(() => {
+    if (open) {
+      setFormData({
+        type: tipoInicial,
+        total: '',
+        proyecto_id: '',
+        categoria: '',
+        observacion: '',
+        nombre_proveedor: '',
+        fecha_factura: new Date().toISOString().slice(0, 10),
+      });
+      setErrors({});
+    }
+  }, [open, tipoInicial]);
 
   const handleChange = (field) => (event) => {
     const value = event.target.value;
@@ -99,6 +118,23 @@ const MovimientoCajaChicaModal = ({
     };
 
     onSubmit(movimientoData);
+  };
+
+  // Abre el diálogo de prorrateo (distribuir el egreso entre varios proyectos). La identidad del
+  // dueño de la caja chica + empresa_id las inyecta el padre (cajaChica.js), igual que en el egreso normal.
+  const handleProrratear = () => {
+    if (!validateForm()) return;
+    const proyectoSeleccionado = proyectos.find((p) => p.id === formData.proyecto_id);
+    onProrratear({
+      type: 'egreso',
+      total: parseFloat(formData.total),
+      categoria: formData.categoria,
+      observacion: formData.observacion || '',
+      nombre_proveedor: formData.nombre_proveedor || '',
+      fecha_factura: { seconds: Math.floor(new Date(formData.fecha_factura + 'T12:00:00').getTime() / 1000) },
+      proyecto_id: formData.proyecto_id || null,
+      proyecto_nombre: proyectoSeleccionado?.nombre || null,
+    });
   };
 
   const handleClose = () => {
@@ -252,6 +288,18 @@ const MovimientoCajaChicaModal = ({
       </DialogContent>
 
       <DialogActions sx={{ px: 3, pb: 2 }}>
+        {formData.type === 'egreso' && onProrratear && (
+          <Button
+            onClick={handleProrratear}
+            variant="outlined"
+            color="error"
+            startIcon={<PieChartOutlineIcon />}
+            disabled={isLoading}
+            sx={{ mr: 'auto' }}
+          >
+            Prorratear entre proyectos
+          </Button>
+        )}
         <Button onClick={handleClose} disabled={isLoading}>
           Cancelar
         </Button>

--- a/src/pages/cajaChica.js
+++ b/src/pages/cajaChica.js
@@ -21,8 +21,9 @@ import profileService from 'src/services/profileService';
 import cajaChicaService from 'src/services/cajaChica/cajaChicaService';
 import TransferenciaModal from 'src/components/cajaChica/TransferenciaModal';
 import MovimientoCajaChicaModal from 'src/components/cajaChica/MovimientoCajaChicaModal';
+import ProrrateoDialog from 'src/components/ProrrateoDialog';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
-import { getProyectosByEmpresa } from 'src/services/proyectosService';
+import { getProyectosByEmpresaId } from 'src/services/proyectosService';
 import proveedorService from 'src/services/proveedorService';
 import { formatTimestamp } from 'src/utils/formatters';
 
@@ -63,6 +64,10 @@ const CajaChicaPage = () => {
   const [proyectosEmpresa, setProyectosEmpresa] = useState([]);
   const [categoriasEmpresa, setCategoriasEmpresa] = useState([]);
   const [proveedoresEmpresa, setProveedoresEmpresa] = useState([]);
+
+  // Estados para prorrateo desde caja chica
+  const [prorrateoOpen, setProrrateoOpen] = useState(false);
+  const [prorrateoDatosBase, setProrrateoDatosBase] = useState(null);
 
 
   const [deletingElement, setDeletingElement] = useState(null);
@@ -139,7 +144,7 @@ const CajaChicaPage = () => {
       const empresa = await getEmpresaDetailsFromUser(user);
       if (empresa) {
         const [pys, provNombres] = await Promise.all([
-          getProyectosByEmpresa(empresa),
+          getProyectosByEmpresaId(empresa.id),
           proveedorService.getNombres(empresa.id),
         ]);
         setProyectosEmpresa(pys);
@@ -186,6 +191,23 @@ const CajaChicaPage = () => {
     } finally {
       setIsMovLoading(false);
     }
+  };
+
+  // Abre el diálogo de prorrateo con la identidad del dueño de la caja chica inyectada,
+  // igual que handleCreateMovimiento. Los N egresos generados llevan caja_chica: true, por lo que
+  // descuentan el saldo de caja chica del usuario y quedan registrados contra cada obra.
+  const handleProrratearMovimiento = (datos) => {
+    const targetUser = userById || user;
+    setProrrateoDatosBase({
+      ...datos,
+      caja_chica: true,
+      origen: 'web',
+      moneda,
+      user_phone: targetUser.phone || targetUser.telefono,
+      empresa_id: user.empresa?.id || user.empresaData?.id || user.empresa_id,
+    });
+    setMovModalOpen(false);
+    setProrrateoOpen(true);
   };
 
   const handleCreateTransfer = async (transferData) => {
@@ -553,12 +575,27 @@ const CajaChicaPage = () => {
           open={movModalOpen}
           onClose={handleCloseMovModal}
           onSubmit={handleCreateMovimiento}
+          onProrratear={handleProrratearMovimiento}
           proyectos={proyectosEmpresa}
           categorias={categoriasEmpresa}
           proveedores={proveedoresEmpresa}
           usuarioDestino={userById || user}
           isLoading={isMovLoading}
           tipoInicial={movModalTipo}
+        />
+
+        <ProrrateoDialog
+          open={prorrateoOpen}
+          datosBase={prorrateoDatosBase || {}}
+          proyectos={proyectosEmpresa}
+          onClose={(success) => {
+            setProrrateoOpen(false);
+            setProrrateoDatosBase(null);
+            if (success) {
+              setAlert({ open: true, message: 'Prorrateo registrado: se descontó de la caja chica y se cargó en cada obra.', severity: 'success' });
+              fetchMovimientos();
+            }
+          }}
         />
 
         <Snackbar open={alert.open} autoHideDuration={6000} onClose={handleCloseAlert}>

--- a/src/pages/cajas.js
+++ b/src/pages/cajas.js
@@ -2460,7 +2460,6 @@ const getTime = (v) => {
         handleFiltrosActivos();
         break;
       case 'registrarMovimiento':
-        if (!activeProject) break;
         {
           const currentUrl = typeof window !== 'undefined'
             ? `${window.location.pathname}${window.location.search}`
@@ -2472,15 +2471,12 @@ const getTime = (v) => {
             scrollY: typeof window !== 'undefined' ? window.scrollY : 0,
           });
           const lastPageUrl = navCtx ? appendNavCtxToUrl(currentUrl, navCtx) : currentUrl;
-          router.push({
-            pathname: '/movementForm',
-            query: {
-              proyectoName: activeProject.nombre,
-              proyectoId: activeProject.id,
-              lastPageUrl,
-              lastPageName: 'Cajas',
-            },
-          });
+          // Si hay un proyecto activo, vamos directo a su form. Si no, navegamos sin proyecto
+          // para que movementForm muestre la pantalla de elegir proyecto (y la opción de prorrateo).
+          const query = activeProject
+            ? { proyectoName: activeProject.nombre, proyectoId: activeProject.id, lastPageUrl, lastPageName: 'Cajas' }
+            : { lastPageUrl, lastPageName: 'Cajas' };
+          router.push({ pathname: '/movementForm', query });
         }
         break;
       case 'recalcularSheets':
@@ -3651,7 +3647,7 @@ useEffect(() => {
   return (
     <>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleCloseMenu} keepMounted>
-        <MenuOption sx={itemSx} onClick={() => handleMenuOptionClick('registrarMovimiento')} disabled={!canUseProjectActions}>
+        <MenuOption sx={itemSx} onClick={() => handleMenuOptionClick('registrarMovimiento')}>
           <AddCircleIcon fontSize="small" /> Registrar movimiento
         </MenuOption>
         <MenuOption sx={itemSx} onClick={() => { handleOpenTransferencia(); closeAllMenus(); }}>

--- a/src/pages/movementForm.js
+++ b/src/pages/movementForm.js
@@ -26,6 +26,7 @@ import {
   WalletIcon,
   EllipsisVerticalIcon,
   ChartPieIcon,
+  CheckIcon,
   ChatBubbleOvalLeftEllipsisIcon,
   GlobeAltIcon,
   ArrowPathRoundedSquareIcon,
@@ -279,7 +280,13 @@ const MovementFormPage = () => {
   // Selección manual de proyecto cuando no viene por query (ej. desde drawer de Proveedor)
   // null = aún no eligió; { id: null, nombre: null } = eligió "Sin asignar"; { id, nombre } = proyecto real
   const [proyectoManual, setProyectoManual] = useState(null);
-  const necesitaElegirProyecto = !isEditMode && !proyectoId && proyectoManual === null;
+
+  // Prorrateo desde la pantalla de elegir proyecto: step intermedio de multi-select + modo del form.
+  const [eligiendoProyectosProrrateo, setEligiendoProyectosProrrateo] = useState(false);
+  const [modoProrrateo, setModoProrrateo] = useState(false);
+  const [proyectosProrrateo, setProyectosProrrateo] = useState([]); // [{ id, nombre }]
+
+  const necesitaElegirProyecto = !isEditMode && !proyectoId && proyectoManual === null && !modoProrrateo && !eligiendoProyectosProrrateo;
 
   // En edit mode, priorizar datos del movimiento sobre query params; luego fallback a selección manual.
   const effectiveProyectoId = (isEditMode && movimiento?.proyecto_id) || proyectoId || proyectoManual?.id || null;
@@ -340,7 +347,27 @@ const MovementFormPage = () => {
   
   // Prorrateo
   const [prorrateoOpen, setProrrateoOpen] = useState(false);
+  const [prorrateoSeleccionIds, setProrrateoSeleccionIds] = useState([]); // ids tildados en el step multi-select
   const [stockPopupOpen, setStockPopupOpen] = useState(false);
+
+  const proyectoKey = (p) => p._id || p.id;
+  const abrirSeleccionProrrateo = () => {
+    setProrrateoSeleccionIds((proyectos || []).map(proyectoKey)); // todos pre-tildados
+    setEligiendoProyectosProrrateo(true);
+  };
+  const toggleProrrateoSeleccion = (id) => {
+    setProrrateoSeleccionIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+  };
+  const confirmarSeleccionProrrateo = () => {
+    const elegidos = (proyectos || [])
+      .filter((p) => prorrateoSeleccionIds.includes(proyectoKey(p)))
+      .map((p) => ({ id: proyectoKey(p), nombre: p.nombre }));
+    if (elegidos.length === 0) return;
+    setProyectosProrrateo(elegidos);
+    setModoProrrateo(true);
+    setEligiendoProyectosProrrateo(false);
+    setModoIngreso('manual');
+  };
 
   useEffect(() => {
     if (!accionesOpen) return undefined;
@@ -1708,35 +1735,49 @@ const createdAtStr = (() => {
               >
                 Volver sin guardar
               </button>
-              <button
-                type="button"
-                onClick={isEditMode ? handleSaveOnly : handleSaveAndExport}
-                disabled={isLoading}
-                className="inline-flex min-w-[5.5rem] items-center justify-center gap-1 rounded-lg border border-primary-main bg-white px-4 py-1.5 text-sm font-semibold text-primary-dark shadow-sm hover:bg-primary-lightest disabled:opacity-50"
-              >
-                {isEditMode ? (
-                  isLoading && !returnAfterSaveRef.current ? (
-                    <ArrowPathIcon className="h-5 w-5 animate-spin" aria-label="Cargando" />
-                  ) : (
-                    'Guardar'
-                  )
-                ) : isLoading && exportAfterSaveRef.current ? (
-                  <ArrowPathIcon className="h-5 w-5 animate-spin" aria-label="Cargando" />
-                ) : (
-                  <>
-                    <DocumentArrowDownIcon className="h-4 w-4" aria-hidden />
-                    Guardar y exportar
-                  </>
-                )}
-              </button>
-              <button
-                type="button"
-                onClick={handleSaveAndReturn}
-                disabled={isLoading}
-                className="inline-flex min-w-[7rem] items-center justify-center rounded-lg bg-primary-main px-4 py-1.5 text-sm font-semibold text-white shadow hover:bg-primary-dark disabled:opacity-50"
-              >
-                {isLoading && returnAfterSaveRef.current ? <ArrowPathIcon className="h-5 w-5 animate-spin" aria-label="Cargando" /> : 'Guardar y volver'}
-              </button>
+              {modoProrrateo ? (
+                <button
+                  type="button"
+                  onClick={() => setProrrateoOpen(true)}
+                  disabled={isLoading || !formik.values.total}
+                  className="inline-flex items-center justify-center gap-1 rounded-lg bg-primary-main px-4 py-1.5 text-sm font-semibold text-white shadow hover:bg-primary-dark disabled:opacity-50"
+                >
+                  <ChartPieIcon className="h-4 w-4" aria-hidden />
+                  Distribuir entre proyectos
+                </button>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={isEditMode ? handleSaveOnly : handleSaveAndExport}
+                    disabled={isLoading}
+                    className="inline-flex min-w-[5.5rem] items-center justify-center gap-1 rounded-lg border border-primary-main bg-white px-4 py-1.5 text-sm font-semibold text-primary-dark shadow-sm hover:bg-primary-lightest disabled:opacity-50"
+                  >
+                    {isEditMode ? (
+                      isLoading && !returnAfterSaveRef.current ? (
+                        <ArrowPathIcon className="h-5 w-5 animate-spin" aria-label="Cargando" />
+                      ) : (
+                        'Guardar'
+                      )
+                    ) : isLoading && exportAfterSaveRef.current ? (
+                      <ArrowPathIcon className="h-5 w-5 animate-spin" aria-label="Cargando" />
+                    ) : (
+                      <>
+                        <DocumentArrowDownIcon className="h-4 w-4" aria-hidden />
+                        Guardar y exportar
+                      </>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleSaveAndReturn}
+                    disabled={isLoading}
+                    className="inline-flex min-w-[7rem] items-center justify-center rounded-lg bg-primary-main px-4 py-1.5 text-sm font-semibold text-white shadow hover:bg-primary-dark disabled:opacity-50"
+                  >
+                    {isLoading && returnAfterSaveRef.current ? <ArrowPathIcon className="h-5 w-5 animate-spin" aria-label="Cargando" /> : 'Guardar y volver'}
+                  </button>
+                </>
+              )}
             </div>
           </div>
         </header>
@@ -1822,17 +1863,90 @@ const createdAtStr = (() => {
                   <p className="px-1 text-xs text-neutral-500">No hay proyectos cargados en la empresa.</p>
                 )}
               </div>
-              {!proyectoEsObligatorio && (
-                <div className="mt-4 border-t border-divider pt-4">
-                  <button
-                    type="button"
-                    onClick={() => setProyectoManual({ id: null, nombre: null })}
-                    className="w-full rounded-lg border border-dashed border-neutral-400 px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
-                  >
-                    Sin asignar proyecto
-                  </button>
+              {(proyectos?.length >= 2 || !proyectoEsObligatorio) && (
+                <div className="mt-4 flex flex-col gap-2 border-t border-divider pt-4">
+                  {proyectos?.length >= 2 && (
+                    <button
+                      type="button"
+                      onClick={abrirSeleccionProrrateo}
+                      className="flex w-full items-center justify-center gap-2 rounded-lg border border-primary-main bg-primary-main/5 px-4 py-2 text-sm font-semibold text-primary-main hover:bg-primary-main/10"
+                    >
+                      <ChartPieIcon className="h-4 w-4 shrink-0" aria-hidden />
+                      Dividir entre varios proyectos
+                    </button>
+                  )}
+                  {!proyectoEsObligatorio && (
+                    <button
+                      type="button"
+                      onClick={() => setProyectoManual({ id: null, nombre: null })}
+                      className="w-full rounded-lg border border-dashed border-neutral-400 px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+                    >
+                      Sin asignar proyecto
+                    </button>
+                  )}
                 </div>
               )}
+            </div>
+          </div>
+        ) : eligiendoProyectosProrrateo ? (
+          <div className="flex flex-1 flex-col items-center justify-center px-4 py-8">
+            <div className="w-full max-w-md rounded-xl border border-divider bg-white p-6 shadow-sm">
+              <h2 className="text-center text-lg font-semibold text-neutral-900">¿Entre qué proyectos querés dividir el gasto?</h2>
+              <p className="mt-2 text-center text-sm text-neutral-600">
+                Están todos seleccionados. Destildá los que no correspondan.
+              </p>
+              <div className="mt-3 flex items-center justify-between px-1">
+                <span className="text-xs text-neutral-500">
+                  {prorrateoSeleccionIds.length} de {proyectos?.length || 0} seleccionados
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setProrrateoSeleccionIds(
+                    prorrateoSeleccionIds.length === (proyectos?.length || 0) ? [] : (proyectos || []).map(proyectoKey)
+                  )}
+                  className="text-xs font-medium text-primary-main hover:underline"
+                >
+                  {prorrateoSeleccionIds.length === (proyectos?.length || 0) ? 'Ninguno' : 'Seleccionar todos'}
+                </button>
+              </div>
+              <div className="mt-2 flex max-h-64 flex-col gap-2 overflow-y-auto">
+                {(proyectos || []).map((p) => {
+                  const id = proyectoKey(p);
+                  const checked = prorrateoSeleccionIds.includes(id);
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      onClick={() => toggleProrrateoSeleccion(id)}
+                      className={`flex w-full items-center gap-3 rounded-lg border px-4 py-2.5 text-left text-sm font-medium ${
+                        checked ? 'border-primary-main bg-primary-main/5 text-neutral-900' : 'border-neutral-300 bg-white text-neutral-700 hover:bg-neutral-50'
+                      }`}
+                    >
+                      <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border ${checked ? 'border-primary-main bg-primary-main text-white' : 'border-neutral-400 bg-white'}`}>
+                        {checked && <CheckIcon className="h-3.5 w-3.5" aria-hidden />}
+                      </span>
+                      {p.nombre}
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="mt-5 flex flex-col gap-2">
+                <button
+                  type="button"
+                  onClick={confirmarSeleccionProrrateo}
+                  disabled={prorrateoSeleccionIds.length === 0}
+                  className="w-full rounded-lg bg-primary-main px-4 py-3 text-sm font-semibold text-white shadow hover:bg-primary-dark disabled:opacity-40"
+                >
+                  Continuar
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEligiendoProyectosProrrateo(false)}
+                  className="w-full rounded-lg px-4 py-2 text-sm font-medium text-neutral-600 hover:bg-neutral-50"
+                >
+                  Volver
+                </button>
+              </div>
             </div>
           </div>
         ) : modoIngreso === null && !isEditMode ? (
@@ -1881,6 +1995,16 @@ const createdAtStr = (() => {
                 className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain"
               >
                 <div className="flex flex-col gap-2 pb-1">
+                  {modoProrrateo && (
+                    <div className="flex items-start gap-2 rounded-lg border border-primary-main/40 bg-primary-main/5 px-3 py-2">
+                      <ChartPieIcon className="mt-0.5 h-4 w-4 shrink-0 text-primary-main" aria-hidden />
+                      <p className="text-xs text-neutral-700">
+                        <span className="font-semibold text-neutral-900">Modo prorrateo:</span> cargá el gasto una vez y se
+                        dividirá entre los <span className="font-semibold">{proyectosProrrateo.length} proyectos</span> elegidos.
+                        Tocá <span className="font-semibold">“Distribuir entre proyectos”</span> para revisar y confirmar.
+                      </p>
+                    </div>
+                  )}
                   <StitchBlock step={1} title="Detalles del movimiento">
                     <MovementFields {...sharedFieldProps} block="details" />
                   </StitchBlock>
@@ -2156,6 +2280,7 @@ const createdAtStr = (() => {
             proyecto_nombre: effectiveProyectoName,
           }}
           proyectos={proyectos}
+          proyectosPreseleccionados={modoProrrateo ? proyectosProrrateo : []}
           onSuccess={(data) => {
             console.log('Prorrateo exitoso:', data);
           }}


### PR DESCRIPTION
## Contexto
Ticket **TAR-402** — parte 2 (Web). El prorrateo (distribuir un egreso entre varios proyectos) solo existía en `movementForm`, que exige tener proyectos asignados. Un usuario con **solo caja chica** no podía prorratear desde la web. Ahora puede hacerlo desde el modal de caja chica.

## Qué hace
Un prorrateo de caja chica = **N egresos** (uno por proyecto, sumando el total) con `caja_chica: true` + `proyecto_id` + identidad del dueño. Cada egreso **descuenta el saldo de caja chica** del usuario y **queda registrado contra cada obra** — misma semántica que el egreso único de caja-chica-con-proyecto que ya existe. **Sin cambios de backend**: reusa `POST /movimiento/prorrateo` (`createMovimientoProrrateo` ya propaga `caja_chica`/identidad vía `...datosBase`).

## Cambios (frontend)
- **`ProrrateoDialog.js`**: botón **"Seleccionar todos los proyectos"**.
- **`MovimientoCajaChicaModal.js`**: botón **"Prorratear entre proyectos"** (solo egreso) + prop `onProrratear`; **reset del form al abrir** (arregla los inputs que no se limpiaban tras crear un movimiento/prorrateo).
- **`cajaChica.js`**: orquesta el diálogo inyectando la identidad del dueño (`user_phone` + `empresa_id`, soporta modo espía) y carga **todos** los proyectos de la empresa (`getProyectosByEmpresaId`).

## Verificación
- `npm run lint` y `npm run build` OK.
- Pendiente validación E2E en staging/empresa de prueba: confirmar que baja el saldo de caja chica y que cada obra recibe su egreso (mismo `prorrateo_grupo_id`). ⚠️ Producción con datos reales.

## Relacionado
Parte 1 (fix del bot): https://github.com/fedemaidan/sorby_bot_wa/pull/224

🤖 Generated with [Claude Code](https://claude.com/claude-code)