### PR TITLE
TAR-343 — Toggle de Impuestos en config de ingresos

### DIFF
--- a/src/sections/empresa/configuracionGeneral.js
+++ b/src/sections/empresa/configuracionGeneral.js
@@ -59,6 +59,7 @@ export const ConfiguracionGeneral = ({ empresa, updateEmpresaData, hasPermission
     asignado: false,
     tags_extra: false,
     dolar_referencia: false,
+    impuestos: false,
   };
 
   const [ingresoInfo, setIngresoInfo] = useState({


### PR DESCRIPTION
Frontend de TAR-343. PR hermano (backend): fedemaidan/sorby_bot_wa#230.

---

## TAR-343 — Hacer configurable el IVA en ingresos
**Causa raíz / Problema:** No había forma de habilitar/deshabilitar por empresa que los ingresos manejen IVA. Debía ser configurable, apagado por default, igual que el resto de los campos de un ingreso (y que `impuestos` en egresos).

**Cómo lo hicimos (funcional):** En Configuración → *"campos que muestra un ingreso"* ahora aparece el toggle **Impuestos**, apagado por default. Al prenderlo, el ingreso pasa a soportar IVA: se muestra el editor de impuestos en el form del dashboard y el bot detecta IVA en los ingresos cargados por WhatsApp.

**Decisiones y por qué:**
• **Reusar el mecanismo existente de `ingreso_info`** → la UI de campos de ingreso se genera iterando las keys de `ingreso_info_default`; agregar `impuestos: false` hace aparecer el toggle solo, sin UI nueva. Mismo patrón que `comprobante_info.impuestos` en egresos.
• **Default off** → rollout seguro; las empresas que no lo prenden funcionan igual que hoy.

**Cómo lo implementamos (técnico):**
• `src/sections/empresa/configuracionGeneral.js`: se agrega `impuestos: false` a `ingreso_info_default`. El toggle se renderiza automáticamente y se guarda en `empresa.ingreso_info` vía el `handleSaveConfig` existente.

**Producción / compatibilidad:** Aditivo, default off. Empresas existentes sin el flag no cambian.

**Verificación:** ESLint OK. El backend (PR hermano) gatea la extracción de IVA en `CREAR_INGRESO` por `ingreso_info.impuestos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)