### PR TITLE
TAR-441 — Modo de moneda (nominal/CAC/USD) en export PDF de control de presupuestos

### DIFF
--- a/src/components/PresupuestoDrawer.js
+++ b/src/components/PresupuestoDrawer.js
@@ -81,6 +81,7 @@ import ClasificacionesPicker from 'src/components/ClasificacionesPicker';
 import ProveedoresMultiSelect from 'src/components/ProveedoresMultiSelect';
 import ExportarPdfMenu from 'src/components/plantillasPdf/ExportarPdfMenu';
 import { buildControlPresupuestoData } from 'src/utils/controlPresupuesto/buildControlPresupuestoData';
+import { calcPresupuestadoNominal } from 'src/utils/controlPresupuesto/presupuestoNominal';
 
 const loadDefaultControlPresupuestoDoc = () =>
   import('src/utils/controlPresupuesto/PdfControlPresupuestoDocument').then(
@@ -2638,6 +2639,12 @@ const PresupuestoDrawer = ({
                         defaultDocumentLoader={loadDefaultControlPresupuestoDoc}
                         tituloEditable
                         defaultTitulo={presupuesto.tipo === 'ingreso' ? 'RECIBO DE INGRESOS' : 'RECIBO DE PAGOS'}
+                        modosDisponibles={[
+                          'nominal',
+                          ...(presupuesto.indexacion === 'CAC' ? ['cac'] : []),
+                          ...(presupuesto.indexacion === 'USD' || presupuesto.moneda === 'USD' ? ['usd'] : []),
+                        ]}
+                        modoDefault="nominal"
                         buildData={(opts) => {
                           const obra = proyectos.find((p) => p.id === proyectoId)?.nombre || '';
                           const label = presupuesto.label || presupuesto.nombre || presupuesto.categoria || 'Presupuesto';
@@ -2646,6 +2653,8 @@ const PresupuestoDrawer = ({
                           return buildControlPresupuestoData({
                             movimientos: movimientosFiltrados,
                             titulo: opts?.titulo || (esIngreso ? 'RECIBO DE INGRESOS' : 'RECIBO DE PAGOS'),
+                            // El usuario elige el modo en el export; default pesos nominales (espeja la tabla del drawer).
+                            modo: opts?.modo || 'nominal',
                             presupuestoLabel: label,
                             contratista,
                             obra,
@@ -2656,6 +2665,7 @@ const PresupuestoDrawer = ({
                             cacTipo: presupuesto.cac_tipo || null,
                             baseCalculo: presupuesto.base_calculo || 'total',
                             presupuestadoNativo: Number(presupuesto.monto != null ? presupuesto.monto : presupuesto.monto_ingresado || 0),
+                            presupuestadoNominal: calcPresupuestadoNominal(presupuesto),
                             montoIngresado: presupuesto.monto_ingresado != null ? Number(presupuesto.monto_ingresado) : null,
                             cacIndiceActual: cacActualEfectivo || cacEfectivo,
                             tipoCambioActual: dolarEfectivo,

--- a/src/components/plantillasPdf/ExportarPdfMenu.js
+++ b/src/components/plantillasPdf/ExportarPdfMenu.js
@@ -13,6 +13,8 @@ import {
   Typography,
   Tooltip,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import PictureAsPdfRoundedIcon from '@mui/icons-material/PictureAsPdfRounded';
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
@@ -30,10 +32,15 @@ import { useExportarPdf } from './useExportarPdf';
  * - Si `tituloEditable`, muestra un campo de título (default `defaultTitulo`) cuyo
  *   valor se pasa al `buildData({ titulo })` → el usuario controla el encabezado del
  *   PDF desde el export (no depende de la plantilla del agente).
+ * - Si `modosDisponibles` trae más de una opción, muestra un selector de moneda
+ *   (Pesos nominales / CAC a hoy / USD) cuyo valor va en `buildData({ modo })`. El
+ *   modo controla los NÚMEROS (no la plantilla), por eso vive en el export.
  *
  * La lógica (listar + render) vive en el hook useExportarPdf, compartido con
  * ExportarPdfDialog. Genérico por `documentType`.
  */
+const MODO_LABELS = { nominal: 'Pesos nominales', cac: 'CAC a hoy', usd: 'USD' };
+
 export default function ExportarPdfMenu({
   empresaId,
   empresaNombre = '',
@@ -45,17 +52,23 @@ export default function ExportarPdfMenu({
   onError,
   tituloEditable = false,
   defaultTitulo = '',
+  modosDisponibles = [],
+  modoDefault = 'nominal',
 }) {
   const router = useRouter();
   const [anchorEl, setAnchorEl] = useState(null);
   const [titulo, setTitulo] = useState(defaultTitulo);
+  const [modo, setModo] = useState(modoDefault);
   const open = Boolean(anchorEl);
   const { plantillas, loadingList, generating, cargarOpciones, exportar } = useExportarPdf({
     empresaId, empresaNombre, documentType, buildData, defaultDocumentLoader, fileName, onError,
   });
 
-  // Mantener el título sincronizado con el default cuando cambia el contexto (ej. otro presupuesto).
+  // Mantener título y modo sincronizados con el default cuando cambia el contexto (ej. otro presupuesto).
   useEffect(() => { setTitulo(defaultTitulo); }, [defaultTitulo]);
+  useEffect(() => { setModo(modoDefault); }, [modoDefault]);
+
+  const mostrarSelectorModo = Array.isArray(modosDisponibles) && modosDisponibles.length > 1;
 
   const abrir = (e) => {
     setAnchorEl(e.currentTarget);
@@ -65,8 +78,11 @@ export default function ExportarPdfMenu({
 
   const handleExportar = (plantilla) => {
     cerrar();
-    const opts = tituloEditable ? { titulo: (titulo || '').trim() || defaultTitulo } : undefined;
-    exportar(plantilla, opts);
+    const opts = {
+      ...(tituloEditable ? { titulo: (titulo || '').trim() || defaultTitulo } : {}),
+      ...(mostrarSelectorModo ? { modo } : {}),
+    };
+    exportar(plantilla, Object.keys(opts).length ? opts : undefined);
   };
 
   return (
@@ -110,6 +126,31 @@ export default function ExportarPdfMenu({
               fullWidth
               variant="outlined"
             />
+          </Box>
+        )}
+
+        {mostrarSelectorModo && (
+          <Box
+            sx={{ px: 2, pt: 0.5, pb: 1 }}
+            onKeyDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+              Mostrar importes en
+            </Typography>
+            <ToggleButtonGroup
+              value={modo}
+              exclusive
+              size="small"
+              fullWidth
+              onChange={(e, v) => { if (v) setModo(v); }}
+            >
+              {modosDisponibles.map((m) => (
+                <ToggleButton key={m} value={m} sx={{ fontSize: '0.65rem', py: 0.4, textTransform: 'none' }}>
+                  {MODO_LABELS[m] || m}
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
           </Box>
         )}
 

--- a/src/components/plantillasPdf/PdfPlantillaChatDialog.js
+++ b/src/components/plantillasPdf/PdfPlantillaChatDialog.js
@@ -4,7 +4,7 @@ import { keyframes } from '@emotion/react';
 import {
   Box, Button, Chip, CircularProgress, Dialog, DialogContent, DialogTitle, Divider,
   IconButton, InputBase, MenuItem, Paper, Stack, TextField,
-  Tooltip, Typography,
+  ToggleButton, ToggleButtonGroup, Tooltip, Typography,
 } from '@mui/material';
 import AddPhotoAlternateOutlinedIcon from '@mui/icons-material/AddPhotoAlternateOutlined';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
@@ -31,6 +31,8 @@ const PdfPlantillaPreviewInner = dynamic(() => import('./PdfPlantillaPreviewInne
 });
 
 const GREETING = '¡Hola! Diseñá tu plantilla describiendo lo que querés — por ejemplo "agregá el logo más grande", "colores sobrios", "una columna con el acumulado" — o adjuntá una imagen de referencia. Te muestro la vista previa en tiempo real.';
+
+const MODO_LABELS = { nominal: 'Pesos nominales', cac: 'CAC a hoy', usd: 'USD' };
 
 function readFileAsDataUrl(file) {
   return new Promise((resolve, reject) => {
@@ -89,12 +91,16 @@ export default function PdfPlantillaChatDialog({
   empresaId,
   documentType,
   sampleData,
+  buildSampleData = null,
+  sampleDataModes = [],
   defaultDocumentLoader,
   empresaNombre = '',
   logos = [],
   initialTemplate = null,
   onSaved,
 }) {
+  const mostrarSelectorModo = typeof buildSampleData === 'function' && sampleDataModes.length > 1;
+  const [modo, setModo] = useState(sampleDataModes[0] || 'nominal');
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -128,6 +134,7 @@ export default function PdfPlantillaChatDialog({
       return;
     }
     setMessages([{ role: 'assistant', content: GREETING }]);
+    setModo(sampleDataModes[0] || 'nominal');
     setTemplateName(initialTemplate?.nombre || '');
     setSelectedLogoId(initialTemplate?.logo_id || (logos[0]?._id ?? ''));
     if (isEdit) {
@@ -227,11 +234,15 @@ export default function PdfPlantillaChatDialog({
       documentType,
       currentCode: currentCode || null,
       referenceImageDataUrl: refImg,
+      modo,
+      modosDisponibles: sampleDataModes,
     });
     setLoading(false);
 
     if (result) {
       setMessages((prev) => [...prev, { role: 'assistant', content: result.message }]);
+      // La IA puede sugerir el modo de moneda (nominal/cac/usd); movemos el selector.
+      if (result.modo && sampleDataModes.includes(result.modo)) setModo(result.modo);
       if (result.code) {
         awaitingCorrectionRef.current = result.code; // disparará el corrector al renderizar
         setCurrentCode(result.code);
@@ -241,7 +252,7 @@ export default function PdfPlantillaChatDialog({
       setMessages((prev) => [...prev, { role: 'assistant', content: 'Hubo un error al contactar al asistente. Intentá de nuevo.' }]);
     }
     inputRef.current?.focus();
-  }, [input, loading, correcting, messages, empresaId, documentType, currentCode, handleCompile, referenceImage]);
+  }, [input, loading, correcting, messages, empresaId, documentType, currentCode, handleCompile, referenceImage, modo, sampleDataModes]);
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend(); }
@@ -283,7 +294,8 @@ export default function PdfPlantillaChatDialog({
   };
 
   const PreviewComponent = CompiledComponent || DefaultComponent;
-  const previewKey = useMemo(() => `preview-${previewVersion}-${selectedLogoId}-${logoDataUrl ? 1 : 0}`, [previewVersion, selectedLogoId, logoDataUrl]);
+  const previewData = buildSampleData ? buildSampleData(modo) : sampleData;
+  const previewKey = useMemo(() => `preview-${previewVersion}-${selectedLogoId}-${logoDataUrl ? 1 : 0}-${modo}`, [previewVersion, selectedLogoId, logoDataUrl, modo]);
   const busy = loading || correcting;
 
   return (
@@ -397,6 +409,21 @@ export default function PdfPlantillaChatDialog({
                 <Typography component="span" variant="caption" color="error.main" sx={{ ml: 1 }}>— Error: {compileError}</Typography>
               )}
             </Typography>
+            {mostrarSelectorModo && (
+              <Tooltip title="Moneda con la que se muestran los importes" arrow>
+                <ToggleButtonGroup
+                  value={modo}
+                  exclusive
+                  size="small"
+                  onChange={(e, v) => { if (v) setModo(v); }}
+                  sx={{ '& .MuiToggleButton-root': { fontSize: 10, py: 0.2, px: 1, textTransform: 'none' } }}
+                >
+                  {sampleDataModes.map((m) => (
+                    <ToggleButton key={m} value={m}>{MODO_LABELS[m] || m}</ToggleButton>
+                  ))}
+                </ToggleButtonGroup>
+              </Tooltip>
+            )}
             <Chip label={CompiledComponent ? 'Diseño personalizado' : 'Plantilla por defecto'} size="small" color={CompiledComponent ? 'primary' : 'default'} variant={CompiledComponent ? 'filled' : 'outlined'} sx={{ fontSize: 10, height: 20 }} />
           </Box>
           <Box sx={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
@@ -404,7 +431,7 @@ export default function PdfPlantillaChatDialog({
               <PdfPlantillaPreviewInner
                 key={previewKey}
                 PlantillaPDF={PreviewComponent}
-                data={sampleData}
+                data={previewData}
                 logoDataUrl={logoDataUrl}
                 empresaNombre={empresaNombre}
                 onImageReady={handlePreviewImageReady}

--- a/src/components/plantillasPdf/SeccionPlantillas.js
+++ b/src/components/plantillasPdf/SeccionPlantillas.js
@@ -31,6 +31,8 @@ export default function SeccionPlantillas({
   titulo,
   descripcionDefault,
   sampleData,
+  buildSampleData = null,
+  sampleDataModes = [],
   defaultDocumentLoader,
   onNotify,
 }) {
@@ -143,6 +145,8 @@ export default function SeccionPlantillas({
           empresaId={empresaId}
           documentType={documentType}
           sampleData={sampleData}
+          buildSampleData={buildSampleData}
+          sampleDataModes={sampleDataModes}
           defaultDocumentLoader={defaultDocumentLoader}
           empresaNombre={empresaNombre}
           logos={logos}

--- a/src/pages/control-presupuestos.js
+++ b/src/pages/control-presupuestos.js
@@ -2418,6 +2418,11 @@ const ControlPresupuestosPage = () => {
                     : movDrawer.tipo === 'ingreso' ? 'RECIBO DE INGRESOS'
                       : 'ESTADO DE CUENTA'
                 }
+                modosDisponibles={[
+                  'nominal',
+                  ...(movDrawerData.some((m) => (m.moneda || 'ARS') === 'USD') ? ['usd'] : []),
+                ]}
+                modoDefault="nominal"
                 buildData={(opts) => {
                   const totales = calcularTotales();
                   const presupuestado =
@@ -2430,10 +2435,11 @@ const ControlPresupuestosPage = () => {
                         : 'ESTADO DE CUENTA'
                   );
                   // Export a nivel proyecto: presupuestos mixtos, sin indexación única.
-                  // El builder cae al modo "moneda de vista" (sin columna de equivalencia).
+                  // Modo nominal (pesos reales) por default; USD si hay movimientos en dólares.
                   return buildControlPresupuestoData({
                     movimientos: movDrawerData,
                     titulo,
+                    modo: opts?.modo || 'nominal',
                     presupuestoLabel: movDrawer.label,
                     obra: proyectoActual?.nombre || '',
                     empresaNombre: empresa?.nombre || '',

--- a/src/pages/plantillas-pdf.js
+++ b/src/pages/plantillas-pdf.js
@@ -16,7 +16,7 @@ import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
 import empresaLogoService from 'src/services/empresaLogoService';
 import SeccionPlantillas from 'src/components/plantillasPdf/SeccionPlantillas';
-import CONTROL_PRESUPUESTO_SAMPLE_DATA from 'src/utils/controlPresupuesto/sampleData';
+import CONTROL_PRESUPUESTO_SAMPLE_DATA, { buildSampleData as buildControlPresupuestoSampleData } from 'src/utils/controlPresupuesto/sampleData';
 import COMPROBANTE_MOVIMIENTO_SAMPLE_DATA from 'src/utils/comprobanteMovimiento/sampleData';
 
 // Los documentos por defecto se cargan client-side (importan @react-pdf, fuera del bundle SSR).
@@ -164,6 +164,8 @@ const PlantillasPdfPage = () => {
                 titulo="Plantillas de control de presupuesto"
                 descripcionDefault="Recibo de pagos estándar. Se usa cuando no hay una plantilla principal."
                 sampleData={CONTROL_PRESUPUESTO_SAMPLE_DATA}
+                buildSampleData={buildControlPresupuestoSampleData}
+                sampleDataModes={['nominal', 'cac', 'usd']}
                 defaultDocumentLoader={loadDefaultControlPresupuestoDoc}
                 onNotify={notify}
               />

--- a/src/services/pdfPlantillaService.js
+++ b/src/services/pdfPlantillaService.js
@@ -58,8 +58,8 @@ const pdfPlantillaService = {
     }
   },
 
-  // Generador (pasada 1): { message, code }
-  aiChat: async ({ messages, empresaId, documentType, currentCode, referenceImageDataUrl }) => {
+  // Generador (pasada 1): { message, code, modo? }
+  aiChat: async ({ messages, empresaId, documentType, currentCode, referenceImageDataUrl, modo, modosDisponibles }) => {
     try {
       const res = await api.post('pdf-plantillas/ai-chat', {
         messages,
@@ -67,6 +67,8 @@ const pdfPlantillaService = {
         documentType,
         currentCode: currentCode || null,
         referenceImageDataUrl: referenceImageDataUrl || null,
+        modo: modo || null,
+        modosDisponibles: modosDisponibles || [],
       });
       return res.status === 200 ? res.data : null;
     } catch (e) {

--- a/src/utils/controlPresupuesto/PdfControlPresupuestoDocument.js
+++ b/src/utils/controlPresupuesto/PdfControlPresupuestoDocument.js
@@ -89,6 +89,9 @@ export function PdfControlPresupuestoDocument({ data, logoDataUrl, empresaNombre
   const saldoNeg = Number(d.saldo) < 0;
   const barColor = sobre ? OVER : ACCENT;
   const equivSub = (v) => (mostrarEquiv && v != null ? fmtEquiv(v, equivLabel) : null);
+  // Etiqueta del modo de moneda (Nominal / CAC a hoy / USD). Se omite cuando ya hay
+  // columna de equivalencia, para no duplicar la referencia.
+  const modoNota = !mostrarEquiv && d.modo_label ? `(${d.modo_label})` : null;
 
   return (
     <Document>
@@ -135,17 +138,17 @@ export function PdfControlPresupuestoDocument({ data, logoDataUrl, empresaNombre
             <View style={styles.resumenCell}>
               <Text style={styles.resumenLabel}>PRESUPUESTADO</Text>
               <Text style={styles.resumenValue}>{fmtMoney(d.presupuestado, moneda)}</Text>
-              {equivSub(d.presupuestado_equiv) ? <Text style={styles.resumenEquiv}>{equivSub(d.presupuestado_equiv)}</Text> : null}
+              {equivSub(d.presupuestado_equiv) ? <Text style={styles.resumenEquiv}>{equivSub(d.presupuestado_equiv)}</Text> : modoNota ? <Text style={styles.resumenEquiv}>{modoNota}</Text> : null}
             </View>
             <View style={[styles.resumenCell, styles.resumenCellMid]}>
               <Text style={styles.resumenLabel}>{d.tipo === 'ingresos' ? 'INGRESADO' : 'EJECUTADO'}</Text>
               <Text style={styles.resumenValue}>{fmtMoney(d.ejecutado, moneda)}</Text>
-              {equivSub(d.ejecutado_equiv) ? <Text style={styles.resumenEquiv}>{equivSub(d.ejecutado_equiv)}</Text> : null}
+              {equivSub(d.ejecutado_equiv) ? <Text style={styles.resumenEquiv}>{equivSub(d.ejecutado_equiv)}</Text> : modoNota ? <Text style={styles.resumenEquiv}>{modoNota}</Text> : null}
             </View>
             <View style={styles.resumenCell}>
               <Text style={styles.resumenLabel}>SALDO</Text>
               <Text style={[styles.resumenValue, { color: saldoNeg ? OVER : INK }]}>{fmtMoney(d.saldo, moneda)}</Text>
-              {equivSub(d.saldo_equiv) ? <Text style={styles.resumenEquiv}>{equivSub(d.saldo_equiv)}</Text> : null}
+              {equivSub(d.saldo_equiv) ? <Text style={styles.resumenEquiv}>{equivSub(d.saldo_equiv)}</Text> : modoNota ? <Text style={styles.resumenEquiv}>{modoNota}</Text> : null}
             </View>
           </View>
           <View style={styles.barRow}>

--- a/src/utils/controlPresupuesto/__tests__/buildControlPresupuestoData.test.js
+++ b/src/utils/controlPresupuesto/__tests__/buildControlPresupuestoData.test.js
@@ -9,7 +9,7 @@ const mov = (seconds, total, moneda, eq) => ({
 });
 
 describe('buildControlPresupuestoData', () => {
-  describe('presupuesto indexado por CAC', () => {
+  describe("modo 'cac' (pesos a hoy, presupuesto indexado por CAC)", () => {
     const movimientos = [
       mov(200, 700000, 'ARS', { ars: 700000, cac: 1400, usd_blue: 580 }),
       mov(100, 300000, 'ARS', { ars: 300000, cac: 600, usd_blue: 250 }),
@@ -17,6 +17,7 @@ describe('buildControlPresupuestoData', () => {
     const data = buildControlPresupuestoData({
       movimientos,
       titulo: 'RECIBO DE PAGOS',
+      modo: 'cac',
       indexacion: 'CAC',
       monedaPresupuesto: 'CAC',
       cacTipo: 'general',
@@ -25,6 +26,8 @@ describe('buildControlPresupuestoData', () => {
     });
 
     test('flags y moneda primaria', () => {
+      expect(data.modo).toBe('cac');
+      expect(data.modo_label).toBe('CAC a hoy');
       expect(data.moneda).toBe('ARS');
       expect(data.indexacion).toBe('CAC');
       expect(data.mostrar_equiv).toBe(true);
@@ -57,9 +60,62 @@ describe('buildControlPresupuestoData', () => {
     });
   });
 
-  test('regresión del bug: presupuestado pesos − ejecutado CAC daría basura', () => {
+  describe("modo 'nominal' (default, pesos reales)", () => {
+    const movimientos = [
+      mov(200, 700000, 'ARS', { ars: 700000, cac: 1400, usd_blue: 580 }),
+      mov(100, 300000, 'ARS', { ars: 300000, cac: 600, usd_blue: 250 }),
+    ];
+
+    test('es el modo por defecto cuando no se pasa modo', () => {
+      const data = buildControlPresupuestoData({ movimientos, indexacion: 'CAC' });
+      expect(data.modo).toBe('nominal');
+      expect(data.modo_label).toBe('Nominal');
+    });
+
+    test('presupuesto indexado por CAC mostrado en nominal: sin equivalencia, pesos reales', () => {
+      const data = buildControlPresupuestoData({
+        movimientos,
+        modo: 'nominal',
+        indexacion: 'CAC',
+        monedaPresupuesto: 'CAC',
+        presupuestadoNominal: 1200000,
+        cacIndiceActual: 500, // se ignora en nominal
+      });
+      expect(data.moneda).toBe('ARS');
+      expect(data.indexacion).toBe(null);
+      expect(data.mostrar_equiv).toBe(false);
+      expect(data.equiv_label).toBe('');
+      // ejecutado = Σ pesos reales (eq.ars), NO caquificado.
+      expect(data.ejecutado).toBe(1000000); // 300000 + 700000
+      expect(data.presupuestado).toBe(1200000); // nominal provisto
+      expect(data.saldo).toBe(200000);
+      expect(data.movimientos[0]).toMatchObject({ monto: 300000, monto_equiv: null });
+    });
+
+    test('nominal ≠ caquificado cuando el índice del momento ≠ el actual (raíz del ticket)', () => {
+      // Pago de $300.000 hecho con índice CAC del momento = 300 (cac = 1000),
+      // pero el índice actual es 500 → caquificado = 1000 × 500 = 500.000.
+      const movs = [mov(100, 300000, 'ARS', { ars: 300000, cac: 1000 })];
+      const args = {
+        movimientos: movs,
+        indexacion: 'CAC',
+        monedaPresupuesto: 'CAC',
+        presupuestadoNominal: 300000,
+        presupuestadoNativo: 1000,
+        cacIndiceActual: 500,
+      };
+      const nominal = buildControlPresupuestoData({ ...args, modo: 'nominal' });
+      const cac = buildControlPresupuestoData({ ...args, modo: 'cac' });
+      expect(nominal.ejecutado).toBe(300000); // pesos reales pagados
+      expect(cac.ejecutado).toBe(500000); // caquificado a hoy
+      expect(nominal.ejecutado).not.toBe(cac.ejecutado);
+    });
+  });
+
+  test('regresión: modo cac no mezcla pesos − CAC', () => {
     const data = buildControlPresupuestoData({
       movimientos: [mov(100, 0, 'ARS', { ars: 30000, cac: 60 })],
+      modo: 'cac',
       indexacion: 'CAC',
       monedaPresupuesto: 'CAC',
       presupuestadoNativo: 100, // CAC
@@ -71,9 +127,10 @@ describe('buildControlPresupuestoData', () => {
     expect(data.saldo).not.toBe(50000 - 60); // el bug viejo
   });
 
-  test('cac_tipo mano_obra → equiv_label "CAC MO"', () => {
+  test('modo cac + cac_tipo mano_obra → equiv_label "CAC MO"', () => {
     const data = buildControlPresupuestoData({
       movimientos: [mov(100, 0, 'ARS', { ars: 1000, cac: 2 })],
+      modo: 'cac',
       indexacion: 'CAC',
       cacTipo: 'mano_obra',
       presupuestadoNativo: 10,
@@ -82,23 +139,25 @@ describe('buildControlPresupuestoData', () => {
     expect(data.equiv_label).toBe('CAC MO');
   });
 
-  test('presupuesto en dólares nativo → solo USD, sin equivalencia', () => {
+  test("modo 'usd' → solo USD, sin equivalencia", () => {
     const data = buildControlPresupuestoData({
       movimientos: [
         mov(100, 200, 'USD', { ars: 250000, usd_blue: 200 }),
         mov(200, 300000, 'ARS', { ars: 300000, usd_blue: 250 }),
       ],
+      modo: 'usd',
       monedaPresupuesto: 'USD',
       presupuestadoNativo: 1000,
     });
     expect(data.moneda).toBe('USD');
+    expect(data.modo_label).toBe('USD');
     expect(data.mostrar_equiv).toBe(false);
     expect(data.ejecutado).toBe(450); // 200 (USD nativo) + 250 (eq.usd_blue del ARS)
     expect(data.presupuestado).toBe(1000);
     expect(data.saldo).toBe(550);
   });
 
-  test('presupuesto en pesos plano → solo pesos', () => {
+  test('presupuesto en pesos plano (nominal default) → solo pesos', () => {
     const data = buildControlPresupuestoData({
       movimientos: [
         mov(100, 300000, 'ARS', { ars: 300000 }),

--- a/src/utils/controlPresupuesto/__tests__/presupuestoNominal.test.js
+++ b/src/utils/controlPresupuesto/__tests__/presupuestoNominal.test.js
@@ -1,0 +1,52 @@
+import { calcPresupuestadoNominal, calcEjecutadoNominalARS } from '../presupuestoNominal';
+
+describe('calcPresupuestadoNominal', () => {
+  test('CAC indexado: monto_ingresado + adicionales valuados a su snapshot', () => {
+    const presupuesto = {
+      indexacion: 'CAC',
+      monto_ingresado: 1000000,
+      adicionales: [
+        { monto: 100, cotizacion_snapshot: { cac_indice: 400 } }, // 40.000
+        { monto: 50, cotizacion_snapshot: { cac_general: 300 } }, // 15.000 (fallback a cac_general)
+      ],
+    };
+    expect(calcPresupuestadoNominal(presupuesto)).toBe(1000000 + 40000 + 15000);
+  });
+
+  test('USD indexado: usa dolar_blue del snapshot del adicional', () => {
+    const presupuesto = {
+      indexacion: 'USD',
+      monto_ingresado: 500000,
+      adicionales: [{ monto: 100, cotizacion_snapshot: { dolar_blue: 1200 } }], // 120.000
+    };
+    expect(calcPresupuestadoNominal(presupuesto)).toBe(500000 + 120000);
+  });
+
+  test('plano (sin indexación): monto ya es el total nominal', () => {
+    expect(calcPresupuestadoNominal({ monto: 800000 })).toBe(800000);
+  });
+
+  test('adicional sin snapshot no rompe (cuenta 0)', () => {
+    const presupuesto = { indexacion: 'CAC', monto_ingresado: 1000, adicionales: [{ monto: 5 }] };
+    expect(calcPresupuestadoNominal(presupuesto)).toBe(1000);
+  });
+});
+
+describe('calcEjecutadoNominalARS', () => {
+  const mov = (total, moneda, eq) => ({ total, moneda, equivalencias: eq ? { total: eq } : undefined });
+
+  test('suma eq.ars (pesos reales) con fallback al total', () => {
+    const movimientos = [
+      mov(300000, 'ARS', { ars: 300000, cac: 1000 }),
+      mov(700000, 'ARS', { ars: 700000, cac: 2000 }),
+      mov(50, 'USD', { ars: 60000, usd_blue: 50 }), // USD → su ARS nominal
+      mov(5000, 'ARS'), // sin equivalencias → fallback al total
+    ];
+    expect(calcEjecutadoNominalARS(movimientos)).toBe(300000 + 700000 + 60000 + 5000);
+  });
+
+  test('respeta base de cálculo subtotal', () => {
+    const movimientos = [{ total: 121000, subtotal: 100000, equivalencias: { subtotal: { ars: 100000 }, total: { ars: 121000 } } }];
+    expect(calcEjecutadoNominalARS(movimientos, 'subtotal')).toBe(100000);
+  });
+});

--- a/src/utils/controlPresupuesto/buildControlPresupuestoData.js
+++ b/src/utils/controlPresupuesto/buildControlPresupuestoData.js
@@ -5,17 +5,17 @@ import dayjs from 'dayjs';
  * (la default `PdfControlPresupuestoDocument` y las custom generadas con IA) a partir
  * de los movimientos que abrió un drawer + el contexto del presupuesto.
  *
- * MONEDA / INDEXACIÓN (espejo de PresupuestoItem y la pestaña Movimientos del
- * PresupuestoDrawer, que es la lógica ya validada):
- *  - Presupuesto indexado (CAC o dólar): la unidad NATIVA (CAC / USD) es la base de
- *    comparación coherente. Mostramos PESOS A HOY = nativo × índice actual, y la
- *    equivalencia en la unidad nativa al lado. Así presupuestado/ejecutado/saldo
- *    quedan SIEMPRE en la misma unidad (nunca pesos − CAC).
- *  - Presupuesto en dólares (nativo, sin indexar): solo dólares.
- *  - Presupuesto en pesos plano: solo pesos.
+ * MODO DE VISUALIZACIÓN (`modo`) — qué moneda se muestra, decidido por el usuario en
+ * el export (selector) y NO por la plantilla:
+ *  - 'nominal' (default): PESOS REALES del momento. Espeja la tabla de movimientos del
+ *    drawer. Presupuestado = nominal (monto_ingresado + adicionales a su snapshot),
+ *    ejecutado = Σ pesos pagados. Sin columna de equivalencia.
+ *  - 'cac': pesos "a hoy" = unidad nativa CAC × índice actual, con la unidad CAC al lado
+ *    como equivalencia (comparación coherente en pesos de hoy).
+ *  - 'usd': importes en dólares (equivalencia usd_blue de cada movimiento).
  *
  * Cada movimiento trae `equivalencias.total.{ars, usd_blue, cac}` (y `.subtotal` si
- * el presupuesto compara por neto). De ahí salen las equivalencias por fila.
+ * el presupuesto compara por neto). De ahí salen los valores por fila en cada modo.
  */
 
 const fechaSecs = (m) => m?.fecha_factura?._seconds || m?.fecha_factura?.seconds || 0;
@@ -35,17 +35,20 @@ const num = (v) => {
 const cacLabel = (cacTipo) =>
   cacTipo === 'mano_obra' ? 'CAC MO' : cacTipo === 'materiales' ? 'CAC MAT' : 'CAC';
 
+const MODO_LABEL = { nominal: 'Nominal', cac: 'CAC a hoy', usd: 'USD' };
+
 /**
  * @param {Object} opts
  * @param {Array}  opts.movimientos          Movimientos con shape de backend.
  * @param {string} opts.titulo               Título del documento (editable en el export).
+ * @param {string} [opts.modo]               'nominal' | 'cac' | 'usd' (default 'nominal').
  * @param {string} [opts.indexacion]         'CAC' | 'USD' | null (indexación del presupuesto en pesos).
  * @param {string} [opts.monedaPresupuesto]  Moneda nativa del presupuesto: 'ARS' | 'USD' | 'CAC'.
  * @param {string} [opts.cacTipo]            'general' | 'mano_obra' | 'materiales'.
- * @param {string} [opts.baseCalculo]        'total' | 'subtotal'.
  * @param {number} [opts.presupuestadoNativo] Monto presupuestado en unidad nativa (CAC units / USD / ARS).
+ * @param {number} [opts.presupuestadoNominal] Presupuestado nominal en pesos (calcPresupuestadoNominal).
  * @param {number} [opts.presupuestado]      Compat: monto ya en moneda de vista (export a nivel proyecto).
- * @param {number} [opts.montoIngresado]     Pesos originales (fallback si falta el nativo).
+ * @param {number} [opts.montoIngresado]     Pesos originales (fallback para nominal/derivados).
  * @param {number} [opts.cacIndiceActual]    Índice CAC de hoy (según cacTipo).
  * @param {number} [opts.tipoCambioActual]   Dólar de hoy.
  */
@@ -58,11 +61,13 @@ export function buildControlPresupuestoData({
   empresaNombre = '',
   domicilio = '',
   tipo = 'gastos',
+  modo = 'nominal',
   indexacion = null,
   monedaPresupuesto = null,
   cacTipo = null,
   baseCalculo = 'total',
   presupuestadoNativo = null,
+  presupuestadoNominal = null,
   presupuestado = 0,
   montoIngresado = null,
   cacIndiceActual = null,
@@ -72,40 +77,40 @@ export function buildControlPresupuestoData({
   const campo = baseCalculo === 'subtotal' ? 'subtotal' : 'total';
   const eqOf = (m) => (m?.equivalencias?.[campo] || m?.equivalencias?.total || {});
 
-  // Cotización vigente y clave de equivalencia según el tipo de presupuesto.
-  const cotiz = indexacion === 'CAC' ? num(cacIndiceActual)
-    : indexacion === 'USD' ? num(tipoCambioActual)
-      : null;
-  const indexado = (indexacion === 'CAC' || indexacion === 'USD') && cotiz > 0;
-  const usdNativo = !indexado && monedaPresupuesto === 'USD';
+  // Cotización vigente para los modos que reexpresan a "hoy".
+  const cotizCac = num(cacIndiceActual);
+  const cotizUsd = num(tipoCambioActual);
 
-  // Por movimiento: valor en la unidad PRIMARIA (lo que se muestra) y en la EQUIVALENTE.
-  let primaryOf;   // pesos a hoy (indexado/ARS) o USD (nativo)
-  let equivOf;     // unidad nativa CAC/USD (solo indexado) o null
+  // ── Estrategia por movimiento según el modo ──────────────────────────────────
+  // primaryOf: valor que se muestra; equivOf: unidad nativa al lado (o null).
+  let primaryOf;
+  let equivOf = null;
+  let moneda = 'ARS';
+  let equivLabel = '';
 
-  if (indexado) {
-    const equivKey = indexacion === 'CAC' ? 'cac' : 'usd_blue';
-    // nativo: equivalencia guardada; si falta, lo derivamos del valor en pesos.
+  if (modo === 'cac' && (indexacion === 'CAC') && cotizCac > 0) {
+    // Pesos a hoy = unidad CAC × índice actual; equivalencia en unidades CAC.
     equivOf = (m) => {
       const eq = eqOf(m);
-      if (eq[equivKey] != null) return num(eq[equivKey]);
+      if (eq.cac != null) return num(eq.cac);
       const pesos = num(eq.ars) || num(m.total);
-      return cotiz > 0 ? pesos / cotiz : 0;
+      return cotizCac > 0 ? pesos / cotizCac : 0;
     };
-    primaryOf = (m) => equivOf(m) * cotiz; // pesos a hoy
-  } else if (usdNativo) {
-    equivOf = null;
+    primaryOf = (m) => equivOf(m) * cotizCac;
+    equivLabel = cacLabel(cacTipo);
+  } else if (modo === 'usd') {
+    // Importes en dólares: usd_blue del movimiento (o total nativo si ya es USD).
+    moneda = 'USD';
     primaryOf = (m) => {
       const eq = eqOf(m);
       if ((m.moneda || 'ARS') === 'USD') return num(m.total);
       return num(eq.usd_blue);
     };
   } else {
-    // Pesos plano / fallback a nivel proyecto (presupuestos mixtos).
-    equivOf = null;
+    // 'nominal' (default y fallback): pesos reales del momento.
     primaryOf = (m) => {
       const eq = eqOf(m);
-      if ((m.moneda || 'ARS') === 'USD') return num(eq.ars) || num(m.total);
+      if (eq.ars != null) return num(eq.ars);
       return num(m.total);
     };
   }
@@ -130,33 +135,37 @@ export function buildControlPresupuestoData({
     };
   });
 
-  // ── Totales en unidad coherente ──────────────────────────────────────────────
-  const ejecutadoEquiv = equivOf ? acumEquiv : null;            // unidad nativa
-  const ejecutado = acumPrimary;                                // unidad primaria
+  const ejecutadoEquiv = equivOf ? acumEquiv : null;
+  const ejecutado = acumPrimary;
 
-  // Presupuestado nativo: provisto, o derivado de los pesos originales.
-  const nativo = presupuestadoNativo != null
-    ? num(presupuestadoNativo)
-    : (montoIngresado != null && cotiz > 0 ? num(montoIngresado) / cotiz : null);
-
+  // ── Presupuestado en la unidad primaria del modo ─────────────────────────────
   let presupuestadoPrimary;
-  let presupuestadoEquiv;
-  if (indexado) {
-    presupuestadoEquiv = nativo != null ? nativo : (ejecutadoEquiv || 0);
-    presupuestadoPrimary = presupuestadoEquiv * cotiz;          // pesos a hoy
+  let presupuestadoEquiv = null;
+  if (modo === 'cac' && indexacion === 'CAC' && cotizCac > 0) {
+    const nativo = presupuestadoNativo != null
+      ? num(presupuestadoNativo)
+      : (montoIngresado != null ? num(montoIngresado) / cotizCac : (ejecutadoEquiv || 0));
+    presupuestadoEquiv = nativo;
+    presupuestadoPrimary = nativo * cotizCac;
+  } else if (modo === 'usd') {
+    if (monedaPresupuesto === 'USD' && presupuestadoNativo != null) {
+      presupuestadoPrimary = num(presupuestadoNativo);
+    } else {
+      const nominalARS = presupuestadoNominal != null ? num(presupuestadoNominal)
+        : montoIngresado != null ? num(montoIngresado)
+          : num(presupuestadoNativo != null ? presupuestadoNativo : presupuestado);
+      presupuestadoPrimary = cotizUsd > 0 ? nominalARS / cotizUsd : 0;
+    }
   } else {
-    presupuestadoEquiv = null;
-    presupuestadoPrimary = presupuestadoNativo != null ? num(presupuestadoNativo) : num(presupuestado);
+    // nominal
+    presupuestadoPrimary = presupuestadoNominal != null ? num(presupuestadoNominal)
+      : montoIngresado != null ? num(montoIngresado)
+        : num(presupuestadoNativo != null ? presupuestadoNativo : presupuestado);
   }
 
   const saldo = presupuestadoPrimary - ejecutado;
   const saldoEquiv = equivOf ? (presupuestadoEquiv - ejecutadoEquiv) : null;
   const avance_pct = presupuestadoPrimary ? (ejecutado / presupuestadoPrimary) * 100 : 0;
-
-  const moneda = usdNativo ? 'USD' : 'ARS';
-  const equiv_label = indexacion === 'CAC' ? cacLabel(cacTipo)
-    : indexacion === 'USD' ? 'USD'
-      : '';
 
   return {
     titulo,
@@ -167,10 +176,12 @@ export function buildControlPresupuestoData({
     obra,
     presupuesto_label: presupuestoLabel,
     tipo,
+    modo,
+    modo_label: MODO_LABEL[modo] || MODO_LABEL.nominal,
     moneda,
-    indexacion: indexado ? indexacion : null,
+    indexacion: modo === 'cac' ? indexacion : null,
     mostrar_equiv: !!equivOf,
-    equiv_label,
+    equiv_label: equivLabel,
     presupuestado: presupuestadoPrimary,
     ejecutado,
     saldo,

--- a/src/utils/controlPresupuesto/presupuestoNominal.js
+++ b/src/utils/controlPresupuesto/presupuestoNominal.js
@@ -1,0 +1,51 @@
+/**
+ * Valores NOMINALES (pesos reales, sin "caquificar") de un presupuesto y sus
+ * movimientos. Fuente única de las fórmulas que antes vivían inline en los
+ * tooltips del PresupuestoDrawer, reutilizadas por el export a PDF (modo nominal).
+ *
+ * "Nominal" = el peso del momento, sin reexpresar a pesos de hoy vía índice CAC.
+ * Para presupuestos indexados, los adicionales se valúan con su PROPIO
+ * cotizacion_snapshot (el valor del momento en que se agregaron, no el actual).
+ */
+
+const num = (v) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+/**
+ * Presupuestado nominal en pesos (o en su moneda nativa si el presupuesto es plano).
+ * - Indexado (CAC/USD): monto_ingresado original + Σ adicionales valuados a su snapshot.
+ * - Plano: presupuesto.monto (ya incluye adicionales, en su moneda nativa).
+ */
+export function calcPresupuestadoNominal(presupuesto) {
+  const p = presupuesto || {};
+  if (p.indexacion === 'CAC' || p.indexacion === 'USD') {
+    const base = num(p.monto_ingresado);
+    const adicionales = (p.adicionales || []).reduce((s, a) => {
+      const monto = num(a?.monto);
+      const snap = a?.cotizacion_snapshot || {};
+      const cotiz = p.indexacion === 'CAC'
+        ? (snap.cac_indice ?? snap.cac_general ?? null)
+        : (snap.dolar_blue ?? null);
+      return s + (cotiz ? monto * num(cotiz) : 0);
+    }, 0);
+    return base + adicionales;
+  }
+  return num(p.monto);
+}
+
+/**
+ * Ejecutado nominal en pesos: suma de los movimientos al peso del momento.
+ * Usa la equivalencia en ARS guardada en cada movimiento (que ya refleja el valor
+ * nominal pagado), con fallback al total nativo. Mismo criterio por fila que el
+ * modo nominal de buildControlPresupuestoData, para que totales y filas coincidan.
+ */
+export function calcEjecutadoNominalARS(movimientos, baseCalculo = 'total') {
+  const campo = baseCalculo === 'subtotal' ? 'subtotal' : 'total';
+  return (movimientos || []).reduce((s, m) => {
+    const eq = m?.equivalencias?.[campo] || m?.equivalencias?.total || {};
+    const ars = eq.ars != null ? num(eq.ars) : num(m?.[campo] ?? m?.total);
+    return s + ars;
+  }, 0);
+}

--- a/src/utils/controlPresupuesto/sampleData.js
+++ b/src/utils/controlPresupuesto/sampleData.js
@@ -2,42 +2,93 @@
  * Datos de muestra para previsualizar plantillas de Control de Presupuesto.
  * Mismo shape que el objeto `data` que produce `buildControlPresupuestoData`.
  *
- * Caso elegido: presupuesto en PESOS INDEXADO POR CAC → muestra la unidad primaria
- * (pesos a hoy) + la columna de equivalencia (CAC), el bloque resumen
- * Presupuestado/Ejecutado/Saldo y la barra de avance. Así el preview ejercita el
- * render dinámico completo.
+ * `buildSampleData(modo)` arma la muestra según el modo de moneda elegido en el
+ * editor, para que el preview refleje exactamente lo que verá el usuario:
+ *  - 'nominal' (default): pesos reales, sin columna de equivalencia.
+ *  - 'cac': pesos a hoy + columna de equivalencia en unidades CAC.
+ *  - 'usd': importes en dólares.
  */
-const CONTROL_PRESUPUESTO_SAMPLE_DATA = {
-  titulo: 'RECIBO DE PAGOS',
-  fecha_emision: '22/5/2026',
-  empresa_nombre: 'Tu empresa',
-  domicilio: 'Costa de Oro',
-  contratista: 'Rodrigo Soria',
-  obra: 'Casa Tatán',
-  presupuesto_label: 'Albañilería 1° etapa',
-  tipo: 'gastos',
-  moneda: 'ARS',
-  indexacion: 'CAC',
-  mostrar_equiv: true,
-  equiv_label: 'CAC',
-  presupuestado: 8750000,
-  ejecutado: 7250000,
-  saldo: 1500000,
-  avance_pct: 82.86,
-  presupuestado_equiv: 17500,
-  ejecutado_equiv: 14500,
-  saldo_equiv: 3000,
-  movimientos: [
-    { numero: 1, fecha: '27/3/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 300000, acumulado: 300000, monto_equiv: 600, acumulado_equiv: 600 },
-    { numero: 2, fecha: '28/3/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 400000, acumulado: 700000, monto_equiv: 800, acumulado_equiv: 1400 },
-    { numero: 3, fecha: '10/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1050000, acumulado: 1750000, monto_equiv: 2100, acumulado_equiv: 3500 },
-    { numero: 4, fecha: '17/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 600000, acumulado: 2350000, monto_equiv: 1200, acumulado_equiv: 4700 },
-    { numero: 5, fecha: '24/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 900000, acumulado: 3250000, monto_equiv: 1800, acumulado_equiv: 6500 },
-    { numero: 6, fecha: '30/4/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 4250000, monto_equiv: 2000, acumulado_equiv: 8500 },
-    { numero: 7, fecha: '8/5/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 5250000, monto_equiv: 2000, acumulado_equiv: 10500 },
-    { numero: 8, fecha: '15/5/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 6250000, monto_equiv: 2000, acumulado_equiv: 12500 },
-    { numero: 9, fecha: '22/5/2026', detalle: 'Entrega', proveedor: 'Rodrigo Soria', categoria: 'Albañilería', monto: 1000000, acumulado: 7250000, monto_equiv: 2000, acumulado_equiv: 14500 },
-  ],
-};
+
+const INDICE_CAC = 500;   // pesos por unidad CAC (muestra)
+const DOLAR = 1250;       // pesos por USD (muestra)
+
+const ROWS = [
+  { fecha: '27/3/2026', ars: 300000 },
+  { fecha: '28/3/2026', ars: 400000 },
+  { fecha: '10/4/2026', ars: 1050000 },
+  { fecha: '17/4/2026', ars: 600000 },
+  { fecha: '24/4/2026', ars: 900000 },
+  { fecha: '30/4/2026', ars: 1000000 },
+  { fecha: '8/5/2026', ars: 1000000 },
+  { fecha: '15/5/2026', ars: 1000000 },
+  { fecha: '22/5/2026', ars: 1000000 },
+];
+
+const PRESUPUESTADO_ARS = 8750000;
+
+const MODO_LABEL = { nominal: 'Nominal', cac: 'CAC a hoy', usd: 'USD' };
+
+export function buildSampleData(modo = 'nominal') {
+  const esCac = modo === 'cac';
+  const esUsd = modo === 'usd';
+  const moneda = esUsd ? 'USD' : 'ARS';
+
+  const montoDe = (ars) => (esUsd ? Math.round(ars / DOLAR) : ars);
+  const equivDe = (ars) => ars / INDICE_CAC; // unidades CAC
+
+  let acum = 0;
+  let acumEquiv = 0;
+  const movimientos = ROWS.map((r, i) => {
+    const monto = montoDe(r.ars);
+    acum += monto;
+    const monto_equiv = esCac ? equivDe(r.ars) : null;
+    if (esCac) acumEquiv += monto_equiv;
+    return {
+      numero: i + 1,
+      fecha: r.fecha,
+      detalle: 'Entrega',
+      proveedor: 'Rodrigo Soria',
+      categoria: 'Albañilería',
+      monto,
+      acumulado: acum,
+      monto_equiv,
+      acumulado_equiv: esCac ? acumEquiv : null,
+    };
+  });
+
+  const presupuestado = montoDe(PRESUPUESTADO_ARS);
+  const ejecutado = acum;
+  const saldo = presupuestado - ejecutado;
+  const presupuestado_equiv = esCac ? equivDe(PRESUPUESTADO_ARS) : null;
+  const ejecutado_equiv = esCac ? acumEquiv : null;
+
+  return {
+    titulo: 'RECIBO DE PAGOS',
+    fecha_emision: '22/5/2026',
+    empresa_nombre: 'Tu empresa',
+    domicilio: 'Costa de Oro',
+    contratista: 'Rodrigo Soria',
+    obra: 'Casa Tatán',
+    presupuesto_label: 'Albañilería 1° etapa',
+    tipo: 'gastos',
+    modo,
+    modo_label: MODO_LABEL[modo] || MODO_LABEL.nominal,
+    moneda,
+    indexacion: esCac ? 'CAC' : null,
+    mostrar_equiv: esCac,
+    equiv_label: esCac ? 'CAC' : '',
+    presupuestado,
+    ejecutado,
+    saldo,
+    avance_pct: presupuestado ? (ejecutado / presupuestado) * 100 : 0,
+    presupuestado_equiv,
+    ejecutado_equiv,
+    saldo_equiv: esCac ? presupuestado_equiv - ejecutado_equiv : null,
+    movimientos,
+  };
+}
+
+// Compat: muestra por defecto (modo nominal).
+const CONTROL_PRESUPUESTO_SAMPLE_DATA = buildSampleData('nominal');
 
 export default CONTROL_PRESUPUESTO_SAMPLE_DATA;


### PR DESCRIPTION
# TAR-441 — Modo de moneda (nominal / CAC a hoy / USD) en el export PDF de control de presupuestos

Permite elegir en qué moneda se muestran los importes del PDF de control de presupuestos. PR hermano (backend): https://github.com/fedemaidan/sorby_bot_wa/pull/237. Ticket: TAR-441.

---

## TAR-441 — El cambio de "CAC a valores nominales" no se aplicaba

**Causa raíz / Problema:** En el editor de plantillas con IA, pedir "mostrame en pesos nominales" no cambiaba nada. La IA solo controla el **diseño** del PDF, no los **números**; y el cálculo (`buildControlPresupuestoData`) para un presupuesto indexado tenía un único camino: mostrar siempre los pesos "a hoy" (caquificado = nativo × índice CAC actual). **No existía un modo nominal**, así que el pedido del usuario no tenía dónde aplicarse y los montos seguían sin coincidir con los suyos.

**Cómo lo hicimos (funcional):** Al exportar a PDF (desde un presupuesto o desde el proyecto) ahora hay un selector de moneda: **Pesos nominales / CAC a hoy / USD**. Por defecto muestra **pesos nominales**, igual que la tabla de movimientos que ya se ve en el presupuesto. El mismo selector está en el editor de plantillas con IA, y si el usuario le pide a la IA "mostralo en dólares / en CAC / en pesos reales", la IA mueve ese selector sola. La plantilla es la misma para los tres modos (no hay que duplicarla).

**Decisiones y por qué:**
• Selector explícito como fuente de verdad (y la IA solo lo *sugiere*) → determinístico y confiable; depender de que la IA "entienda" la moneda era justo lo que fallaba.
• Modo por exportación, plantilla agnóstica a la moneda → una sola plantilla sirve para los 3 modos; evita duplicar plantillas por moneda.
• Default = **nominal**, espejando la tabla de movimientos del drawer → es lo que el usuario espera ("mis pesos reales"); el caquificado pasa a ser una opción más.
• Nominal = pesos reales del momento (sin reexpresar por índice) → es el número que el usuario reconoce; CAC a hoy queda para comparación en moneda constante.

**Cómo lo implementamos (técnico):**
• `buildControlPresupuestoData({ modo })` con `modo ∈ 'nominal' | 'cac' | 'usd'` (default `nominal`): branch explícito por modo. `nominal` usa `eq.ars ?? total` por movimiento; `cac` es el comportamiento anterior (pesos a hoy + equivalencia CAC); `usd` usa `usd_blue`. Suma `modo`/`modo_label` al `data` y mantiene `mostrar_equiv`/`equiv_label`/`*_equiv`.
• `presupuestoNominal.js` (nuevo): `calcPresupuestadoNominal` y `calcEjecutadoNominalARS`, extrayendo a un solo lugar las fórmulas nominales que estaban inline en los tooltips del `PresupuestoDrawer`.
• `ExportarPdfMenu`: `ToggleButtonGroup` → `buildData({ modo })`; props `modosDisponibles`/`modoDefault`. Call sites (`PresupuestoDrawer.js`, `control-presupuestos.js`) pasan `modo`, `presupuestadoNominal` y los modos según indexación / movimientos USD.
• Editor IA: `sampleData.js` → `buildSampleData(modo)` para que el preview refleje el modo; selector en `PdfPlantillaChatDialog` (threaded por `SeccionPlantillas`/`plantillas-pdf.js`); `aiChat` envía `modo`/`modosDisponibles` y aplica el `modo` que sugiera el backend.
• `PdfControlPresupuestoDocument`: muestra `(Nominal)` / `(CAC a hoy)` / `(USD)` cuando no hay columna de equivalencia.

**Producción / compatibilidad:** Sin migración ni cambios de modelo: el front ya tiene todo (los movimientos traen `equivalencias.total.{ars, usd_blue, cac}` y el presupuesto su `monto_ingresado` + snapshots). Único cambio de comportamiento intencional: el **default del PDF pasa de caquificado a nominal**. Las plantillas custom ya guardadas siguen funcionando (el `data` mantiene `mostrar_equiv`/`equiv_label`/`*_equiv`).

**Verificación:** Tests unitarios de `buildControlPresupuestoData` (3 modos + regresión cac + caso del ticket: nominal ≠ caquificado cuando el índice del momento ≠ el actual) y de `presupuestoNominal` (incluye adicionales con su snapshot). `npx jest src/utils/controlPresupuesto` → verde. Lint OK.

**Notas al código:**
• `buildControlPresupuestoData` modo `nominal`: por movimiento se usa `eq.ars ?? total` (no `total` a secas) para que un movimiento en USD aporte sus **pesos del momento** (equivalencia ARS de su fecha), no sus dólares ni una reconversión a hoy. Así la columna queda homogénea en pesos reales.
• `calcPresupuestadoNominal`: los adicionales se valúan con **su propio** `cotizacion_snapshot` (no la cotización actual) para conservar el valor nominal del momento en que se cargaron.
• El selector vive en el export (no en la plantilla) a propósito: el modo es un problema de datos, no de layout; por eso la plantilla quedó agnóstica.
