### PR TITLE
DHN — Modal de corrección unificado + tipo de licencia

### DIFF
--- a/src/components/dhn/CorreccionConciliacionModal.js
+++ b/src/components/dhn/CorreccionConciliacionModal.js
@@ -9,13 +9,12 @@ import {
   Dialog,
   Divider,
   IconButton,
+  MenuItem,
   Slider,
   Stack,
   Tab,
   Tabs,
   TextField,
-  ToggleButton,
-  ToggleButtonGroup,
   Toolbar,
   Tooltip,
   Typography,
@@ -36,6 +35,9 @@ import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import { HorasRawTable } from "src/components/dhn/HorasRawModal";
 import { ImageViewer, useImageViewerState } from "src/components/ImageViewer";
 import { getHourChipSx } from "src/components/dhn/hourChipStyles";
+import tiposLicenciaService from "src/services/dhn/tiposLicenciaService";
+
+const SIN_TIPO_LICENCIA = "__sin_tipo__";
 
 const HORA_FIELDS = [
   { key: "horasNormales", label: "Normales" },
@@ -128,7 +130,37 @@ const CorreccionConciliacionModal = ({
 }) => {
   const theme = useTheme();
   const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
+  // Los botones "Horas Sistema / Horas NASA" y el panel "Sheet NASA" solo aplican
+  // en conciliación (cuando el padre pasa los handlers de selección). Reutilizado
+  // sin esos handlers (ej: edición de un trabajo diario) el modal los oculta.
+  const isConciliacion = typeof onSelectExcel === "function" || typeof onSelectSistema === "function";
   const comprobantes = useMemo(() => (Array.isArray(row?.comprobantes) ? row.comprobantes : []), [row]);
+
+  const [tiposLicencia, setTiposLicencia] = useState([]);
+  useEffect(() => {
+    if (!open) return undefined;
+    let active = true;
+    tiposLicenciaService
+      .getAll()
+      .then((items) => {
+        if (active) setTiposLicencia(Array.isArray(items) ? items : []);
+      })
+      .catch(() => {
+        if (active) setTiposLicencia([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, [open]);
+
+  const tipoLicenciaOptions = useMemo(() => {
+    const opts = tiposLicencia.map((t) => ({ value: t.codigo, label: `${t.codigo} — ${t.nombre}` }));
+    const current = formHoras?.tipoLicencia;
+    if (current && !opts.some((o) => o.value === current)) {
+      opts.unshift({ value: current, label: current });
+    }
+    return opts;
+  }, [tiposLicencia, formHoras?.tipoLicencia]);
   const turnosDetectados = useMemo(
     () => (Array.isArray(row?.turnosDetectados) ? row.turnosDetectados : []),
     [row]
@@ -188,13 +220,25 @@ const CorreccionConciliacionModal = ({
     [onFormHorasChange]
   );
 
-  const handleLicenseToggle = useCallback(
-    (_event, value) => {
-      if (value === null) return;
-      handleHorasFieldChange("fechaLicencia", value === "si");
+  const handleLicenciaChange = useCallback(
+    (event) => {
+      if (typeof onFormHorasChange !== "function") return;
+      const value = event.target.value;
+      const isLicencia = value !== "";
+      onFormHorasChange((prev) => ({
+        ...prev,
+        fechaLicencia: isLicencia,
+        tipoLicencia: isLicencia && value !== SIN_TIPO_LICENCIA ? value : null,
+      }));
     },
-    [handleHorasFieldChange]
+    [onFormHorasChange]
   );
+
+  // Valor del select: vacío = sin licencia; un código = licencia de ese tipo.
+  // SIN_TIPO_LICENCIA cubre registros viejos con licencia marcada pero sin tipo.
+  const licenciaValue = formHoras?.fechaLicencia
+    ? (formHoras?.tipoLicencia || SIN_TIPO_LICENCIA)
+    : "";
 
   const handleSelectExcelClick = useCallback(async () => {
     if (typeof onSelectExcel === "function") {
@@ -507,27 +551,31 @@ const CorreccionConciliacionModal = ({
           }}
         >
           <Stack spacing={2}>
-            <Stack direction="row" spacing={1} flexWrap="wrap">
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={handleSelectSistemaClick}
-                disabled={selectionLoading}
-                sx={{ textTransform: "none" }}
-              >
-                Horas Sistema
-              </Button>
-              <Button
-                variant="contained"
-                size="small"
-                onClick={handleSelectExcelClick}
-                disabled={selectionLoading}
-                sx={{ textTransform: "none" }}
-              >
-                Horas NASA
-              </Button>
-            </Stack>
-            <Divider />
+            {isConciliacion && (
+              <>
+                <Stack direction="row" spacing={1} flexWrap="wrap">
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={handleSelectSistemaClick}
+                    disabled={selectionLoading}
+                    sx={{ textTransform: "none" }}
+                  >
+                    Horas Sistema
+                  </Button>
+                  <Button
+                    variant="contained"
+                    size="small"
+                    onClick={handleSelectExcelClick}
+                    disabled={selectionLoading}
+                    sx={{ textTransform: "none" }}
+                  >
+                    Horas NASA
+                  </Button>
+                </Stack>
+                <Divider />
+              </>
+            )}
             <Stack
               direction="row"
               spacing={2}
@@ -537,7 +585,7 @@ const CorreccionConciliacionModal = ({
             >
               <Box sx={{ flex: 1, minWidth: 200 }}>
                 <Typography variant="subtitle2" gutterBottom>
-                  Sistema
+                  {isConciliacion ? "Sistema" : "Horas"}
                 </Typography>
                 <Stack spacing={1} sx={{ flexWrap: "wrap" }}>
                   {HORA_FIELDS.map((field) => (
@@ -555,57 +603,52 @@ const CorreccionConciliacionModal = ({
                     />
                   ))}
                 </Stack>
-                <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 1 }}>
-                  <Typography variant="body2" sx={{ minWidth: 60 }}>
-                    Licencia
-                  </Typography>
-                  <ToggleButtonGroup
-                    value={formHoras?.fechaLicencia ? "si" : "no"}
-                    exclusive
+                <Box sx={{ mt: 1.5 }}>
+                  <TextField
+                    select
+                    fullWidth
+                    label="Licencia"
+                    value={licenciaValue}
+                    onChange={handleLicenciaChange}
                     size="small"
-                    onChange={handleLicenseToggle}
-                    sx={{
-                      borderRadius: 1,
-                      bgcolor: "background.paper",
-                      boxShadow: 1,
-                      "& .MuiToggleButton-root": {
-                        borderColor: "divider",
-                        px: 1.5,
-                      },
-                    }}
-                    aria-label="Seleccionar licencia"
+                    sx={{ maxWidth: 240 }}
                   >
-                    <ToggleButton value="si" aria-label="Licencia sí">
-                      Sí
-                    </ToggleButton>
-                    <ToggleButton value="no" aria-label="Licencia no">
-                      No
-                    </ToggleButton>
-                  </ToggleButtonGroup>
-                </Stack>
+                    <MenuItem value="">Sin licencia</MenuItem>
+                    {licenciaValue === SIN_TIPO_LICENCIA && (
+                      <MenuItem value={SIN_TIPO_LICENCIA}>Licencia (sin tipo)</MenuItem>
+                    )}
+                    {tipoLicenciaOptions.map((opt) => (
+                      <MenuItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                </Box>
               </Box>
-              <Box sx={{ flex: 1, minWidth: 200 }}>
-                <Typography variant="subtitle2" gutterBottom>
-                  Sheet NASA
-                </Typography>
-                <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
-                  {sheetItems.length === 0 ? (
-                    <Typography variant="caption" color="text.secondary">
-                      Sin horas en sheet
-                    </Typography>
-                  ) : (
-                    sheetItems.map((item) => (
-                      <Chip
-                        key={item.k}
-                        label={`${item.k} ${item.v} hs`}
-                        size="small"
-                        variant="outlined"
-                        sx={getHourChipSx(item.k)}
-                      />
-                    ))
-                  )}
-                </Stack>
-              </Box>
+              {isConciliacion && (
+                <Box sx={{ flex: 1, minWidth: 200 }}>
+                  <Typography variant="subtitle2" gutterBottom>
+                    Sheet NASA
+                  </Typography>
+                  <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                    {sheetItems.length === 0 ? (
+                      <Typography variant="caption" color="text.secondary">
+                        Sin horas en sheet
+                      </Typography>
+                    ) : (
+                      sheetItems.map((item) => (
+                        <Chip
+                          key={item.k}
+                          label={`${item.k} ${item.v} hs`}
+                          size="small"
+                          variant="outlined"
+                          sx={getHourChipSx(item.k)}
+                        />
+                      ))
+                    )}
+                  </Stack>
+                </Box>
+              )}
             </Stack>
             {turnosDetectados.length > 0 && (
               <Box>

--- a/src/pages/DHN/conciliacion/[id].js
+++ b/src/pages/DHN/conciliacion/[id].js
@@ -103,6 +103,7 @@ const ConciliacionDetallePage = () => {
     horasZanjeo: null,
     horasNocturnas: null,
     fechaLicencia: false,
+    tipoLicencia: null,
   });
   const [selectionLoading, setSelectionLoading] = useState(false);
   const [bulkSelectionLoading, setBulkSelectionLoading] = useState(false);
@@ -641,6 +642,7 @@ const ConciliacionDetallePage = () => {
                   horasZanjeo: row?.dbHoras?.horasZanjeo ?? null,
                   horasNocturnas: row?.dbHoras?.horasNocturnas ?? null,
                   fechaLicencia: row?.dbHoras?.fechaLicencia ?? false,
+                  tipoLicencia: row?.dbHoras?.tipoLicencia ?? null,
                 };
                 setFormHoras(initial);
                 setRowToEdit(row);

--- a/src/pages/dhn/trabajador/[trabajadorId].js
+++ b/src/pages/dhn/trabajador/[trabajadorId].js
@@ -12,7 +12,8 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import useTrabajoDiarioPage from 'src/hooks/dhn/useTrabajoDiarioPage';
-import EditarTrabajoDiarioModal from 'src/components/dhn/EditarTrabajoDiarioModal';
+import CorreccionConciliacionModal from 'src/components/dhn/CorreccionConciliacionModal';
+import TrabajoRegistradoService from 'src/services/dhn/TrabajoRegistradoService';
 import FiltroTrabajoDiario from 'src/components/dhn/FiltroTrabajoDiario';
 import ImagenModal from 'src/components/ImagenModal';
 import TrabajosDetectadosList from 'src/components/dhn/TrabajosDetectadosList';
@@ -74,6 +75,19 @@ const TrabajadorPage = () => {
   const [rawModalFileName, setRawModalFileName] = useState('');
   const [rawModalUrl, setRawModalUrl] = useState('');
 
+  const [formHoras, setFormHoras] = useState({
+    horasNormales: null,
+    horas50: null,
+    horas100: null,
+    horasAltura: null,
+    horasHormigon: null,
+    horasZanjeo: null,
+    horasNocturnas: null,
+    fechaLicencia: false,
+    tipoLicencia: null,
+  });
+  const [savingEdit, setSavingEdit] = useState(false);
+
   const handleOpenComprobante = useCallback((comp, item) => {
     if (!comp) return;
     const url = comp?.url || comp?.url_storage || '';
@@ -133,6 +147,53 @@ const TrabajadorPage = () => {
     defaultSort: 'fecha:asc',
     onOpenComprobante: handleOpenComprobante,
   });
+
+  useEffect(() => {
+    if (!edit.open || !edit.entity) return;
+    const t = edit.entity;
+    const he = t.horasExcel || {};
+    setFormHoras({
+      horasNormales: he.horasNormales ?? t.horasNormales ?? null,
+      horas50: he.horas50 ?? t.horas50 ?? null,
+      horas100: he.horas100 ?? t.horas100 ?? null,
+      horasAltura: t.horasAltura ?? null,
+      horasHormigon: t.horasHormigon ?? null,
+      horasZanjeo: t.horasZanjeo ?? null,
+      horasNocturnas: he.horasNocturnas ?? t.horasNocturnas ?? null,
+      fechaLicencia: t.fechaLicencia || false,
+      tipoLicencia: t.tipoLicencia ?? null,
+    });
+  }, [edit.open, edit.entity]);
+
+  const handleSaveTrabajoDiario = useCallback(async () => {
+    const entity = edit.entity;
+    if (!entity?._id) return;
+    setSavingEdit(true);
+    try {
+      const base = entity.horasExcel || {};
+      const payload = {
+        fechaLicencia: Boolean(formHoras.fechaLicencia),
+        tipoLicencia: formHoras.fechaLicencia ? (formHoras.tipoLicencia ?? null) : null,
+        horasAltura: formHoras.horasAltura ?? null,
+        horasHormigon: formHoras.horasHormigon ?? null,
+        horasZanjeo: formHoras.horasZanjeo ?? null,
+        horasExcel: {
+          ...base,
+          horasNormales: formHoras.horasNormales ?? null,
+          horas50: formHoras.horas50 ?? null,
+          horas100: formHoras.horas100 ?? null,
+          horasNocturnas: formHoras.horasNocturnas ?? null,
+        },
+      };
+      await TrabajoRegistradoService.update(entity._id, payload);
+      await edit.onSave();
+      edit.onClose();
+    } catch (e) {
+      console.error('Error al actualizar trabajo diario', e);
+    } finally {
+      setSavingEdit(false);
+    }
+  }, [edit, formHoras]);
 
   const formatters = { fecha: formatDateDDMMYYYY };
 
@@ -234,11 +295,14 @@ const TrabajadorPage = () => {
         </Stack>
       </Container>
 
-      <EditarTrabajoDiarioModal
+      <CorreccionConciliacionModal
         open={edit.open}
         onClose={edit.onClose}
-        onSave={edit.onSave}
-        trabajoDiario={edit.entity}
+        row={edit.entity}
+        formHoras={formHoras}
+        onFormHorasChange={setFormHoras}
+        selectionLoading={savingEdit}
+        onSave={handleSaveTrabajoDiario}
       />
 
       <HistorialModal


### PR DESCRIPTION
# DHN — Modal de corrección unificado + tipo de licencia

Reutilizar el modal de corrección para editar trabajos diarios y reemplazar el toggle Sí/No de licencia por un selector de tipo. PR hermano (backend): https://github.com/fedemaidan/sorby_bot_wa/pull/231

---

## Modal de corrección unificado + tipo de licencia
**Causa raíz / Problema:** La edición de un trabajo diario usaba un modal aparte (`EditarTrabajoDiarioModal`), distinto del de conciliación, duplicando UI. Y la licencia se marcaba con un Sí/No, sin poder indicar el tipo.

**Cómo lo hicimos (funcional):** Editar un trabajo diario desde la página del trabajador ahora abre el **mismo modal de corrección** que en conciliación, sin las partes que solo aplican a conciliación (botones Horas Sistema/NASA y panel Sheet NASA). La **licencia pasa a elegirse de una lista de tipos**.

**Decisiones y por qué:**
- Reutilizar `CorreccionConciliacionModal` en vez de mantener dos modales → menos duplicación; lo específico de conciliación se oculta según los handlers que reciba.
- Detectar "modo conciliación" por la presencia de `onSelectExcel`/`onSelectSistema` → no hace falta un flag extra.
- Selector de **tipo** de licencia en vez de Sí/No → permite registrar el tipo; con opción "sin tipo" para registros viejos.

**Cómo lo implementamos (técnico):**
- `components/dhn/CorreccionConciliacionModal.js`: `isConciliacion` condiciona los botones de selección y el panel Sheet NASA; `TextField select` de licencia alimentado por `tiposLicenciaService`; persiste `tipoLicencia`.
- `pages/dhn/trabajador/[trabajadorId].js`: usa el modal unificado, arma `formHoras` y guarda vía `TrabajoRegistradoService.update`.
- `pages/DHN/conciliacion/[id].js`: `tipoLicencia` sumado al form.

**Producción / compatibilidad:** Aditivo. `tipoLicencia` es opcional; registros sin tipo se muestran como "Licencia (sin tipo)". Sin migración.

**Verificación:** Validación manual en la UI de DHN (edición de trabajo diario y conciliación).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
