### PR TITLE
TAR-430: editar materiales extraídos inline en movementForm

### DIFF
--- a/src/components/stock/solicitudes/SolicitudMaterialesInline.js
+++ b/src/components/stock/solicitudes/SolicitudMaterialesInline.js
@@ -1,0 +1,309 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { Box } from '@mui/material';
+import { CubeIcon, PlusIcon, TrashIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import MaterialAutocomplete from 'src/components/MaterialAutocomplete';
+import StockSolicitudesService from 'src/services/stock/stockSolicitudesService';
+import StockMovimientosService from 'src/services/stock/stockMovimientosService';
+
+// Tokens de diseño tomados de movementForm.js (movementFields.js) para mantener uniformidad.
+const inputCls =
+  'w-full rounded-lg border border-neutral-200 bg-white px-2.5 py-1.5 text-sm text-neutral-900 shadow-sm focus:border-primary-main focus:outline-none focus:ring-1 focus:ring-primary-main';
+
+// Grilla de columnas compartida por encabezados y filas (alineación tipo tabla).
+const gridCls =
+  'grid grid-cols-[minmax(180px,1.4fr)_5rem_6rem_5.5rem_minmax(120px,1fr)_2rem] items-center gap-2';
+
+// El MaterialAutocomplete es MUI; lo achicamos para que matchee los inputs nativos del form.
+const autocompleteSx = {
+  '& .MuiOutlinedInput-root': { borderRadius: '8px', bgcolor: '#fff' },
+  '& .MuiOutlinedInput-notchedOutline': { borderColor: '#e5e7eb' },
+  '& .MuiOutlinedInput-input': { padding: '7px 8px', fontSize: 14 },
+  '& .MuiAutocomplete-endAdornment': { top: 'calc(50% - 13px)' },
+};
+
+const estadoPill = (estado) => {
+  switch (String(estado || '').toUpperCase()) {
+    case 'ENTREGADO':
+      return { label: 'Entregado', cls: 'border-success-main/30 bg-success-main/10 text-success-dark' };
+    case 'PARCIALMENTE_ENTREGADO':
+      return { label: 'Parcial', cls: 'border-warning-main/30 bg-warning-main/10 text-warning-dark' };
+    default:
+      return { label: 'Pendiente', cls: 'border-neutral-200 bg-neutral-100 text-neutral-600' };
+  }
+};
+
+const noEnter = (e) => { if (e.key === 'Enter') e.preventDefault(); };
+
+/** Tarjeta con el mismo lenguaje visual que las secciones del formulario (StitchBlock). */
+const Card = ({ children }) => (
+  <section className="flex shrink-0 flex-col rounded-xl border border-divider bg-white shadow-sm">
+    {children}
+  </section>
+);
+
+const solicitudToForm = (s = {}) => ({
+  tipo: s.tipo || 'INGRESO',
+  subtipo: s.subtipo || '',
+  fecha: s.fecha ? String(s.fecha).substring(0, 10) : '',
+  responsable: s.responsable || '',
+  proveedor_nombre: s?.proveedor?.nombre || '',
+  proveedor_id: s?.proveedor?.id || '',
+  proveedor_cuit: s?.proveedor?.cuit || '',
+  id_compra: s.id_compra || '',
+  url_doc: s.url_doc || '',
+  documentos: Array.isArray(s.documentos) ? s.documentos : (s.url_doc ? [s.url_doc] : []),
+  proyecto_id: s.proyecto_id || '',
+  proyecto_nombre: s.proyecto_nombre || '',
+  numero_documento: s.numero_documento || s.numero_remito || s.numero_factura || '',
+  etiqueta: s.etiqueta || '',
+});
+
+// cantidad en valor absoluto; el signo lo maneja el back vía tipo.
+const movimientoToFila = (mm = {}) => ({
+  nombre_item: mm.nombre_item || '',
+  cantidad: Math.abs(mm.cantidad ?? 0),
+  tipo: mm.tipo || 'INGRESO',
+  subtipo: mm.subtipo || 'GENERAL',
+  fecha_movimiento: mm.fecha_movimiento ? String(mm.fecha_movimiento).substring(0, 10) : '',
+  proyecto_id: mm.proyecto_id || '',
+  proyecto_nombre: mm.proyecto_nombre || '',
+  observacion: mm.observacion || '',
+  id_material: mm.id_material || '',
+  _id: mm._id || undefined,
+  estado: mm.estado || 'PENDIENTE',
+  precio_unitario: mm.precio_unitario ?? null,
+});
+
+/**
+ * Vista y edición inline de los materiales extraídos de una solicitud de stock,
+ * incrustada al final de movementForm. Misma funcionalidad que la tabla de
+ * Movimientos de la página de solicitudes (material con buscador/creación,
+ * cantidad, estado, precio y observación). Se oculta sola si no hay materiales.
+ *
+ * NO tiene botón de guardar propio: el guardado se dispara desde los botones
+ * "Guardar" del formulario vía ref (validar / guardar).
+ *
+ * Props: solicitudId, user, onError?
+ * Ref:   { validar(): {ok, message}, guardar(): Promise<void>, hasPendingChanges(): bool }
+ */
+function SolicitudMaterialesInline({ solicitudId, user, onError }, ref) {
+  const [form, setForm] = useState(null);
+  const [movs, setMovs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const eliminadosRef = useRef([]); // ids reales a borrar en el back al guardar
+
+  const cargar = useCallback(() => {
+    if (!solicitudId) return undefined;
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(false);
+    StockSolicitudesService.obtenerSolicitud({ solicitudId })
+      .then((entry) => {
+        if (cancelled) return;
+        const s = entry?.solicitud || {};
+        const lineas = Array.isArray(entry?.movimientos) ? entry.movimientos : [];
+        setForm(solicitudToForm(s));
+        setMovs(lineas.map(movimientoToFila));
+        eliminadosRef.current = [];
+        setDirty(false);
+      })
+      .catch(() => { if (!cancelled) setLoadError(true); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [solicitudId]);
+
+  useEffect(() => cargar(), [cargar]);
+
+  const setRow = useCallback((idx, patch) => {
+    setMovs((prev) => prev.map((m, i) => (i === idx ? { ...m, ...patch } : m)));
+    setDirty(true);
+  }, []);
+
+  const agregarLinea = useCallback(() => {
+    setMovs((prev) => [
+      ...prev,
+      {
+        nombre_item: '', cantidad: 1,
+        tipo: form?.tipo || 'INGRESO', subtipo: form?.subtipo || 'GENERAL',
+        proyecto_id: form?.proyecto_id || '', proyecto_nombre: form?.proyecto_nombre || '',
+        observacion: '', id_material: '', precio_unitario: null, estado: 'PENDIENTE',
+      },
+    ]);
+    setDirty(true);
+  }, [form]);
+
+  const quitarLinea = useCallback((idx) => {
+    setMovs((prev) => {
+      const m = prev[idx];
+      if (m?._id) eliminadosRef.current.push(m._id);
+      return prev.filter((_, i) => i !== idx);
+    });
+    setDirty(true);
+  }, []);
+
+  const filaInvalida = (m) => !(m.nombre_item?.trim() || m.id_material) || !Number(m.cantidad);
+  const hayInvalidas = movs.some(filaInvalida);
+
+  const guardar = useCallback(async () => {
+    await Promise.all(
+      eliminadosRef.current.map((id) => StockMovimientosService.eliminarMovimiento(id)),
+    );
+    await StockSolicitudesService.guardarSolicitud({
+      user,
+      form: { ...form, responsable: user?.email || form?.responsable || '' },
+      movs, editMode: true, editId: solicitudId,
+    });
+  }, [user, form, movs, solicitudId]);
+
+  // Guardado disparado desde los botones "Guardar" del formulario.
+  useImperativeHandle(ref, () => ({
+    hasPendingChanges: () => dirty,
+    validar: () => (hayInvalidas
+      ? { ok: false, message: 'Completá material y cantidad en los materiales extraídos' }
+      : { ok: true }),
+    guardar: async () => {
+      if (!dirty) return;
+      try {
+        await guardar();
+        cargar();
+      } catch (e) {
+        onError?.(e?.message || 'No se pudieron guardar los materiales');
+        throw e;
+      }
+    },
+  }), [dirty, hayInvalidas, guardar, cargar, onError]);
+
+  if (loadError) {
+    return (
+      <Card>
+        <div className="flex items-center gap-2 px-3 py-2.5">
+          <p className="flex-1 text-sm text-error-dark">No se pudieron cargar los materiales extraídos.</p>
+          <button type="button" onClick={cargar} className="inline-flex items-center gap-1 text-xs font-medium text-primary-dark hover:underline">
+            <ArrowPathIcon className="h-4 w-4" /> Reintentar
+          </button>
+        </div>
+      </Card>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Card>
+        <div className="space-y-2 px-3 py-2.5">
+          <div className="h-4 w-40 animate-pulse rounded bg-neutral-100" />
+          <div className="h-9 animate-pulse rounded-lg bg-neutral-100" />
+          <div className="h-9 animate-pulse rounded-lg bg-neutral-100" />
+        </div>
+      </Card>
+    );
+  }
+
+  // "Solo si hay materiales extraídos": vacía y sin cambios → no mostramos la sección.
+  if (movs.length === 0 && !dirty) return null;
+
+  return (
+    <Card>
+      <div className="flex items-center gap-2 border-b border-divider px-2 py-1">
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary-main text-white" aria-hidden>
+          <CubeIcon className="h-3.5 w-3.5" />
+        </span>
+        <h2 className="text-xs font-semibold tracking-tight text-neutral-900">Materiales extraídos</h2>
+        <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-[11px] font-semibold text-neutral-700">{movs.length}</span>
+        <span className="ml-auto hidden text-[11px] text-neutral-400 sm:block">Revisá y corregí lo detectado en la factura</span>
+      </div>
+
+      <div className="overflow-x-auto px-2 py-1.5">
+        <div className="min-w-[680px]">
+          {/* Encabezados de columna */}
+          <div className={`${gridCls} px-1 pb-1 text-[10px] font-bold uppercase tracking-wide text-neutral-500`}>
+            <div>Material</div>
+            <div className="text-right">Cant.</div>
+            <div className="text-center">Estado</div>
+            <div className="text-right">Precio $</div>
+            <div>Observación</div>
+            <div />
+          </div>
+
+          {movs.map((m, idx) => {
+            const pill = estadoPill(m.estado);
+            return (
+              <div key={m._id || `nuevo-${idx}`} className={`${gridCls} border-t border-divider/70 py-1.5`}>
+                <Box sx={autocompleteSx} className="min-w-0">
+                  <MaterialAutocomplete
+                    user={user}
+                    value={m.id_material || ''}
+                    fallbackText={m.nombre_item || ''}
+                    onTextChange={(texto) => setRow(idx, { id_material: null, nombre_item: texto || '' })}
+                    onMaterialSelect={(mat) => setRow(idx, {
+                      id_material: mat.id || null,
+                      nombre_item: mat.label || mat.nombre || '',
+                      ...(mat.precio_unitario != null ? { precio_unitario: mat.precio_unitario } : {}),
+                    })}
+                    onMaterialCreated={(mat) => setRow(idx, { id_material: mat.id, nombre_item: mat.nombre })}
+                    label=""
+                    placeholder="Buscar o escribir material…"
+                    fullWidth
+                    showCreateOption
+                  />
+                </Box>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={m.cantidad ?? ''}
+                  onChange={(e) => setRow(idx, { cantidad: e.target.value })}
+                  onKeyDown={noEnter}
+                  className={`${inputCls} text-right ${!Number(m.cantidad) ? 'border-error-main focus:border-error-main focus:ring-error-main' : ''}`}
+                />
+                <div className="flex justify-center">
+                  <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${pill.cls}`}>
+                    {pill.label}
+                  </span>
+                </div>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={m.precio_unitario ?? ''}
+                  onChange={(e) => setRow(idx, { precio_unitario: e.target.value === '' ? null : Number(e.target.value) })}
+                  onKeyDown={noEnter}
+                  placeholder="0"
+                  className={`${inputCls} text-right`}
+                />
+                <input
+                  type="text"
+                  value={m.observacion || ''}
+                  onChange={(e) => setRow(idx, { observacion: e.target.value })}
+                  onKeyDown={noEnter}
+                  placeholder="—"
+                  className={`${inputCls} min-w-0`}
+                />
+                <div className="flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => quitarLinea(idx)}
+                    title="Quitar material"
+                    className="rounded-md p-1 text-neutral-400 hover:bg-error-main/10 hover:text-error-dark"
+                  >
+                    <TrashIcon className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-2 flex items-center justify-between gap-2 border-t border-divider/70 pt-2">
+          <button type="button" onClick={agregarLinea} className="inline-flex items-center gap-1 text-xs font-medium text-primary-dark hover:underline">
+            <PlusIcon className="h-4 w-4" /> Agregar material
+          </button>
+          <span className="hidden text-[11px] text-neutral-400 sm:block">Se guardan al guardar el movimiento</span>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export default forwardRef(SolicitudMaterialesInline);

--- a/src/pages/movementForm.js
+++ b/src/pages/movementForm.js
@@ -61,6 +61,7 @@ import {
 } from 'src/components/movementFieldsConfig';
 import profileService from 'src/services/profileService';
 import MaterialesFacturaActions from 'src/components/stock/MaterialesFacturaActions';
+import SolicitudMaterialesInline from 'src/components/stock/solicitudes/SolicitudMaterialesInline';
 import { getProyectosByEmpresa, getProyectosFromUser } from 'src/services/proyectosService';
 import ControlObraService from 'src/services/controlObra/controlObraService';
 import ProrrateoDialog from 'src/components/ProrrateoDialog';
@@ -268,6 +269,7 @@ const MovementFormPage = () => {
   const pendingExtraccionRef = useRef(false);
   const returnAfterSaveRef = useRef(false);
   const exportAfterSaveRef = useRef(false);
+  const materialesInlineRef = useRef(null);
   // "Guardar y exportar": tras cerrar el diálogo de PDF, volver a la página anterior (cajas).
   const returnAfterExportRef = useRef(false);
   const [createdUser, setCreatedUser] = useState(null);
@@ -443,6 +445,9 @@ const MovementFormPage = () => {
           formik.setFieldValue('monto_aprobado', updatedMovimiento.monto_aprobado ?? '', false);
         }
       }
+
+      // Guardar los materiales extraídos editados inline junto con el movimiento.
+      await materialesInlineRef.current?.guardar?.();
 
       setAlert({ open: true, message: 'Movimiento guardado con éxito!', severity: 'success' });
       if (returnAfterSaveRef.current) {
@@ -867,6 +872,12 @@ const createdAtStr = (() => {
         message: `Completá los campos obligatorios: ${labels.join(', ')}`,
         severity: 'error',
       });
+      return;
+    }
+
+    const materialesCheck = materialesInlineRef.current?.validar?.();
+    if (materialesCheck && !materialesCheck.ok) {
+      setAlert({ open: true, message: materialesCheck.message, severity: 'error' });
       return;
     }
 
@@ -2090,6 +2101,17 @@ const createdAtStr = (() => {
                   <StitchBlock step={3} title="Detalles financieros e impuestos">
                     <MovementFields {...sharedFieldProps} block="financial" />
                   </StitchBlock>
+                  {isEditMode
+                    && formik.values.categoria === 'Materiales'
+                    && empresa?.stock_config?.caja_a_stock === true
+                    && movimiento?.solicitud_stock_id && (
+                    <SolicitudMaterialesInline
+                      ref={materialesInlineRef}
+                      solicitudId={movimiento.solicitud_stock_id}
+                      user={user}
+                      onError={(message) => setAlert({ open: true, message, severity: 'error' })}
+                    />
+                  )}
                 </div>
               </div>
             </form>

--- a/src/services/stock/stockSolicitudesService.js
+++ b/src/services/stock/stockSolicitudesService.js
@@ -168,6 +168,7 @@ const StockSolicitudesService = {
         observacion: m.observacion || null,
 
         id_material: m.id_material ?? null,
+        precio_unitario: (m.precio_unitario === '' || m.precio_unitario == null) ? null : Number(m.precio_unitario),
       }));
 
     // Preparar fecha para la solicitud (11:00 del mediodía)


### PR DESCRIPTION
# TAR-430 — Editar "Materiales extraídos" inline en el detalle de facturas

Permite ver y editar los materiales detectados de una factura directamente en `movementForm`, sin salir a otra pantalla.

---

## TAR-430 — Pestaña/sección "Materiales Extraídos" en el detalle de facturas

**Causa raíz / Problema:** Al ver un movimiento de Materiales que ya generó una solicitud de stock, no se veían los materiales detectados: solo aparecía un link "Ver solicitud →" que llevaba a `/stockSolicitudes`. Para corregir un material, su cantidad, precio u observación había que navegar a otra pantalla y editar ahí. Incómodo y rompe el contexto del movimiento.

**Cómo lo hicimos (funcional):** Abajo del formulario del movimiento ahora aparece la sección **"Materiales extraídos"** (solo si el movimiento tiene materiales detectados). Lista cada material con su cantidad, estado, precio y observación, y permite editarlos en el lugar: elegir/crear el material desde el catálogo (buscador con check verde de "vinculado"), cambiar cantidad, precio y observación, agregar o quitar materiales. Los cambios se guardan **al tocar "Guardar" / "Guardar y volver" del formulario** — no hay un botón de guardado aparte para no duplicarlo.

**Decisiones y por qué:**
• Edición inline (no modal ni página aparte) → el usuario corrige sin perder el contexto del movimiento; era el punto del ticket.
• Sin botón "Guardar" propio; se guarda con los botones del form → evita un segundo guardado confuso y deja una sola acción de guardado.
• Reusar el `MaterialAutocomplete` existente para el campo material → no perder funcionalidad (buscar catálogo, crear material nuevo, alias, limpiar, check verde), idéntico a la página de solicitudes.
• Diseño en Tailwind nativo (mismos tokens que `movementForm`) → uniforme con el resto del formulario; el `MaterialAutocomplete` (MUI) se ajustó para matchear los inputs nativos.
• Alcance acotado a **solicitud de stock** (`solicitud_stock_id`). El caso "Acopio" queda como estaba ("Ver acopio →"); se puede sumar en otra iteración.

**Cómo lo implementamos (técnico):**
• Nuevo componente `src/components/stock/solicitudes/SolicitudMaterialesInline.js`: carga la solicitud con `StockSolicitudesService.obtenerSolicitud`, mantiene el estado editable de los movimientos y persiste con `StockSolicitudesService.guardarSolicitud`. Se monta al final del `<form>` en `movementForm.js` solo en modo edición, categoría Materiales, `stock_config.caja_a_stock` y `solicitud_stock_id` presente.
• El guardado se integra al flujo del form vía `forwardRef` + `useImperativeHandle`: el componente expone `validar()` y `guardar()`. `movementForm` llama `validar()` en `handleSubmitForm` (bloquea el submit si hay materiales incompletos) y `guardar()` dentro de `savePayload`, después de guardar el movimiento.
• `stockSolicitudesService.guardarSolicitud` ahora incluye `precio_unitario` en el payload de cada movimiento (antes se descartaba), para que precio se persista.

**Producción / compatibilidad:** Sin migración ni breaking changes. `precio_unitario` ya existía en el modelo de movimientos; solo se empieza a enviar en el PATCH (cambio aditivo que además habilita persistir precio desde la página de solicitudes). Los movimientos viejos quedan intactos. La sección no aparece si la empresa no tiene la feature de stock activa.

**Verificación:** Probado en local (mov. real con solicitud de stock): se ven los 3 materiales inline; editar cantidad/precio/observación y elegir material del catálogo funciona; al tocar "Guardar" (incluido el modal de confirmación de totales) los cambios persisten (validado contra la API); si un material queda sin nombre o cantidad 0, el guardado del movimiento se bloquea con aviso. Lint OK.

**Notas al código:**
• `SolicitudMaterialesInline.js` → `Card` se define a nivel de módulo (no dentro del componente) a propósito: definirlo adentro creaba un tipo nuevo en cada render y React remontaba toda la sección, lo que rompía el estado del buscador (dropdown no abría, se perdía el foco).
• `SolicitudMaterialesInline.js` → `guardar()` se expone por ref y NO emite alerta de éxito propia: el "Movimiento guardado con éxito" del form ya cubre el caso; solo emite `onError` si falla, para no undoear el guardado del movimiento ya hecho.
• `movementForm.js` (`savePayload`) → el guardado de materiales va después de guardar/recargar el movimiento y antes de la navegación de "Guardar y volver", así se persisten los materiales antes de salir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
