### PR TITLE
Control de presupuestos: fix export PDF (acumulado CAC/USD + orden) + export a Excel

### DIFF
--- a/src/components/PresupuestoDrawer.js
+++ b/src/components/PresupuestoDrawer.js
@@ -80,6 +80,7 @@ import {
 import ClasificacionesPicker from 'src/components/ClasificacionesPicker';
 import ProveedoresMultiSelect from 'src/components/ProveedoresMultiSelect';
 import ExportarPdfMenu from 'src/components/plantillasPdf/ExportarPdfMenu';
+import ExportarExcelMenu from 'src/components/plantillasPdf/ExportarExcelMenu';
 import { buildControlPresupuestoData } from 'src/utils/controlPresupuesto/buildControlPresupuestoData';
 import { calcPresupuestadoNominal } from 'src/utils/controlPresupuesto/presupuestoNominal';
 
@@ -2630,50 +2631,64 @@ const PresupuestoDrawer = ({
                         />
                       </Tooltip>
                     )}
-                    {presupuesto?.id && movimientosFiltrados.length > 0 && (
-                      <ExportarPdfMenu
-                        empresaId={empresaId}
-                        empresaNombre={empresaNombre}
-                        documentType="control_presupuesto"
-                        fileName={`control-presupuesto-${presupuesto.nombre || presupuesto.categoria || presupuesto.id}`}
-                        defaultDocumentLoader={loadDefaultControlPresupuestoDoc}
-                        tituloEditable
-                        defaultTitulo={presupuesto.tipo === 'ingreso' ? 'RECIBO DE INGRESOS' : 'RECIBO DE PAGOS'}
-                        modosDisponibles={[
-                          'nominal',
-                          ...(presupuesto.indexacion === 'CAC' ? ['cac'] : []),
-                          ...(presupuesto.indexacion === 'USD' || presupuesto.moneda === 'USD' ? ['usd'] : []),
-                        ]}
-                        modoDefault="nominal"
-                        buildData={(opts) => {
-                          const obra = proyectos.find((p) => p.id === proyectoId)?.nombre || '';
-                          const label = presupuesto.label || presupuesto.nombre || presupuesto.categoria || 'Presupuesto';
-                          const contratista = presupuesto.proveedores?.[0]?.nombre || presupuesto.categoria || '';
-                          const esIngreso = presupuesto.tipo === 'ingreso';
-                          return buildControlPresupuestoData({
-                            movimientos: movimientosFiltrados,
-                            titulo: opts?.titulo || (esIngreso ? 'RECIBO DE INGRESOS' : 'RECIBO DE PAGOS'),
-                            // El usuario elige el modo en el export; default pesos nominales (espeja la tabla del drawer).
-                            modo: opts?.modo || 'nominal',
-                            presupuestoLabel: label,
-                            contratista,
-                            obra,
-                            empresaNombre,
-                            // Contexto del presupuesto → moneda/indexación dinámica en el PDF.
-                            indexacion: presupuesto.indexacion || null,
-                            monedaPresupuesto: presupuesto.moneda || 'ARS',
-                            cacTipo: presupuesto.cac_tipo || null,
-                            baseCalculo: presupuesto.base_calculo || 'total',
-                            presupuestadoNativo: Number(presupuesto.monto != null ? presupuesto.monto : presupuesto.monto_ingresado || 0),
-                            presupuestadoNominal: calcPresupuestadoNominal(presupuesto),
-                            montoIngresado: presupuesto.monto_ingresado != null ? Number(presupuesto.monto_ingresado) : null,
-                            cacIndiceActual: cacActualEfectivo || cacEfectivo,
-                            tipoCambioActual: dolarEfectivo,
-                            tipo: esIngreso ? 'ingresos' : 'gastos',
-                          });
-                        }}
-                      />
-                    )}
+                    {presupuesto?.id && movimientosFiltrados.length > 0 && (() => {
+                      const fileNameExport = `control-presupuesto-${presupuesto.nombre || presupuesto.categoria || presupuesto.id}`;
+                      const modosExport = [
+                        'nominal',
+                        ...(presupuesto.indexacion === 'CAC' ? ['cac'] : []),
+                        ...(presupuesto.indexacion === 'USD' || presupuesto.moneda === 'USD' ? ['usd'] : []),
+                      ];
+                      // buildData compartido por el export a PDF y a Excel (mismo modo/datos).
+                      const buildExportData = (opts) => {
+                        const obra = proyectos.find((p) => p.id === proyectoId)?.nombre || '';
+                        const label = presupuesto.label || presupuesto.nombre || presupuesto.categoria || 'Presupuesto';
+                        const contratista = presupuesto.proveedores?.[0]?.nombre || presupuesto.categoria || '';
+                        const esIngreso = presupuesto.tipo === 'ingreso';
+                        return buildControlPresupuestoData({
+                          movimientos: movimientosFiltrados,
+                          titulo: opts?.titulo || (esIngreso ? 'RECIBO DE INGRESOS' : 'RECIBO DE PAGOS'),
+                          // El usuario elige el modo en el export; default pesos nominales (espeja la tabla del drawer).
+                          modo: opts?.modo || 'nominal',
+                          presupuestoLabel: label,
+                          contratista,
+                          obra,
+                          empresaNombre,
+                          // Contexto del presupuesto → moneda/indexación dinámica en el PDF.
+                          indexacion: presupuesto.indexacion || null,
+                          monedaPresupuesto: presupuesto.moneda || 'ARS',
+                          cacTipo: presupuesto.cac_tipo || null,
+                          baseCalculo: presupuesto.base_calculo || 'total',
+                          presupuestadoNativo: Number(presupuesto.monto != null ? presupuesto.monto : presupuesto.monto_ingresado || 0),
+                          presupuestadoNominal: calcPresupuestadoNominal(presupuesto),
+                          montoIngresado: presupuesto.monto_ingresado != null ? Number(presupuesto.monto_ingresado) : null,
+                          cacIndiceActual: cacActualEfectivo || cacEfectivo,
+                          tipoCambioActual: dolarEfectivo,
+                          tipo: esIngreso ? 'ingresos' : 'gastos',
+                        });
+                      };
+                      return (
+                        <>
+                          <ExportarPdfMenu
+                            empresaId={empresaId}
+                            empresaNombre={empresaNombre}
+                            documentType="control_presupuesto"
+                            fileName={fileNameExport}
+                            defaultDocumentLoader={loadDefaultControlPresupuestoDoc}
+                            tituloEditable
+                            defaultTitulo={presupuesto.tipo === 'ingreso' ? 'RECIBO DE INGRESOS' : 'RECIBO DE PAGOS'}
+                            modosDisponibles={modosExport}
+                            modoDefault="nominal"
+                            buildData={buildExportData}
+                          />
+                          <ExportarExcelMenu
+                            fileName={fileNameExport}
+                            modosDisponibles={modosExport}
+                            modoDefault="nominal"
+                            buildData={buildExportData}
+                          />
+                        </>
+                      );
+                    })()}
                   </Stack>
 
                   {movimientosLoading ? (

--- a/src/components/plantillasPdf/ExportarExcelMenu.js
+++ b/src/components/plantillasPdf/ExportarExcelMenu.js
@@ -1,0 +1,121 @@
+import { useState, useEffect } from 'react';
+import {
+  Chip,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+  ListSubheader,
+  Box,
+  Typography,
+  Tooltip,
+  ToggleButton,
+  ToggleButtonGroup,
+} from '@mui/material';
+import GridOnRoundedIcon from '@mui/icons-material/GridOnRounded';
+import TableRowsRoundedIcon from '@mui/icons-material/TableRowsRounded';
+import { exportControlPresupuestoXLSX } from 'src/utils/controlPresupuesto/exportControlPresupuestoXLSX';
+
+/**
+ * Botón "Excel" gemelo de ExportarPdfMenu: exporta SOLO la tabla de movimientos del
+ * control de presupuesto (las mismas columnas que el recibo PDF) a un .xlsx, con el
+ * mismo selector de modo (Pesos nominales / CAC a hoy / USD). No hay plantillas ni
+ * encabezado: solo la tabla, tal cual la muestra el PDF.
+ *
+ * Comparte la firma de datos con ExportarPdfMenu: `buildData({ modo })` devuelve el
+ * objeto de buildControlPresupuestoData; de ahí sale la tabla.
+ */
+const MODO_LABELS = { nominal: 'Pesos nominales', cac: 'CAC a hoy', usd: 'USD' };
+
+export default function ExportarExcelMenu({
+  buildData,
+  fileName = 'control-presupuesto',
+  disabled = false,
+  onError,
+  modosDisponibles = [],
+  modoDefault = 'nominal',
+}) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [modo, setModo] = useState(modoDefault);
+  const open = Boolean(anchorEl);
+
+  useEffect(() => { setModo(modoDefault); }, [modoDefault]);
+
+  const mostrarSelectorModo = Array.isArray(modosDisponibles) && modosDisponibles.length > 1;
+
+  const exportar = (modoElegido) => {
+    try {
+      const data = buildData(mostrarSelectorModo ? { modo: modoElegido } : undefined);
+      exportControlPresupuestoXLSX(data, fileName);
+    } catch (err) {
+      console.error('Error exportando a Excel:', err);
+      onError?.('No se pudo exportar a Excel');
+    }
+  };
+
+  const handleClick = (e) => {
+    // Con un solo modo no hace falta menú: se exporta directo.
+    if (!mostrarSelectorModo) { exportar(modo); return; }
+    setAnchorEl(e.currentTarget);
+  };
+
+  const cerrar = () => setAnchorEl(null);
+
+  return (
+    <>
+      <Tooltip title="Exportar a Excel" arrow>
+        <Chip
+          icon={<GridOnRoundedIcon sx={{ fontSize: 15 }} />}
+          label="Excel"
+          size="small"
+          variant="outlined"
+          color="success"
+          disabled={disabled}
+          onClick={handleClick}
+          sx={{ cursor: 'pointer', fontSize: '0.65rem', height: 22, '& .MuiChip-icon': { ml: 0.6 } }}
+        />
+      </Tooltip>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={cerrar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { minWidth: 256, mt: 0.5, borderRadius: 2 } } }}
+      >
+        <ListSubheader sx={{ lineHeight: '32px', fontWeight: 700, color: 'text.secondary' }}>
+          Exportar tabla a Excel
+        </ListSubheader>
+
+        <Box
+          sx={{ px: 2, pt: 0.5, pb: 1 }}
+          onKeyDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+            Mostrar importes en
+          </Typography>
+          <ToggleButtonGroup
+            value={modo}
+            exclusive
+            size="small"
+            fullWidth
+            onChange={(e, v) => { if (v) setModo(v); }}
+          >
+            {modosDisponibles.map((m) => (
+              <ToggleButton key={m} value={m} sx={{ fontSize: '0.65rem', py: 0.4, textTransform: 'none' }}>
+                {MODO_LABELS[m] || m}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </Box>
+
+        <MenuItem onClick={() => { cerrar(); exportar(modo); }} sx={{ py: 1 }}>
+          <ListItemIcon><TableRowsRoundedIcon fontSize="small" /></ListItemIcon>
+          <ListItemText primary="Exportar tabla"/>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/src/pages/control-presupuestos.js
+++ b/src/pages/control-presupuestos.js
@@ -89,6 +89,7 @@ const labelItem = (item, fallback = 'Ingreso general') => {
 import dayjs from 'dayjs';
 import PresupuestoDrawer from 'src/components/PresupuestoDrawer';
 import ExportarPdfMenu from 'src/components/plantillasPdf/ExportarPdfMenu';
+import ExportarExcelMenu from 'src/components/plantillasPdf/ExportarExcelMenu';
 import { buildControlPresupuestoData } from 'src/utils/controlPresupuesto/buildControlPresupuestoData';
 import Tooltip from '@mui/material/Tooltip';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
@@ -2404,52 +2405,62 @@ const ControlPresupuestosPage = () => {
                 sx={{ cursor: 'pointer', fontSize: '0.65rem', height: 22, ml: 'auto' }}
               />
             </Tooltip>
-            {movDrawerData.length > 0 && (
-              <ExportarPdfMenu
-                empresaId={empresaId}
-                empresaNombre={empresa?.nombre || ''}
-                documentType="control_presupuesto"
-                fileName={`movimientos-${proyectoActual?.nombre || 'proyecto'}-${movDrawer.label}`}
-                defaultDocumentLoader={loadDefaultControlPresupuestoDoc}
-                onError={(message) => setAlert({ open: true, message, severity: 'error' })}
-                tituloEditable
-                defaultTitulo={
-                  movDrawer.tipo === 'egreso' ? 'RECIBO DE PAGOS'
-                    : movDrawer.tipo === 'ingreso' ? 'RECIBO DE INGRESOS'
-                      : 'ESTADO DE CUENTA'
-                }
-                modosDisponibles={[
-                  'nominal',
-                  ...(movDrawerData.some((m) => (m.moneda || 'ARS') === 'USD') ? ['usd'] : []),
-                ]}
-                modoDefault="nominal"
-                buildData={(opts) => {
-                  const totales = calcularTotales();
-                  const presupuestado =
-                    movDrawer.tipo === 'egreso' ? totales.egresos.total
-                      : movDrawer.tipo === 'ingreso' ? totales.ingresos.total
-                        : 0;
-                  const titulo = opts?.titulo || (
-                    movDrawer.tipo === 'egreso' ? 'RECIBO DE PAGOS'
-                      : movDrawer.tipo === 'ingreso' ? 'RECIBO DE INGRESOS'
-                        : 'ESTADO DE CUENTA'
-                  );
-                  // Export a nivel proyecto: presupuestos mixtos, sin indexación única.
-                  // Modo nominal (pesos reales) por default; USD si hay movimientos en dólares.
-                  return buildControlPresupuestoData({
-                    movimientos: movDrawerData,
-                    titulo,
-                    modo: opts?.modo || 'nominal',
-                    presupuestoLabel: movDrawer.label,
-                    obra: proyectoActual?.nombre || '',
-                    empresaNombre: empresa?.nombre || '',
-                    monedaPresupuesto: moneda,
-                    presupuestadoNativo: presupuestado,
-                    tipo: movDrawer.tipo === 'ingreso' ? 'ingresos' : 'gastos',
-                  });
-                }}
-              />
-            )}
+            {movDrawerData.length > 0 && (() => {
+              const fileNameExport = `movimientos-${proyectoActual?.nombre || 'proyecto'}-${movDrawer.label}`;
+              const modosExport = [
+                'nominal',
+                ...(movDrawerData.some((m) => (m.moneda || 'ARS') === 'USD') ? ['usd'] : []),
+              ];
+              const defaultTitulo =
+                movDrawer.tipo === 'egreso' ? 'RECIBO DE PAGOS'
+                  : movDrawer.tipo === 'ingreso' ? 'RECIBO DE INGRESOS'
+                    : 'ESTADO DE CUENTA';
+              // buildData compartido por el export a PDF y a Excel (mismo modo/datos).
+              const buildExportData = (opts) => {
+                const totales = calcularTotales();
+                const presupuestado =
+                  movDrawer.tipo === 'egreso' ? totales.egresos.total
+                    : movDrawer.tipo === 'ingreso' ? totales.ingresos.total
+                      : 0;
+                // Export a nivel proyecto: presupuestos mixtos, sin indexación única.
+                // Modo nominal (pesos reales) por default; USD si hay movimientos en dólares.
+                return buildControlPresupuestoData({
+                  movimientos: movDrawerData,
+                  titulo: opts?.titulo || defaultTitulo,
+                  modo: opts?.modo || 'nominal',
+                  presupuestoLabel: movDrawer.label,
+                  obra: proyectoActual?.nombre || '',
+                  empresaNombre: empresa?.nombre || '',
+                  monedaPresupuesto: moneda,
+                  presupuestadoNativo: presupuestado,
+                  tipo: movDrawer.tipo === 'ingreso' ? 'ingresos' : 'gastos',
+                });
+              };
+              return (
+                <>
+                  <ExportarPdfMenu
+                    empresaId={empresaId}
+                    empresaNombre={empresa?.nombre || ''}
+                    documentType="control_presupuesto"
+                    fileName={fileNameExport}
+                    defaultDocumentLoader={loadDefaultControlPresupuestoDoc}
+                    onError={(message) => setAlert({ open: true, message, severity: 'error' })}
+                    tituloEditable
+                    defaultTitulo={defaultTitulo}
+                    modosDisponibles={modosExport}
+                    modoDefault="nominal"
+                    buildData={buildExportData}
+                  />
+                  <ExportarExcelMenu
+                    fileName={fileNameExport}
+                    modosDisponibles={modosExport}
+                    modoDefault="nominal"
+                    onError={(message) => setAlert({ open: true, message, severity: 'error' })}
+                    buildData={buildExportData}
+                  />
+                </>
+              );
+            })()}
           </Stack>
 
           {movDrawerLoading ? (

--- a/src/utils/controlPresupuesto/PdfControlPresupuestoDocument.js
+++ b/src/utils/controlPresupuesto/PdfControlPresupuestoDocument.js
@@ -175,7 +175,7 @@ export function PdfControlPresupuestoDocument({ data, logoDataUrl, empresaNombre
             <Text style={[styles.td, styles.cDetalle]}>{m.detalle || m.proveedor || '-'}</Text>
             <Text style={[styles.td, styles.cMonto]}>{fmtMoney(m.monto, moneda)}</Text>
             {mostrarEquiv ? <Text style={[styles.td, styles.cEquiv, styles.tdMuted]}>{m.monto_equiv != null ? fmtEquiv(m.monto_equiv, equivLabel) : '—'}</Text> : null}
-            <Text style={[styles.td, styles.cAcum]}>{fmtMoney(m.acumulado, moneda)}</Text>
+            <Text style={[styles.td, styles.cAcum]}>{mostrarEquiv ? fmtEquiv(m.acumulado_equiv, equivLabel) : fmtMoney(m.acumulado, moneda)}</Text>
           </View>
         ))}
 

--- a/src/utils/controlPresupuesto/__tests__/buildControlPresupuestoData.test.js
+++ b/src/utils/controlPresupuesto/__tests__/buildControlPresupuestoData.test.js
@@ -182,4 +182,50 @@ describe('buildControlPresupuestoData', () => {
     expect(data.ejecutado).toBe(500000);
     expect(data.saldo).toBe(300000);
   });
+
+  // Bug fix: con fechas de Mongo (Date / ISO) el sort cronológico debe ordenar del
+  // más viejo al más nuevo y acumular en ese orden (antes fechaSecs solo entendía el
+  // shape de Firestore → no ordenaba y el acumulado salía al revés).
+  describe('orden cronológico con fechas de Mongo (Date / ISO)', () => {
+    const movMongo = (fecha, total, eq) => ({
+      fecha_factura: fecha, total, moneda: 'ARS', nombre_proveedor: 'Proveedor',
+      equivalencias: eq ? { total: eq } : undefined,
+    });
+
+    test('ordena del más viejo al más nuevo y acumula en ese orden (ISO desordenado)', () => {
+      const data = buildControlPresupuestoData({
+        movimientos: [
+          movMongo('2026-06-29', 8335),    // más nuevo, llega primero
+          movMongo('2026-06-08', 6000000), // más viejo, llega último
+          movMongo('2026-06-20', 109350),
+        ],
+      });
+      expect(data.movimientos.map((m) => m.fecha)).toEqual(['8/6/2026', '20/6/2026', '29/6/2026']);
+      expect(data.movimientos.map((m) => m.numero)).toEqual([1, 2, 3]);
+      // acumulado crece del más viejo (su propio monto) al más nuevo (total).
+      expect(data.movimientos.map((m) => m.acumulado)).toEqual([6000000, 6109350, 6117685]);
+    });
+
+    test('acepta Date nativo', () => {
+      const data = buildControlPresupuestoData({
+        movimientos: [
+          movMongo(new Date('2026-06-29'), 100),
+          movMongo(new Date('2026-06-08'), 200),
+        ],
+      });
+      expect(data.movimientos.map((m) => m.acumulado)).toEqual([200, 300]);
+    });
+
+    test('cac: acumulado_equiv suma en CAC del más viejo al más nuevo', () => {
+      const data = buildControlPresupuestoData({
+        movimientos: [
+          movMongo('2026-06-29', 8335, { ars: 8335, cac: 0.41 }),
+          movMongo('2026-06-08', 6000000, { ars: 6000000, cac: 292.78 }),
+        ],
+        modo: 'cac', indexacion: 'CAC', monedaPresupuesto: 'CAC', cacIndiceActual: 20488,
+      });
+      // el más viejo (8/6) primero; acumulado_equiv en CAC, no en pesos.
+      expect(data.movimientos.map((m) => m.acumulado_equiv)).toEqual([292.78, 293.19]);
+    });
+  });
 });

--- a/src/utils/controlPresupuesto/buildControlPresupuestoData.js
+++ b/src/utils/controlPresupuesto/buildControlPresupuestoData.js
@@ -18,7 +18,17 @@ import dayjs from 'dayjs';
  * el presupuesto compara por neto). De ahí salen los valores por fila en cada modo.
  */
 
-const fechaSecs = (m) => m?.fecha_factura?._seconds || m?.fecha_factura?.seconds || 0;
+// Segundos epoch de fecha_factura. Soporta Firestore Timestamp ({_seconds}/{seconds})
+// y también Date/string ISO (Mongo) — si no, el sort cronológico no ordena y el
+// acumulado queda en el orden de entrada (del más nuevo al más viejo).
+const fechaSecs = (m) => {
+  const f = m?.fecha_factura;
+  if (!f) return 0;
+  if (typeof f._seconds === 'number') return f._seconds;
+  if (typeof f.seconds === 'number') return f.seconds;
+  const d = dayjs(f);
+  return d.isValid() ? d.unix() : 0;
+};
 
 const fechaStr = (m) => {
   const s = fechaSecs(m);

--- a/src/utils/controlPresupuesto/exportControlPresupuestoXLSX.js
+++ b/src/utils/controlPresupuesto/exportControlPresupuestoXLSX.js
@@ -1,0 +1,71 @@
+import * as XLSX from 'xlsx';
+
+/**
+ * Exporta a Excel SOLO la tabla de movimientos del control de presupuesto, con las
+ * mismas columnas que el recibo PDF (PdfControlPresupuestoDocument) según el modo
+ * elegido (nominal / CAC / USD). No incluye encabezado, resumen ni plantilla: solo
+ * la tabla, una fila por movimiento. Los importes van como números (Excel los suma).
+ *
+ * Recibe el mismo `data` que produce buildControlPresupuestoData.
+ */
+const num = (v) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+export function exportControlPresupuestoXLSX(data, fileName = 'control-presupuesto') {
+  const d = data || {};
+  const movs = Array.isArray(d.movimientos) ? d.movimientos : [];
+  const mostrarEquiv = !!d.mostrar_equiv;
+  const moneda = d.moneda || 'ARS';
+  const equivLabel = d.equiv_label || '';
+  const montoHeader = moneda === 'USD' ? 'MONTO USD' : 'MONTO $';
+
+  // Mismas columnas que el PDF: N° · Fecha · Detalle · Monto · [equiv] · Acumulado.
+  const header = ['N°', 'FECHA', 'DETALLE', montoHeader];
+  if (mostrarEquiv) header.push(equivLabel || 'EQUIV.');
+  header.push('ACUMULADO');
+
+  const rows = movs.map((m, i) => {
+    const row = [
+      m.numero != null ? m.numero : i + 1,
+      m.fecha || '',
+      m.detalle || m.proveedor || '',
+      num(m.monto),
+    ];
+    if (mostrarEquiv) row.push(num(m.monto_equiv));
+    row.push(mostrarEquiv ? num(m.acumulado_equiv) : num(m.acumulado));
+    return row;
+  });
+
+  const ws = XLSX.utils.aoa_to_sheet([header, ...rows]);
+
+  // Anchos en píxeles, alineados por índice de columna: Detalle 250, Monto y
+  // Acumulado 150. El resto queda con el ancho por defecto.
+  const cols = [{}, {}, { wpx: 250 }, { wpx: 150 }];
+  if (mostrarEquiv) cols.push({});
+  cols.push({ wpx: 150 });
+  ws['!cols'] = cols;
+
+  // Formato de número: signo de moneda + sin decimales (el valor real se mantiene
+  // para que Excel pueda sumar). $ pesos / USD dólares, y la unidad (CAC) como sufijo
+  // en la columna equivalente. Mismo criterio que el PDF.
+  const fmtMoneda = moneda === 'USD' ? '"USD "#,##0' : '"$ "#,##0';
+  const fmtEquivU = `#,##0" ${equivLabel || 'CAC'}"`;
+  const idxMonto = 3;
+  const idxAcum = mostrarEquiv ? 5 : 4;
+  const formatos = { [idxMonto]: fmtMoneda, [idxAcum]: mostrarEquiv ? fmtEquivU : fmtMoneda };
+  if (mostrarEquiv) formatos[4] = fmtEquivU;
+  for (let r = 1; r <= rows.length; r++) {
+    for (const c of Object.keys(formatos)) {
+      const ref = XLSX.utils.encode_cell({ r, c: Number(c) });
+      if (ws[ref]) ws[ref].z = formatos[c];
+    }
+  }
+
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'Movimientos');
+  XLSX.writeFile(wb, `${(fileName || 'control-presupuesto').replace(/\.xlsx$/i, '')}.xlsx`);
+}
+
+export default exportControlPresupuestoXLSX;


### PR DESCRIPTION
**Ticket:** [Control de Presupuestos — visualización CAC vs nominal (Notion)](https://app.notion.com/p/Control-de-Presupuestos-El-Agente-no-aplica-correctamente-el-cambio-de-visualizaci-n-de-CAC-a-valo-38450a1e5341800f9642c46f5f648ab8?v=3384ca8149254d58b1781f468b1bf8bf&source=copy_link) · Frontend · rama desde `main`.

---

## Causa raíz / Problema
Al exportar el "Recibo de pagos" de un presupuesto indexado (CAC o USD), la columna **ACUMULADO** sumaba en **pesos nominales** (no en la unidad del presupuesto) y el acumulado salía **invertido**: arrancaba desde el movimiento más nuevo, así que el total caía en el más viejo en vez de en el más reciente.

## Cómo lo hicimos (funcional)
El acumulado del recibo ahora suma en la **unidad del presupuesto** (CAC/USD) y respeta el **orden cronológico** (del más viejo al más nuevo). Así el último acumulado coincide con el **EJECUTADO** del resumen.

## Decisiones y por qué
- **Acumular en la unidad del presupuesto, no en pesos** → coherencia con el resumen (Presupuestado/Ejecutado/Saldo ya van en CAC/USD).
- **Orden cronológico ascendente** → el acumulado es un running total real "hasta esa fecha".

## Cómo lo implementamos (técnico)
- `controlPresupuesto/PdfControlPresupuestoDocument.js` → la columna ACUMULADO usa `acumulado_equiv` (con `fmtEquiv`) cuando el presupuesto es indexado (`mostrar_equiv`).
- `controlPresupuesto/buildControlPresupuestoData.js` → `fechaSecs` ahora soporta `fecha_factura` como **Date/string ISO (Mongo)**, no solo Firestore Timestamp. Antes devolvía `0` para todos → el `sort` cronológico no ordenaba y el acumulado quedaba en el orden de entrada.
- Tests: orden con fechas Mongo (Date/ISO) + `acumulado_equiv` en CAC.

## Producción / compatibilidad
- Solo afecta el **export PDF** de control de presupuestos. Sin migración. `fechaSecs` sigue soportando el shape de Firestore (compat con datos viejos) además del de Mongo.

## Notas al código
- `buildControlPresupuestoData.js:fechaSecs` → la migración a Mongo cambió `fecha_factura` de Firestore Timestamp (`{_seconds}`) a `Date`/ISO; el sort dependía del shape viejo y por eso el acumulado salía al revés.

## Verificación
- Tests de `buildControlPresupuestoData` verdes (17, incl. los nuevos de orden/acumulado). Lint limpio. Sin validación en browser (pendiente, solo a pedido).

---

## Feature — Exportar la tabla a Excel

**Causa raíz / Problema:** del control de presupuestos solo se podía exportar a PDF. Para trabajar los números (sumar, filtrar) hacía falta la tabla en Excel.

**Cómo lo hicimos (funcional):** al lado del botón **PDF** aparece un botón **Excel** (en el drawer del presupuesto y en el de movimientos del proyecto). Tiene el **mismo selector de modo** (Pesos nominales / CAC a hoy / USD) que el PDF. Exporta **solo la tabla** de movimientos (las mismas columnas que el recibo PDF), sin encabezado, resumen ni plantilla.

**Decisiones y por qué:**
- **Solo la tabla, sin plantilla** → el Excel es para operar los datos, no un documento presentable (eso es el PDF).
- **Mismo `buildData`/selector de modo que el PDF** → la tabla del Excel es idéntica a la del PDF según el modo elegido; una sola fuente de datos.
- **Importes como números con formato de moneda** (no texto) → Excel los puede **sumar**; el formato muestra el signo ($ / USD) y sin decimales, pero el valor real queda completo.

**Cómo lo implementamos (técnico):**
- `components/plantillasPdf/ExportarExcelMenu.js` (nuevo) → Chip "Excel" + menú con el selector de modo; gemelo de `ExportarPdfMenu` pero sin plantillas.
- `utils/controlPresupuesto/exportControlPresupuestoXLSX.js` (nuevo) → arma el `.xlsx` con SheetJS desde el `data` de `buildControlPresupuestoData`. Columnas = las del PDF (N° · Fecha · Detalle · Monto · [CAC/USD] · Acumulado). Anchos: Detalle 250px, Monto y Acumulado 150px. Formato de número por celda (`.z`): `$`/`USD` sin decimales, equivalencia con sufijo de unidad (CAC).
- `PresupuestoDrawer.js` y `control-presupuestos.js` → render del botón Excel al lado del de PDF, compartiendo el mismo `buildData`/`modosDisponibles` vía un IIFE local (sin duplicar la construcción de datos).

**Producción / compatibilidad:** solo frontend, aditivo. No toca el PDF ni el backend. Sin migración.

**Verificación:** lint limpio en los archivos tocados. Sin validación en browser (pendiente, solo a pedido).

---

## TL;DR
- **Fix export PDF:** el recibo de un presupuesto CAC/USD ahora muestra el **ACUMULADO en su unidad** (no en pesos) y en **orden cronológico** (del más viejo al más nuevo). Causa: `fechaSecs` solo entendía fechas de Firestore; con Mongo (Date/ISO) no ordenaba.
- **Feature Excel:** botón **Excel** al lado del de PDF (mismo selector de modo) que exporta **solo la tabla** de movimientos a `.xlsx`, sin plantilla; importes como números con signo de moneda y sin decimales; anchos Detalle 250 / Monto 150 / Acumulado 150.
- **Archivos:** `controlPresupuesto/PdfControlPresupuestoDocument.js`, `controlPresupuesto/buildControlPresupuestoData.js` (+ test), `controlPresupuesto/exportControlPresupuestoXLSX.js` (nuevo), `plantillasPdf/ExportarExcelMenu.js` (nuevo), `PresupuestoDrawer.js`, `control-presupuestos.js`.
- **Verificación:** 17 tests verdes, lint limpio; sin E2E browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
