### PR TITLE
TAR-440: opción "USD (TC del movimiento)" en vista de caja

### DIFF
--- a/src/pages/cajas.js
+++ b/src/pages/cajas.js
@@ -1010,6 +1010,7 @@ const csvDefaultSelected = useMemo(
    usd_blue:    { out: 'USD',       path: (e) => e?.total?.usd_blue },
    usd_oficial: { out: 'USD',       path: (e) => e?.total?.usd_oficial },  // si lo tenés
    usd_mep_medio: { out: 'USD',     path: (e) => e?.total?.usd_mep_medio },  // si lo tenés
+   usd_referencia: { out: 'USD',    path: (e) => e?.total?.usd_referencia }, // TC cargado en cada movimiento
    ars_oficial: { out: 'ARS',       path: (e) => e?.total?.ars_oficial },
    cac:         { out: 'ARS',       path: (e) => e?.total?.cac },          // ej. si calculás CAC a ARS
  };
@@ -3017,6 +3018,7 @@ useEffect(() => {
             <MenuItem value="usd_blue">USD blue</MenuItem>
             <MenuItem value="usd_oficial">USD oficial</MenuItem>
             <MenuItem value="usd_mep_medio">USD mep (medio)</MenuItem>
+            <MenuItem value="usd_referencia">USD (Tipo de Cambio utilizado en el movimiento)</MenuItem>
           </Select>
         </FormControl>
       </>


### PR DESCRIPTION
# TAR-440 — Opción "USD (TC del movimiento)" en la vista de caja (frontend)

Agrega la nueva metodología de conversión en `/cajas`. PR hermano (backend): fedemaidan/sorby_bot_wa#235 — **requiere ese PR mergeado para que los totales lleguen**.

⚠️ **Falta testear.** Implementado y con lint OK, pero **pendiente de prueba en el browser** con datos reales (comparar el neto consolidado vs "USD blue"). No mergear sin esa validación.

---

## TAR-440 — Caja en USD por TC Referencia
**Causa raíz / Problema:** En la configuración de una caja en dólares, "Mostrar como" solo ofrecía dólar blue/oficial/mep (tasas de mercado del sistema). No había forma de ver la caja con el TC de referencia que el usuario carga en cada movimiento.

**Cómo lo hicimos (funcional):** En "Editar/Crear caja" → "Mostrar como" hay una nueva opción: **"USD (Tipo de Cambio utilizado en el movimiento)"**. Al elegirla, la caja consolida en dólares usando el TC de referencia de cada movimiento (los gastos en USD se suman tal cual). El resto de las opciones sigue igual.

**Decisiones y por qué:**
• Implementarlo como una opción más de equivalencia (campo `caja.equivalencia`) → es el mecanismo existente; los helpers (`getCajaNetFromTotals`, `getCajaTotalsKey`, `formatCajaAmount`, `activeTotalsCurrency`) ya son genéricos y funcionan sin tocarlos.
• El front no envía `equivalencia` al backend → el backend ya devuelve todas las equivalencias precalculadas en `totals`; solo agrego la lectura de la nueva clave.
• Etiqueta "USD (Tipo de Cambio utilizado en el movimiento)" → texto descriptivo acordado con el usuario, sin jerga.

**Cómo lo implementamos (técnico):**
• `src/pages/cajas.js`: nuevo `<MenuItem value="usd_referencia">` en el select "Mostrar como" + entrada `usd_referencia: { out: 'USD', ... }` en `EQUIV_META`. La lectura del neto sale sola vía `getCajaNetFromTotals` → `totals.equivalencias.usd_referencia.neto`.

**Producción / compatibilidad:** Aditivo. Cajas existentes sin cambios. Depende del backend (#235) para que `totals.equivalencias.usd_referencia` exista; mientras tanto la opción mostraría 0.

**Verificación:**
• ✅ `eslint src/pages/cajas.js` exit 0.
• ⏳ **Pendiente:** prueba en browser (login de test, `/cajas`, elegir la opción y comparar el neto consolidado contra "USD blue").

**Notas al código:**
• `EQUIV_META.usd_referencia.path` → se deja por consistencia con las otras entradas aunque hoy `.path` no se consume (solo se usa `.out` para decidir la moneda de formato).

🤖 Generated with [Claude Code](https://claude.com/claude-code)