### PR TITLE
TAR-447 — Edición masiva en Caja: categorías completas + fecha sin desfase (frontend)

### DIFF
--- a/src/components/BulkEditDialog.js
+++ b/src/components/BulkEditDialog.js
@@ -76,6 +76,20 @@ const BulkEditDialog = ({ open, onClose, selectedCount, selectedIds, onDone, opt
     if (field.optionsKey === 'asignados') {
       return Array.isArray(empresa?.asignados) ? empresa.asignados.filter(Boolean) : [];
     }
+    if (field.optionsKey === 'categorias' || field.optionsKey === 'subcategorias') {
+      const cates = [
+        ...(Array.isArray(empresa?.categorias) ? empresa.categorias : []),
+        { name: 'Ingreso dinero', subcategorias: [] },
+        { name: 'Ajuste', subcategorias: ['Ajuste'] },
+      ];
+      if (field.optionsKey === 'categorias') {
+        return cates.map((c) => (typeof c === 'string' ? c : c?.name)).filter(Boolean);
+      }
+      const subs = cates
+        .flatMap((c) => (typeof c === 'string' ? [] : (c?.subcategorias || [])))
+        .filter(Boolean);
+      return [...new Set(subs)];
+    }
     if (field.optionsKey && options[field.optionsKey]) return options[field.optionsKey];
     if (field.optionsKey === 'subempresas') {
       return getSubempresasOptions(empresa);
@@ -155,8 +169,13 @@ const BulkEditDialog = ({ open, onClose, selectedCount, selectedIds, onDone, opt
       } else if (fieldDef?.type === 'operation_date') {
         if (val?.op && val?.value !== null && val?.value !== '' && val?.value !== undefined) {
           if (val.op === 'set') {
-            // Enviar como timestamp en milisegundos
-            campos[name] = { op: 'set', value: new Date(val.value).getTime() };
+            // Enviar el día calendario como 'YYYY-MM-DD' (sin hora). El backend lo ancla
+            // a hora local; mandar timestamp de medianoche local lo corría un día atrás.
+            const d = new Date(val.value);
+            const yyyy = d.getFullYear();
+            const mm = String(d.getMonth() + 1).padStart(2, '0');
+            const dd = String(d.getDate()).padStart(2, '0');
+            campos[name] = { op: 'set', value: `${yyyy}-${mm}-${dd}` };
           } else {
             campos[name] = { op: val.op, value: parseInt(val.value, 10) };
           }


### PR DESCRIPTION
Dos fixes de la edición masiva de Caja: el selector de categorías incompleto y el desfase de un día en la fecha. PR hermano (backend): https://github.com/fedemaidan/sorby_bot_wa/pull/236

---

## TAR-447 (1) — Selector de categorías incompleto
**Causa raíz / Problema:** el selector de categorías de la edición masiva solo mostraba las categorías ya usadas en movimientos de esa obra (venía de un `distinct` sobre movimientos). Una categoría configurada pero todavía sin uso no aparecía, obligando a editar un movimiento a mano primero. Esto además explicaba la "inconsistencia entre cuentas": cada usuario veía categorías distintas según sus movimientos.

**Cómo lo hicimos (funcional):** el selector ahora muestra todas las categorías y subcategorías de la empresa, idéntico a lo que aparece al cargar un movimiento individual.

**Decisiones y por qué:**
• Tomar la lista del catálogo maestro `empresa.categorias` (no de los movimientos) → fuente de verdad única, igual que el alta individual. Mismo patrón que ya existía para `asignados` en este componente.
• Replicar exactamente la lógica de `movementForm.js`, incluidas las categorías sintéticas `Ingreso dinero` y `Ajuste` → paridad total con el formulario individual.

## TAR-447 (2) — Desfase de un día en la fecha
**Causa raíz / Problema:** al fijar una fecha en la edición masiva, los movimientos quedaban con un día menos. El front mandaba un timestamp de medianoche local que terminaba interpretándose en el día anterior en ART.

**Cómo lo hicimos (funcional):** al fijar una fecha se persiste exactamente esa fecha, sin corrimiento.

**Decisiones y por qué:**
• Enviar el día calendario como string `'YYYY-MM-DD'` (sin hora) → el backend lo ancla a hora local con su normalizador canónico (`normalizarFechaADate`, 13:30), misma convención que la edición individual.

**Cómo lo implementamos (técnico):**
• `src/components/BulkEditDialog.js` → `getOptions`: para `categorias`/`subcategorias` arma `cates = [...empresa.categorias, {Ingreso dinero}, {Ajuste}]` y devuelve los `.name` (y subcategorías aplanadas y deduplicadas), en vez de `options.categorias` (derivado de movimientos).
• `src/components/BulkEditDialog.js` → `handleApply`, op `set`: arma `'YYYY-MM-DD'` desde los componentes locales del `Date` del DatePicker, en vez de `new Date(val.value).getTime()`.

**Producción / compatibilidad:** sin migración; solo cambia qué se muestra y en qué formato se envía la fecha. Requiere el PR de backend para que el `'YYYY-MM-DD'` se ancle correctamente.

**Verificación:** abrir edición masiva → Categoría lista todas las de la empresa + `Ingreso dinero` + `Ajuste`; fijar 20/06/2026 → persiste 20/06 (probar ≥5 fechas de distintos meses).

**Notas al código:**
• `getOptions` (rama `categorias`/`subcategorias`) → se replican las sintéticas `Ingreso dinero`/`Ajuste` a propósito para igualar `movementForm.js`; si esa lista cambia, hay que reflejarlo acá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)