### PR TITLE
feat(dhn): permiso DHN_SOLO_LECTURA (menú acotado + edición deshabili…

### DIFF
--- a/src/components/dhn/CorreccionConciliacionModal.js
+++ b/src/components/dhn/CorreccionConciliacionModal.js
@@ -127,6 +127,7 @@ const CorreccionConciliacionModal = ({
   onSelectSistema,
   selectionLoading,
   onSave,
+  readOnly = false,
 }) => {
   const theme = useTheme();
   const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
@@ -558,7 +559,7 @@ const CorreccionConciliacionModal = ({
                     variant="outlined"
                     size="small"
                     onClick={handleSelectSistemaClick}
-                    disabled={selectionLoading}
+                    disabled={selectionLoading || readOnly}
                     sx={{ textTransform: "none" }}
                   >
                     Horas Sistema
@@ -567,7 +568,7 @@ const CorreccionConciliacionModal = ({
                     variant="contained"
                     size="small"
                     onClick={handleSelectExcelClick}
-                    disabled={selectionLoading}
+                    disabled={selectionLoading || readOnly}
                     sx={{ textTransform: "none" }}
                   >
                     Horas NASA
@@ -597,6 +598,7 @@ const CorreccionConciliacionModal = ({
                       value={formHoras?.[field.key] ?? ""}
                       onChange={(event) => handleHorasFieldChange(field.key, event.target.value)}
                       size="small"
+                      disabled={readOnly}
                       sx={{
                         maxWidth: 140,
                       }}
@@ -611,6 +613,7 @@ const CorreccionConciliacionModal = ({
                     value={licenciaValue}
                     onChange={handleLicenciaChange}
                     size="small"
+                    disabled={readOnly}
                     sx={{ maxWidth: 240 }}
                   >
                     <MenuItem value="">Sin licencia</MenuItem>
@@ -705,9 +708,9 @@ const CorreccionConciliacionModal = ({
             )}
             <Box sx={{ display: "flex", gap: 1 }}>
               <Button variant="text" onClick={onClose}>
-                Cancelar
+                {readOnly ? "Cerrar" : "Cancelar"}
               </Button>
-              <Button variant="contained" onClick={handleGuardar} disabled={selectionLoading}>
+              <Button variant="contained" onClick={handleGuardar} disabled={selectionLoading || readOnly}>
                 Guardar
               </Button>
             </Box>

--- a/src/components/dhn/EditarTrabajadorModal.js
+++ b/src/components/dhn/EditarTrabajadorModal.js
@@ -19,7 +19,7 @@ import TrabajadorService from "src/services/dhn/TrabajadorService";
 import { getUser } from "src/utils/celulandia/currentUser";
 import useModalAlert from "src/hooks/useModalAlert";
 
-const EditarTrabajadorModal = ({ open, onClose, onSave, trabajador }) => {
+const EditarTrabajadorModal = ({ open, onClose, onSave, trabajador, readOnly = false }) => {
   const { alert, showAlert, closeAlert } = useModalAlert(open);
 
   const [isLoading, setIsLoading] = useState(false);
@@ -157,6 +157,7 @@ const EditarTrabajadorModal = ({ open, onClose, onSave, trabajador }) => {
                 value={formData.nombre}
                 onChange={(e) => handleInputChange("nombre", e.target.value)}
                 margin="normal"
+                disabled={readOnly}
                 required
               />
             </Grid>
@@ -167,6 +168,7 @@ const EditarTrabajadorModal = ({ open, onClose, onSave, trabajador }) => {
                 value={formData.apellido}
                 onChange={(e) => handleInputChange("apellido", e.target.value)}
                 margin="normal"
+                disabled={readOnly}
                 required
               />
             </Grid>
@@ -177,6 +179,7 @@ const EditarTrabajadorModal = ({ open, onClose, onSave, trabajador }) => {
                 value={formData.dni}
                 onChange={(e) => handleInputChange("dni", e.target.value)}
                 margin="normal"
+                disabled={readOnly}
                 required
               />
             </Grid>
@@ -189,6 +192,7 @@ const EditarTrabajadorModal = ({ open, onClose, onSave, trabajador }) => {
                 onChange={(e) => handleInputChange("desde", e.target.value)}
                 margin="normal"
                 InputLabelProps={{ shrink: true }}
+                disabled={readOnly}
                 required
               />
             </Grid>
@@ -201,6 +205,7 @@ const EditarTrabajadorModal = ({ open, onClose, onSave, trabajador }) => {
                 onChange={(e) => handleInputChange("hasta", e.target.value)}
                 margin="normal"
                 InputLabelProps={{ shrink: true }}
+                disabled={readOnly}
               />
             </Grid>
             <Grid item xs={12} sm={6}>
@@ -211,6 +216,7 @@ const EditarTrabajadorModal = ({ open, onClose, onSave, trabajador }) => {
                       checked={formData.active}
                       onChange={(e) => handleInputChange("active", e.target.checked)}
                       color="primary"
+                      disabled={readOnly}
                     />
                   }
                   label="Activo"
@@ -222,13 +228,13 @@ const EditarTrabajadorModal = ({ open, onClose, onSave, trabajador }) => {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleCloseModal} color="inherit" disabled={isLoading}>
-          Cancelar
+          {readOnly ? "Cerrar" : "Cancelar"}
         </Button>
-        <Button 
-          onClick={handleSave} 
-          color="primary" 
+        <Button
+          onClick={handleSave}
+          color="primary"
           variant="contained"
-          disabled={isLoading}
+          disabled={isLoading || readOnly}
           startIcon={isLoading ? <CircularProgress size={16} /> : null}
         >
           {isLoading ? "Guardando..." : "Guardar"}

--- a/src/hooks/dhn/useDhnSoloLectura.js
+++ b/src/hooks/dhn/useDhnSoloLectura.js
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+import { useAuthContext } from "src/contexts/auth-context";
+
+// Verdadero cuando la empresa tiene la acción DHN_SOLO_LECTURA y el usuario no es
+// admin (los admin nunca quedan en modo solo lectura). permisosOcultos actúa como
+// deny-list, igual que en el resto de los permisos.
+const useDhnSoloLectura = () => {
+  const { user } = useAuthContext();
+  return useMemo(() => {
+    if (user?.admin) return false;
+    const acciones = user?.empresa?.acciones || user?.empresaData?.acciones || [];
+    const ocultos = user?.permisosOcultos || [];
+    return acciones.includes("DHN_SOLO_LECTURA") && !ocultos.includes("DHN_SOLO_LECTURA");
+  }, [user]);
+};
+
+export default useDhnSoloLectura;

--- a/src/layouts/dashboard/side-nav-dhn.js
+++ b/src/layouts/dashboard/side-nav-dhn.js
@@ -44,6 +44,11 @@ export const SideNavDHN = ({
   const lgUp = useMediaQuery((theme) => theme.breakpoints.up("lg"), { noSsr: true });
   const { user, isSpying } = useAuthContext();
 
+  // Solo lectura: el usuario ve únicamente Trabajadores, Control Diario y Control
+  // Quincenal (los admin siguen viendo todo).
+  const soloLectura = !user?.admin && (permisos || []).includes("DHN_SOLO_LECTURA");
+  const pathsSoloLectura = ["/dhn/trabajador", "/dhn/controlDiario", "/dhn/controlQuincenal", "/account"];
+
   const paperSx = {
     backgroundColor: isSpying() ? "neutral.600" : "neutral.800",
     color: "common.white",
@@ -120,6 +125,10 @@ export const SideNavDHN = ({
     });
   }
 
+  const visibleItems = soloLectura
+    ? items.filter((item) => pathsSoloLectura.includes(item.path))
+    : items;
+
   const content = (
     <Scrollbar
       sx={{
@@ -149,7 +158,7 @@ export const SideNavDHN = ({
         {/* Navegación */}
         <Box component="nav" sx={{ flexGrow: 1, px: 1, py: 1 }}>
           <Stack component="ul" spacing={0.25} sx={{ listStyle: "none", p: 0, m: 0 }}>
-            {items.map((item) => {
+            {visibleItems.map((item) => {
               const active = item.path ? pathname === item.path : false;
               const node = (
                 <SideNavItem

--- a/src/pages/DHN/controlQuincenal/diario/[dia].js
+++ b/src/pages/DHN/controlQuincenal/diario/[dia].js
@@ -14,9 +14,11 @@ import TrabajosDetectadosList from 'src/components/dhn/TrabajosDetectadosList';
 import ClearIcon from '@mui/icons-material/Clear';
 import CorreccionConciliacionModal from 'src/components/dhn/CorreccionConciliacionModal';
 import useEditarTrabajoDiario from 'src/hooks/dhn/useEditarTrabajoDiario';
+import useDhnSoloLectura from 'src/hooks/dhn/useDhnSoloLectura';
 
 const ControlDiaPage = () => {
   const router = useRouter();
+  const soloLectura = useDhnSoloLectura();
   const { dia: diaParam } = router.query;
 
   const diaFormatoParam = Array.isArray(diaParam) ? diaParam[0] : diaParam;
@@ -198,6 +200,7 @@ const ControlDiaPage = () => {
         onFormHorasChange={setFormHoras}
         selectionLoading={savingEdit}
         onSave={handleSaveTrabajoDiario}
+        readOnly={soloLectura}
       />
     </DashboardLayout>
   );

--- a/src/pages/dhn/controlDiario.js
+++ b/src/pages/dhn/controlDiario.js
@@ -19,9 +19,11 @@ import useTrabajoDiarioPage from 'src/hooks/dhn/useTrabajoDiarioPage';
 import ImagenModal from 'src/components/ImagenModal';
 import TrabajosDetectadosList from 'src/components/dhn/TrabajosDetectadosList';
 import { parseDDMMYYYYAnyToISO, formatDateDDMMYYYY } from 'src/utils/handleDates';
+import useDhnSoloLectura from 'src/hooks/dhn/useDhnSoloLectura';
 
 const ControlDiarioPage = () => {
   const router = useRouter();
+  const soloLectura = useDhnSoloLectura();
   const diaParam = useMemo(() => {
     const raw = Array.isArray(router.query.dia) ? router.query.dia[0] : router.query.dia;
     return raw ? String(raw) : null;
@@ -210,6 +212,7 @@ const ControlDiarioPage = () => {
         onFormHorasChange={setFormHoras}
         selectionLoading={savingEdit}
         onSave={handleSaveTrabajoDiario}
+        readOnly={soloLectura}
       />
 
       <HistorialModal

--- a/src/pages/dhn/trabajador/[trabajadorId].js
+++ b/src/pages/dhn/trabajador/[trabajadorId].js
@@ -20,6 +20,7 @@ import TrabajosDetectadosList from 'src/components/dhn/TrabajosDetectadosList';
 import HistorialModal from 'src/components/dhn/HistorialModal';
 import HorasRawModal from 'src/components/dhn/HorasRawModal';
 import { formatDateDDMMYYYY } from 'src/utils/handleDates';
+import useDhnSoloLectura from 'src/hooks/dhn/useDhnSoloLectura';
 
 const DEFAULT_MES = dayjs().format('YYYY-MM');
 
@@ -34,6 +35,7 @@ const parseMesParam = (raw) => {
 
 const TrabajadorPage = () => {
   const router = useRouter();
+  const soloLectura = useDhnSoloLectura();
   const { trabajadorId } = router.query;
   const mesParam = useMemo(() => {
     const raw = Array.isArray(router.query.mes) ? router.query.mes[0] : router.query.mes;
@@ -246,6 +248,7 @@ const TrabajadorPage = () => {
         onFormHorasChange={setFormHoras}
         selectionLoading={savingEdit}
         onSave={handleSaveTrabajoDiario}
+        readOnly={soloLectura}
       />
 
       <HistorialModal

--- a/src/pages/dhn/trabajador/index.js
+++ b/src/pages/dhn/trabajador/index.js
@@ -23,9 +23,11 @@ import { useRouter } from 'next/router';
 import AgregarTrabajadorModal from 'src/components/dhn/AgregarTrabajadorModal';
 import EditarTrabajadorModal from 'src/components/dhn/EditarTrabajadorModal';
 import HistorialModal from 'src/components/dhn/HistorialModal';
+import useDhnSoloLectura from 'src/hooks/dhn/useDhnSoloLectura';
 
 const TrabajadoresPage = () => {
   const router = useRouter();
+  const soloLectura = useDhnSoloLectura();
   const {
     trabajadores,
     pagination,
@@ -197,22 +199,24 @@ const TrabajadoresPage = () => {
               ),
             }}
           />
-          <Button
-            size="small"
-            variant="contained"
-            color="primary"
-            startIcon={<AddIcon />}
-            onClick={() => setAgregarModalOpen(true)}
-            sx={{
-              borderRadius: 2,
-              px: 3,
-              py: 1,
-              boxShadow: 2,
-              '&:hover': { boxShadow: 4 },
-            }}
-          >
-            Agregar Trabajador
-          </Button>
+          {!soloLectura && (
+            <Button
+              size="small"
+              variant="contained"
+              color="primary"
+              startIcon={<AddIcon />}
+              onClick={() => setAgregarModalOpen(true)}
+              sx={{
+                borderRadius: 2,
+                px: 3,
+                py: 1,
+                boxShadow: 2,
+                '&:hover': { boxShadow: 4 },
+              }}
+            >
+              Agregar Trabajador
+            </Button>
+          )}
         </Box>
 
         {isError && (
@@ -242,6 +246,7 @@ const TrabajadoresPage = () => {
         onClose={() => setEditarModalOpen(false)}
         onSave={handleSaveEdit}
         trabajador={trabajadorSeleccionado}
+        readOnly={soloLectura}
       />
 
       <HistorialModal

--- a/src/sections/empresa/configuracionGeneral.js
+++ b/src/sections/empresa/configuracionGeneral.js
@@ -243,6 +243,7 @@ export const ConfiguracionGeneral = ({ empresa, updateEmpresaData, hasPermission
 
   const dhnAcciones = [
     "DHN_SYNC_DRIVE",
+    "DHN_SOLO_LECTURA",
   ]
 
   const celulandiaAcciones = [


### PR DESCRIPTION
…tada)

- configuracionGeneral: DHN_SOLO_LECTURA como acción de empresa
- side-nav-dhn: solo Trabajadores, Control Diario y Control Quincenal
- useDhnSoloLectura: hook único de detección (no admin + accion, deny-list)
- CorreccionConciliacionModal / EditarTrabajadorModal: prop readOnly deshabilita inputs y Guardar; se puede abrir para ver imágenes y datos detectados
- wiring en páginas DHN; oculta "Agregar Trabajador" en solo lectura