### PR TITLE
feat(cobros/control-obra): builder de planes, cashflow, cobro flexible y pestaña de cobros en obra

### DIFF
--- a/src/components/controlObra/CobrosObraTab.js
+++ b/src/components/controlObra/CobrosObraTab.js
@@ -1,0 +1,106 @@
+import { useQuery, useQueries } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { Box, Chip, LinearProgress, Paper, Stack, Typography, Button } from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import planCobroService from 'src/services/planCobroService';
+
+const money = (n, moneda) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: moneda === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
+
+// Pestaña "Cobros" de la obra: muestra el/los plan(es) de cobro asociados y cómo
+// vienen. En modo 'plan' el cobro va por acá; en modo 'certificados' el plan se
+// alimenta de los certificados aprobados.
+export default function CobrosObraTab({ obra, empresaId }) {
+  const router = useRouter();
+  const planIds = (obra.plan_cobro_ids && obra.plan_cobro_ids.length)
+    ? obra.plan_cobro_ids
+    : (obra.plan_cobro_id ? [obra.plan_cobro_id] : []);
+
+  const planesQ = useQueries({
+    queries: planIds.map((pid) => ({
+      queryKey: ['control-obra', 'plan-cobro', pid, empresaId],
+      queryFn: async () => (await planCobroService.getPlan(pid, empresaId))?.data?.data,
+      enabled: !!empresaId && !!pid,
+    })),
+  });
+  const planes = planesQ.map((q) => q.data).filter(Boolean);
+  const loading = planesQ.some((q) => q.isLoading);
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" spacing={1} mb={2} flexWrap="wrap">
+        <Typography variant="subtitle2" fontWeight={700}>Cobro de la obra:</Typography>
+        <Chip
+          size="small"
+          color={obra.modo_cobro === 'plan' ? 'primary' : 'default'}
+          label={obra.modo_cobro === 'plan' ? 'Por plan de cobro' : 'Por certificados'}
+        />
+        <Typography variant="caption" color="text.secondary">
+          {obra.modo_cobro === 'plan'
+            ? 'El cobro va por el cronograma del/los plan(es). Los certificados registran avance pero no generan cuotas.'
+            : 'Cada certificado aprobado agrega una cuota al plan.'}
+        </Typography>
+      </Stack>
+
+      {loading && <LinearProgress sx={{ mb: 2 }} />}
+
+      {!loading && planes.length === 0 && (
+        <Typography variant="body2" color="text.secondary">La obra no tiene plan de cobro asociado.</Typography>
+      )}
+
+      <Stack spacing={1.5}>
+        {planes.map((plan) => {
+          const r = plan.resumen || {};
+          const pct = r.total ? Math.round((r.cobrado || 0) / r.total * 100) : 0;
+          return (
+            <Paper key={plan._id} variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+              <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" spacing={1.5} alignItems={{ sm: 'center' }}>
+                <Box sx={{ minWidth: 0 }}>
+                  <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                    <Typography variant="subtitle2" fontWeight={700}>{plan.nombre}</Typography>
+                    <Chip size="small" label={plan.estado} color={plan.estado === 'completado' ? 'success' : plan.estado === 'activo' ? 'primary' : 'default'} />
+                    {plan.indexacion && <Chip size="small" variant="outlined" label={plan.indexacion === 'manual' ? 'Ajuste manual' : plan.indexacion} />}
+                  </Stack>
+                  <Typography variant="caption" color="text.secondary">
+                    {r.cuotas_cobradas || 0}/{r.cuotas_total || 0} cuotas · {plan.cliente_nombre ? `Cliente: ${plan.cliente_nombre}` : 'Sin cliente'}
+                    {r.proxima_cuota?.fecha_vencimiento ? ` · Próxima: ${new Date(r.proxima_cuota.fecha_vencimiento).toLocaleDateString('es-AR')}` : ''}
+                  </Typography>
+                </Box>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  endIcon={<OpenInNewIcon fontSize="small" />}
+                  onClick={() => router.push(`/cobros/${plan._id}`)}
+                >
+                  Ver plan
+                </Button>
+              </Stack>
+
+              <Stack direction="row" spacing={3} mt={1.5} flexWrap="wrap">
+                <Metric label="Total" value={money(r.total, plan.moneda)} />
+                <Metric label="Cobrado" value={money(r.cobrado, plan.moneda)} color="success.main" />
+                <Metric label="Pendiente" value={money(r.pendiente, plan.moneda)} color="error.main" />
+              </Stack>
+
+              <Box mt={1}>
+                <Stack direction="row" justifyContent="space-between" mb={0.5}>
+                  <Typography variant="caption" color="text.secondary">Avance de cobro</Typography>
+                  <Typography variant="caption" fontWeight={600}>{pct}%</Typography>
+                </Stack>
+                <LinearProgress variant="determinate" value={pct} color={plan.estado === 'completado' ? 'success' : 'primary'} sx={{ height: 6, borderRadius: 3 }} />
+              </Box>
+            </Paper>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}
+
+function Metric({ label, value, color }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" display="block">{label}</Typography>
+      <Typography variant="body2" fontWeight={700} color={color}>{value}</Typography>
+    </Box>
+  );
+}

--- a/src/components/controlObra/EditarTareaDrawer.js
+++ b/src/components/controlObra/EditarTareaDrawer.js
@@ -18,6 +18,16 @@ function tareasDeObra(obra, exceptoUid) {
 // solas en el backend (el inicio lo calcula la predecesora).
 export default function EditarTareaDrawer({ obra, subrubro, empresaId, onClose, onDone }) {
   const opciones = useMemo(() => tareasDeObra(obra, subrubro.uid), [obra, subrubro.uid]);
+  // Opciones de categoría/subcategoría a partir de la estructura de la obra (que
+  // viene del catálogo de la empresa cuando el origen es "categorías").
+  const categoriaOpciones = useMemo(() => {
+    const set = new Set();
+    (obra?.rubros || []).forEach((r) => {
+      if (r.categoria) set.add(r.categoria);
+      (r.subrubros || []).forEach((s) => { if (s.categoria) set.add(s.categoria); });
+    });
+    return [...set];
+  }, [obra]);
   const depUids = (subrubro.dependencias || []).map((d) => d.uid);
   // Inicio mostrado = el deseado (inicio_plan). Si la tarea está en modo automático
   // por dependencia, queda vacío (= arranca al terminar la anterior).
@@ -31,9 +41,20 @@ export default function EditarTareaDrawer({ obra, subrubro, empresaId, onClose, 
     fecha_fin: toInput(subrubro.fecha_fin),
     duracion_dias: subrubro.duracion_dias ?? '',
     dependencias: opciones.filter((o) => depUids.includes(o.uid)),
+    categoria: subrubro.categoria || '',
+    subcategoria: subrubro.subcategoria || '',
   });
   const [error, setError] = useState(null);
   const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+
+  // Subcategorías sugeridas: las de la categoría elegida dentro de la obra.
+  const subcategoriaOpciones = useMemo(() => {
+    const set2 = new Set();
+    (obra?.rubros || []).forEach((r) => (r.subrubros || []).forEach((s) => {
+      if (s.subcategoria && (!form.categoria || s.categoria === form.categoria)) set2.add(s.subcategoria);
+    }));
+    return [...set2];
+  }, [obra, form.categoria]);
 
   const tieneDeps = form.dependencias.length > 0;
   const tieneDuracion = form.duracion_dias !== '' && Number(form.duracion_dias) > 0;
@@ -51,6 +72,8 @@ export default function EditarTareaDrawer({ obra, subrubro, empresaId, onClose, 
       // Vacío → arranca al terminar la predecesora. Fin sólo si no hay duración.
       fecha_inicio: form.fecha_inicio || null,
       fecha_fin: tieneDuracion ? undefined : (form.fecha_fin || null),
+      categoria: form.categoria || null,
+      subcategoria: form.subcategoria || null,
     }),
     onSuccess: onDone,
     onError: (e) => setError(e?.response?.data?.error?.message || e.message),
@@ -72,6 +95,28 @@ export default function EditarTareaDrawer({ obra, subrubro, empresaId, onClose, 
         <Stack direction="row" spacing={1}>
           <TextField label="Unidad" value={form.unidad} onChange={(e) => set('unidad', e.target.value)} size="small" sx={{ flex: 1 }} />
           <TextField label="Cantidad" type="number" value={form.cantidad} onChange={(e) => set('cantidad', e.target.value)} size="small" sx={{ flex: 1 }} />
+        </Stack>
+        <Stack direction="row" spacing={1}>
+          <Autocomplete
+            freeSolo
+            options={categoriaOpciones}
+            value={form.categoria}
+            onInputChange={(_, v) => set('categoria', v)}
+            sx={{ flex: 1 }}
+            renderInput={(params) => (
+              <TextField {...params} label="Categoría" size="small" helperText="Para auto-imputar gastos del bot" />
+            )}
+          />
+          <Autocomplete
+            freeSolo
+            options={subcategoriaOpciones}
+            value={form.subcategoria}
+            onInputChange={(_, v) => set('subcategoria', v)}
+            sx={{ flex: 1 }}
+            renderInput={(params) => (
+              <TextField {...params} label="Subcategoría" size="small" />
+            )}
+          />
         </Stack>
 
         <Typography variant="caption" color="text.secondary" sx={{ pt: 0.5 }}>Cronograma</Typography>

--- a/src/components/controlObra/NuevaObraDialog.js
+++ b/src/components/controlObra/NuevaObraDialog.js
@@ -47,6 +47,12 @@ export default function NuevaObraDialog({ open, onClose, empresaId, proyectoId: 
         if (!ppId) throw new Error('Elegí un presupuesto profesional');
         return ControlObraService.crearObra({ empresa_id: empresaId, proyecto_id: proyectoId, perfil, origen: { tipo: 'pp', ref_id: ppId } });
       }
+      if (origen === 'categorias') {
+        if (!titulo) throw new Error('Ingresá un título');
+        return ControlObraService.crearObra({
+          empresa_id: empresaId, proyecto_id: proyectoId, titulo, perfil, origen: { tipo: 'categorias' },
+        });
+      }
       return ControlObraService.crearObra({
         empresa_id: empresaId, proyecto_id: proyectoId, titulo, perfil, origen: { tipo: 'manual' },
         rubros: rubros.map((r) => ({ nombre: r.nombre, subrubros: r.subrubros.filter((s) => s.nombre && s.monto).map((s) => ({ nombre: s.nombre, monto: Number(s.monto) })) })),
@@ -70,10 +76,16 @@ export default function NuevaObraDialog({ open, onClose, empresaId, proyectoId: 
       )}
     >
       <Stack spacing={2}>
-          <ToggleButtonGroup exclusive size="small" value={origen} onChange={(_, v) => v && setOrigen(v)}>
+          <ToggleButtonGroup exclusive size="small" value={origen} onChange={(_, v) => v && setOrigen(v)} sx={{ flexWrap: 'wrap' }}>
             <ToggleButton value="pp">Desde presupuesto profesional</ToggleButton>
+            <ToggleButton value="categorias">Desde categorías</ToggleButton>
             <ToggleButton value="manual">Carga manual</ToggleButton>
           </ToggleButtonGroup>
+          {origen === 'categorias' && (
+            <Typography variant="caption" color="text.secondary">
+              Arma la estructura desde las categorías/subcategorías de la empresa y suma los presupuestos del proyecto. Después podés borrar los rubros que no apliquen.
+            </Typography>
+          )}
 
           <Box>
             <Typography variant="caption" color="text.secondary">Perfil de obra — define indexación CAC, retención y anticipo</Typography>
@@ -112,6 +124,10 @@ export default function NuevaObraDialog({ open, onClose, empresaId, proyectoId: 
             >
               {pps.map((p) => <MenuItem key={p._id} value={p._id}>{p.titulo || '(sin título)'} · {(p.total_neto || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 })}</MenuItem>)}
             </TextField>
+          )}
+
+          {origen === 'categorias' && (
+            <TextField label="Título" value={titulo} onChange={(e) => setTitulo(e.target.value)} fullWidth />
           )}
 
           {origen === 'manual' && (

--- a/src/components/controlObra/ResumenTab.js
+++ b/src/components/controlObra/ResumenTab.js
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { Box, Divider, Paper, Stack, Typography } from '@mui/material';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Box, Divider, Paper, Stack, Typography, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { LineChart } from '@mui/x-charts/LineChart';
 import DashboardIcon from '@mui/icons-material/Dashboard';
@@ -13,6 +13,11 @@ import { KpiCard, fmt, fmtM } from 'src/components/controlObra/ui';
 
 // Tablero de la obra (cockpit): snapshot financiero + qué necesita atención + circuito de plata.
 export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
+  const queryClient = useQueryClient();
+  const modoCobroMut = useMutation({
+    mutationFn: (modo) => ControlObraService.setModoCobro(obra._id, empresaId, modo),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['control-obra'] }),
+  });
   const carteraQ = useQuery({
     queryKey: ['control-obra', 'cartera', empresaId],
     queryFn: () => ControlObraService.resumenCartera(empresaId),
@@ -53,6 +58,26 @@ export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
 
   return (
     <Box>
+      {/* Fase F: cómo se cobra la obra */}
+      <Stack direction="row" alignItems="center" spacing={1.5} mb={2} flexWrap="wrap">
+        <Typography variant="body2" color="text.secondary">Cobro de la obra:</Typography>
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={obra.modo_cobro || 'certificados'}
+          onChange={(_, v) => { if (v) modoCobroMut.mutate(v); }}
+          disabled={modoCobroMut.isPending}
+        >
+          <ToggleButton value="certificados">Por certificados</ToggleButton>
+          <ToggleButton value="plan">Por plan de cobro</ToggleButton>
+        </ToggleButtonGroup>
+        {(obra.modo_cobro === 'plan') && (
+          <Typography variant="caption" color="text.secondary">
+            Los certificados registran avance pero no generan cuotas; el cobro va por el cronograma del plan.
+          </Typography>
+        )}
+      </Stack>
+
       <Stack direction="row" spacing={2} flexWrap="wrap" mb={3} useFlexGap>
         <KpiCard label="Contrato" value={fmtM(total)} sub="presupuesto total" />
         <KpiCard label="Avance físico" value={`${avance.toFixed(1)}%`} sub="ponderado por monto" />

--- a/src/pages/cobros.js
+++ b/src/pages/cobros.js
@@ -22,7 +22,19 @@ import {
   Typography,
   Snackbar,
   Alert,
+  ToggleButton,
+  ToggleButtonGroup,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Chip,
+  LinearProgress,
+  Paper,
 } from '@mui/material';
+import { BarChart } from '@mui/x-charts/BarChart';
+import { LineChart } from '@mui/x-charts/LineChart';
 import AddIcon from '@mui/icons-material/Add';
 import SearchIcon from '@mui/icons-material/Search';
 import InboxIcon from '@mui/icons-material/Inbox';
@@ -65,6 +77,12 @@ const CobrosList = () => {
   const [filtroProyecto, setFiltroProyecto] = useState('');
   const [busqueda, setBusqueda] = useState('');
   const [sortBy, setSortBy] = useState('reciente');
+  const [vista, setVista] = useState('tabla'); // 'cards' | 'tabla'
+  const [seccion, setSeccion] = useState('planes'); // 'planes' | 'cashflow'
+  const [cashflow, setCashflow] = useState({ meses: [], esperado: [], cobrado: [], acumulado: [], kpis: {}, vencido: { monto: 0, cuotas: 0 }, realizado_anterior: 0 });
+  const [cfGranularidad, setCfGranularidad] = useState('adaptativo'); // 'mes' | 'semana' | 'adaptativo'
+  const [cfVista, setCfVista] = useState('grafico'); // 'grafico' | 'tabla'
+  const [cfHistorico, setCfHistorico] = useState(false);
   const [proyectos, setProyectos] = useState([]);
   const [alert, setAlert] = useState({ open: false, message: '', severity: 'info' });
   const [confirmEliminar, setConfirmEliminar] = useState(null); // plan object or null
@@ -76,6 +94,13 @@ const CobrosList = () => {
     });
     getProyectosFromUser(user).then((list) => setProyectos(list || []));
   }, [user]);
+
+  useEffect(() => {
+    if (!empresaId) return;
+    planCobroService.getCashflow(empresaId, filtroProyecto || null, cfGranularidad, { incluirHistorico: cfHistorico })
+      .then((res) => setCashflow(res?.data?.data || {}))
+      .catch(() => setCashflow({ meses: [], esperado: [], cobrado: [] }));
+  }, [empresaId, filtroProyecto, cfGranularidad, cfHistorico]);
 
   const filterParams = filtroEstado ? { estado: filtroEstado } : {};
   const { planes, loading, error, refresh } = usePlanesCobroList(empresaId, filterParams);
@@ -133,6 +158,143 @@ const CobrosList = () => {
             </Button>
           </Stack>
 
+          {/* KPIs de situación — siempre visibles, en cualquier tab */}
+          {(() => {
+            const k = cashflow.kpis || {};
+            const venc = cashflow.vencido || { monto: 0, cuotas: 0 };
+            const money = (n) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 });
+            const items = [
+              { label: 'Vencido', value: money(venc.monto), border: '#D32F2F', danger: true, sub: venc.cuotas ? `${venc.cuotas} cuota${venc.cuotas > 1 ? 's' : ''}` : 'al día' },
+              { label: 'A cobrar este mes', value: money(k.periodo_actual), border: '#1976D2' },
+              { label: 'Próximos 90 días', value: money(k.proximos_90), border: '#2E7D32' },
+            ];
+            return (
+              <Grid container spacing={2} mb={3}>
+                {items.map((m) => (
+                  <Grid item xs={12} sm={4} key={m.label}>
+                    <Paper variant="outlined" sx={{ p: 1.5, borderTop: `3px solid ${m.border}`, bgcolor: m.danger && venc.monto > 0 ? '#FFF5F5' : 'background.paper' }}>
+                      <Typography variant="overline" color="text.secondary" display="block">{m.label}</Typography>
+                      <Typography variant="h6" fontWeight={700} color={m.danger && venc.monto > 0 ? 'error.main' : 'text.primary'}>{m.value}</Typography>
+                      {m.sub && <Typography variant="caption" color="text.secondary">{m.sub}</Typography>}
+                    </Paper>
+                  </Grid>
+                ))}
+              </Grid>
+            );
+          })()}
+
+          <ToggleButtonGroup
+            value={seccion}
+            exclusive
+            size="small"
+            onChange={(_, v) => v && setSeccion(v)}
+            sx={{ mb: 3 }}
+          >
+            <ToggleButton value="planes">Planes</ToggleButton>
+            <ToggleButton value="cashflow">Cashflow</ToggleButton>
+          </ToggleButtonGroup>
+
+          {seccion === 'cashflow' && (() => {
+            const money = (n) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 });
+            const k = cashflow.kpis || {};
+            const venc = cashflow.vencido || { monto: 0, cuotas: 0 };
+            const periodoLabel = cfGranularidad === 'semana' ? 'semana' : cfGranularidad === 'adaptativo' ? 'período' : 'mes';
+            return (
+            <Box sx={{ mb: 3 }}>
+              <Stack direction="row" spacing={2} mb={2} flexWrap="wrap" alignItems="center" useFlexGap>
+                <ToggleButtonGroup value={cfGranularidad} exclusive size="small" onChange={(_, v) => v && setCfGranularidad(v)}>
+                  <ToggleButton value="adaptativo">Auto</ToggleButton>
+                  <ToggleButton value="mes">Mes</ToggleButton>
+                  <ToggleButton value="semana">Semana</ToggleButton>
+                </ToggleButtonGroup>
+                <ToggleButtonGroup value={cfVista} exclusive size="small" onChange={(_, v) => v && setCfVista(v)}>
+                  <ToggleButton value="grafico">Gráfico</ToggleButton>
+                  <ToggleButton value="tabla">Tabla</ToggleButton>
+                </ToggleButtonGroup>
+                <ToggleButton
+                  value="hist"
+                  selected={cfHistorico}
+                  size="small"
+                  onChange={() => setCfHistorico((v) => !v)}
+                >
+                  {cfHistorico ? 'Ocultar histórico' : 'Ver histórico'}
+                </ToggleButton>
+                {cfGranularidad === 'adaptativo' && (
+                  <Typography variant="caption" color="text.secondary">Próximas 8 semanas al detalle, luego por mes</Typography>
+                )}
+              </Stack>
+
+              {(cashflow.meses || []).length === 0 ? (
+                <Typography variant="body2" color="text.secondary">Sin cobros proyectados en la ventana. Probá "Ver histórico".</Typography>
+              ) : (
+                <Paper variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+                  {!cfHistorico && cashflow.realizado_anterior > 0 && (
+                    <Typography variant="caption" color="text.secondary" display="block" mb={1}>
+                      Realizado antes de la ventana: {money(cashflow.realizado_anterior)} (colapsado)
+                    </Typography>
+                  )}
+                  {cfVista === 'grafico' ? (
+                    <Box sx={{ overflowX: 'auto' }}>
+                      <BarChart
+                        height={280}
+                        xAxis={[{ scaleType: 'band', data: cashflow.meses }]}
+                        series={[
+                          { data: cashflow.esperado, label: 'Esperado', color: '#90A4D4' },
+                          { data: cashflow.cobrado, label: 'Cobrado', color: '#2E7D32' },
+                        ]}
+                      />
+                      {/* Curva de saldo acumulado (#4) */}
+                      <Typography variant="caption" color="text.secondary" sx={{ mt: 1 }}>Saldo acumulado proyectado</Typography>
+                      <LineChart
+                        height={200}
+                        xAxis={[{ scaleType: 'point', data: cashflow.meses }]}
+                        series={[{ data: cashflow.acumulado || [], label: 'Acumulado', color: '#1976D2', area: true, showMark: false }]}
+                      />
+                    </Box>
+                  ) : (
+                    <Box sx={{ overflowX: 'auto' }}>
+                      <Table size="small">
+                        <TableHead>
+                          <TableRow>
+                            <TableCell>{periodoLabel === 'semana' ? 'Semana' : periodoLabel === 'período' ? 'Período' : 'Mes'}</TableCell>
+                            <TableCell align="right">Esperado</TableCell>
+                            <TableCell align="right">Cobrado</TableCell>
+                            <TableCell align="right">Total período</TableCell>
+                            <TableCell align="right">Acumulado</TableCell>
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {cashflow.meses.map((m, i) => {
+                            const esp = cashflow.esperado[i] || 0;
+                            const cob = cashflow.cobrado[i] || 0;
+                            return (
+                              <TableRow key={m}>
+                                <TableCell>{m}</TableCell>
+                                <TableCell align="right">{money(esp)}</TableCell>
+                                <TableCell align="right" sx={{ color: 'success.main' }}>{money(cob)}</TableCell>
+                                <TableCell align="right" sx={{ fontWeight: 700 }}>{money(esp + cob)}</TableCell>
+                                <TableCell align="right" sx={{ color: 'primary.main' }}>{money((cashflow.acumulado || [])[i])}</TableCell>
+                              </TableRow>
+                            );
+                          })}
+                          <TableRow>
+                            <TableCell sx={{ fontWeight: 700 }}>Total ventana</TableCell>
+                            <TableCell align="right" sx={{ fontWeight: 700 }}>{money((cashflow.esperado || []).reduce((a, b) => a + b, 0))}</TableCell>
+                            <TableCell align="right" sx={{ fontWeight: 700, color: 'success.main' }}>{money((cashflow.cobrado || []).reduce((a, b) => a + b, 0))}</TableCell>
+                            <TableCell colSpan={2} />
+                          </TableRow>
+                        </TableBody>
+                      </Table>
+                    </Box>
+                  )}
+                </Paper>
+              )}
+            </Box>
+            );
+          })()}
+
+          {seccion === 'planes' && (
+          <>
           <Stack direction="row" spacing={2} mb={3} alignItems="center" flexWrap="wrap" useFlexGap>
             <TextField
               size="small"
@@ -190,6 +352,15 @@ const CobrosList = () => {
                 ))}
               </Select>
             </FormControl>
+            <ToggleButtonGroup
+              value={vista}
+              exclusive
+              size="small"
+              onChange={(_, v) => v && setVista(v)}
+            >
+              <ToggleButton value="cards">Tarjetas</ToggleButton>
+              <ToggleButton value="tabla">Tabla</ToggleButton>
+            </ToggleButtonGroup>
           </Stack>
 
           {/* Skeleton loading */}
@@ -229,7 +400,7 @@ const CobrosList = () => {
             </Box>
           )}
 
-          {!loading && planesFiltrados.length > 0 && (
+          {!loading && planesFiltrados.length > 0 && vista === 'cards' && (
             <Grid container spacing={2}>
               {planesFiltrados.map((plan) => (
                 <Grid item xs={12} sm={6} md={4} lg={3} key={plan._id}>
@@ -241,6 +412,66 @@ const CobrosList = () => {
                 </Grid>
               ))}
             </Grid>
+          )}
+
+          {!loading && planesFiltrados.length > 0 && vista === 'tabla' && (
+            <Box sx={{ overflowX: 'auto', border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+              <Table size="small" stickyHeader>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Plan</TableCell>
+                    <TableCell>Cliente</TableCell>
+                    <TableCell>Proyecto</TableCell>
+                    <TableCell align="right">Total</TableCell>
+                    <TableCell align="right">Cobrado</TableCell>
+                    <TableCell align="right">Pendiente</TableCell>
+                    <TableCell align="center">Avance</TableCell>
+                    <TableCell>Próxima</TableCell>
+                    <TableCell align="center">Estado</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {planesFiltrados.map((plan) => {
+                    const r = plan.resumen || {};
+                    const pct = r.total ? Math.round((r.cobrado || 0) / r.total * 100) : 0;
+                    const money = (n) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: plan.moneda === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
+                    return (
+                      <TableRow
+                        key={plan._id}
+                        hover
+                        sx={{ cursor: 'pointer' }}
+                        onClick={() => router.push(`/cobros/${plan._id}`)}
+                      >
+                        <TableCell>{plan.nombre}</TableCell>
+                        <TableCell>{plan.cliente_nombre || '—'}</TableCell>
+                        <TableCell>{plan.proyecto_nombre || '—'}</TableCell>
+                        <TableCell align="right">{money(r.total)}</TableCell>
+                        <TableCell align="right">{money(r.cobrado)}</TableCell>
+                        <TableCell align="right">{money(r.pendiente)}</TableCell>
+                        <TableCell align="center" sx={{ minWidth: 90 }}>
+                          <LinearProgress variant="determinate" value={pct} sx={{ height: 6, borderRadius: 3 }} />
+                          <Typography variant="caption" color="text.secondary">{pct}%</Typography>
+                        </TableCell>
+                        <TableCell>
+                          {r.proxima_cuota?.fecha_vencimiento
+                            ? new Date(r.proxima_cuota.fecha_vencimiento).toLocaleDateString('es-AR')
+                            : '—'}
+                        </TableCell>
+                        <TableCell align="center">
+                          <Chip
+                            size="small"
+                            label={plan.estado}
+                            color={plan.estado === 'completado' ? 'success' : plan.estado === 'activo' ? 'primary' : 'default'}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </Box>
+          )}
+          </>
           )}
         </Container>
       </Box>

--- a/src/pages/cobros/[id].js
+++ b/src/pages/cobros/[id].js
@@ -6,6 +6,7 @@ import {
   Button,
   Chip,
   CircularProgress,
+  Collapse,
   Container,
   Dialog,
   DialogActions,
@@ -23,6 +24,7 @@ import {
   TextField,
   ToggleButton,
   ToggleButtonGroup,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -35,6 +37,7 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import FolderIcon from '@mui/icons-material/Folder';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
@@ -58,11 +61,16 @@ const DetallePlanPage = () => {
   const [reverting, setReverting] = useState(null);
   const [tipoCobro, setTipoCobro] = useState('total'); // 'total' | 'parcial'
   const [montoParcial, setMontoParcial] = useState('');
+  const [modoCobro, setModoCobro] = useState('nuevo'); // 'nuevo' | 'vincular' | 'solo_estado'
+  const [movVinculables, setMovVinculables] = useState([]);
+  const [movSel, setMovSel] = useState(null);
 
   // Edit cuota dialog
   const [editCuota, setEditCuota] = useState(null); // cuota object or null
   const [editForm, setEditForm] = useState({ monto: '', fecha_vencimiento: '', descripcion: '' });
   const [editCacInput, setEditCacInput] = useState(''); // CAC units input para planes indexados
+  const [editCacRef, setEditCacRef] = useState(null); // override del índice de referencia (cac_indice_ref)
+  const [editCacRefMes, setEditCacRefMes] = useState(''); // mes YYYY-MM para buscar el índice publicado
 
   // Delete cuota dialog
   const [deleteCuota, setDeleteCuota] = useState(null);
@@ -71,9 +79,23 @@ const DetallePlanPage = () => {
   // Add cuota dialog
   const [showAddCuota, setShowAddCuota] = useState(false);
   const [addForm, setAddForm] = useState({ monto: '', fecha_vencimiento: '', descripcion: '' });
+  const [addUnidades, setAddUnidades] = useState(''); // unidades CAC/USD en el diálogo de agregar (planes indexados)
   // CAC actual para planes indexados — se usa para calcular el valor en pesos ajustado
   const [cacActual, setCacActual] = useState(null);
   const [usdActual, setUsdActual] = useState(null);
+  // A2 (TAR-466 pt.1): desplegar el detalle de cuotas que componen el total cobrado
+  const [showCobradoDetail, setShowCobradoDetail] = useState(false);
+  // Fase 4 — edición de total y saldo sin asignar
+  const [showEditTotal, setShowEditTotal] = useState(false);
+  const [editTotalValue, setEditTotalValue] = useState('');
+  const [showAsignarSaldo, setShowAsignarSaldo] = useState(false);
+  const [savingSaldo, setSavingSaldo] = useState(false);
+  // Fase 5 — ajuste manual periódico
+  const [showAjuste, setShowAjuste] = useState(false);
+  const [ajustePct, setAjustePct] = useState('');
+  // Anexos (Fase 6 ronda 2)
+  const [showAnexo, setShowAnexo] = useState(false);
+  const [anexoForm, setAnexoForm] = useState({ monto: '', motivo: '', modo: 'prorratear' });
 
   useEffect(() => {
     if (!user) return;
@@ -123,11 +145,27 @@ const DetallePlanPage = () => {
     return cuota.monto || 0;
   };
 
+  // A3 (TAR-466 pt.2): para cuotas ya cobradas mostramos el monto REAL cobrado,
+  // no el valor ajustado al índice de hoy (que confunde: parece cobrado de más).
+  const getMontoDisplay = (cuota) => {
+    if (!cuota) return 0;
+    if (cuota.estado === 'cobrada') return cuota.monto_cobrado || 0;
+    return getMontoCuota(cuota);
+  };
+  // ¿La cuota cobrada tiene un valor "actualizado a hoy" distinto al real? (para tooltip)
+  const getValorActualizado = (cuota) => (cuota?.estado === 'cobrada' ? getMontoCuota(cuota) : null);
+
   const handleCobrarClick = (cuotaId) => {
     const cuota = (plan.cuotas || []).find((c) => c._id === cuotaId);
     setConfirmCobrar(cuota || { _id: cuotaId });
     setTipoCobro('total');
     setMontoParcial('');
+    setModoCobro('nuevo');
+    setMovSel(null);
+    // Precargar movimientos vinculables (por si el usuario elige "vincular")
+    planCobroService.listarMovimientosVinculables(empresaId, plan?.proyecto_id)
+      .then((res) => setMovVinculables(res?.data?.data || []))
+      .catch(() => setMovVinculables([]));
   };
 
   const handleCobrarConfirm = async () => {
@@ -135,20 +173,30 @@ const DetallePlanPage = () => {
     const cuotaId = confirmCobrar._id;
     const parcial = tipoCobro === 'parcial' ? parseNumberInput(montoParcial) : null;
     if (tipoCobro === 'parcial' && (!parcial || Number(parcial) <= 0)) return;
+    if (modoCobro === 'vincular' && !movSel) {
+      setAlert({ open: true, message: 'Elegí un movimiento para vincular', severity: 'warning' });
+      return;
+    }
     setConfirmCobrar(null);
     setCobrandoId(cuotaId);
     try {
       await marcarCobrada(cuotaId, {
         fecha_cobrado: new Date().toISOString().split('T')[0],
         monto_parcial: parcial ? Number(parcial) : undefined,
+        modo: modoCobro,
+        movimiento_id: modoCobro === 'vincular' ? movSel?._id : undefined,
       });
       await refresh();
-      const msg = tipoCobro === 'parcial'
-        ? 'Pago parcial registrado.'
-        : 'Cuota cobrada. Movimiento de caja registrado.';
+      const msg = modoCobro === 'vincular'
+        ? 'Cuota cobrada vinculando el movimiento existente.'
+        : modoCobro === 'solo_estado'
+          ? 'Cuota marcada como cobrada (sin movimiento de caja).'
+          : tipoCobro === 'parcial'
+            ? 'Pago parcial registrado.'
+            : 'Cuota cobrada. Movimiento de caja registrado.';
       setAlert({ open: true, message: msg, severity: 'success' });
     } catch (err) {
-      setAlert({ open: true, message: err.message || 'Error al marcar cuota', severity: 'error' });
+      setAlert({ open: true, message: err?.response?.data?.error || err.message || 'Error al marcar cuota', severity: 'error' });
     } finally {
       setCobrandoId(null);
     }
@@ -169,17 +217,38 @@ const DetallePlanPage = () => {
 
   const handleEditClick = (cuota) => {
     setEditCuota(cuota);
-    // Para planes CAC usamos el monto ajustado al índice actual; si no cargó aún, usamos nominal
+    // El monto persistido (cuota.monto) es el nominal al índice BASE del plan
+    // (monto_cac × cac_indice_base). Editamos contra esa base, no contra el índice de hoy,
+    // para que las unidades CAC queden consistentes con la creación del plan.
     const esCac = plan?.indexacion === 'CAC' && cuota.monto_cac;
-    const montoArs = esCac ? getMontoCuota(cuota) : (cuota.monto || 0);
     setEditForm({
-      monto: String(montoArs),
+      monto: String(cuota.monto || 0),
       fecha_vencimiento: cuota.fecha_vencimiento
         ? new Date(cuota.fecha_vencimiento).toISOString().split('T')[0]
         : '',
       descripcion: cuota.descripcion || '',
     });
     setEditCacInput(esCac ? String(Math.round(cuota.monto_cac * 100) / 100) : '');
+    setEditCacRef(cuota.cac_indice_ref || null);
+    setEditCacRefMes('');
+  };
+
+  // Al elegir un mes, busca el índice CAC publicado y lo fija como referencia de la cuota.
+  const handleEditCacRefMes = async (mes) => {
+    setEditCacRefMes(mes);
+    if (!mes) { setEditCacRef(null); return; }
+    try {
+      const res = await planCobroService.previewCAC(`${mes}-01`, plan?.cac_tipo || 'general');
+      const idx = res?.data?.data?.cac_indice || null;
+      if (idx) {
+        setEditCacRef(idx);
+        // Mantiene los pesos pactados y recalcula las unidades contra la nueva referencia.
+        const pesos = parseFloat(parseNumberInput(editForm.monto));
+        if (!isNaN(pesos)) setEditCacInput(String(Math.round((pesos / idx) * 100) / 100));
+      }
+    } catch {
+      /* si falla el preview, se mantiene la referencia base */
+    }
   };
 
   const handleEditConfirm = async () => {
@@ -192,6 +261,7 @@ const DetallePlanPage = () => {
       await editarCuota(editCuota._id, {
         monto: Number(montoNum),
         ...(esCacPlan && cacNum > 0 ? { monto_cac: cacNum } : {}),
+        ...(esCacPlan ? { cac_indice_ref: editCacRef || null } : {}),
         fecha_vencimiento: editForm.fecha_vencimiento || undefined,
         descripcion: editForm.descripcion || undefined,
       });
@@ -199,6 +269,76 @@ const DetallePlanPage = () => {
       setAlert({ open: true, message: 'Cuota actualizada', severity: 'success' });
     } catch (err) {
       setAlert({ open: true, message: err.message || 'Error al editar cuota', severity: 'error' });
+    }
+  };
+
+  // ─── Fase 4: total + saldo sin asignar ───────────────────────────────────────
+  const handleEditTotalConfirm = async () => {
+    const val = parseNumberInput(editTotalValue);
+    if (!val || Number(val) <= 0) return;
+    setSavingSaldo(true);
+    try {
+      await planCobroService.editarPlan(id, { empresa_id: empresaId, monto_total: Number(val) });
+      setShowEditTotal(false);
+      await refresh();
+      setAlert({ open: true, message: 'Total del plan actualizado', severity: 'success' });
+    } catch (err) {
+      setAlert({ open: true, message: err?.response?.data?.error || 'Error al editar total', severity: 'error' });
+    } finally {
+      setSavingSaldo(false);
+    }
+  };
+
+  const runSaldoAction = async (fn, okMsg) => {
+    setSavingSaldo(true);
+    try {
+      await fn();
+      setShowAsignarSaldo(false);
+      await refresh();
+      setAlert({ open: true, message: okMsg, severity: 'success' });
+    } catch (err) {
+      setAlert({ open: true, message: err?.response?.data?.error || 'Error al resolver el saldo', severity: 'error' });
+    } finally {
+      setSavingSaldo(false);
+    }
+  };
+
+  const handleAplicarAjuste = async () => {
+    const pct = parseFloat(String(ajustePct).replace(',', '.'));
+    if (isNaN(pct)) return;
+    setSavingSaldo(true);
+    try {
+      await planCobroService.aplicarAjusteManual(id, { empresa_id: empresaId, pct });
+      setShowAjuste(false);
+      setAjustePct('');
+      await refresh();
+      setAlert({ open: true, message: 'Ajuste aplicado a las cuotas pendientes', severity: 'success' });
+    } catch (err) {
+      setAlert({ open: true, message: err?.response?.data?.error || 'Error al aplicar el ajuste', severity: 'error' });
+    } finally {
+      setSavingSaldo(false);
+    }
+  };
+
+  const handleAnexoConfirm = async () => {
+    const montoNum = parseFloat(parseNumberInput(anexoForm.monto));
+    if (!montoNum) return;
+    setSavingSaldo(true);
+    try {
+      await planCobroService.agregarAnexo(id, {
+        empresa_id: empresaId,
+        monto: montoNum,
+        motivo: anexoForm.motivo || undefined,
+        modo: anexoForm.modo,
+      });
+      setShowAnexo(false);
+      setAnexoForm({ monto: '', motivo: '', modo: 'prorratear' });
+      await refresh();
+      setAlert({ open: true, message: 'Anexo aplicado', severity: 'success' });
+    } catch (err) {
+      setAlert({ open: true, message: err?.response?.data?.error || 'Error al aplicar el anexo', severity: 'error' });
+    } finally {
+      setSavingSaldo(false);
     }
   };
 
@@ -216,14 +356,17 @@ const DetallePlanPage = () => {
   const handleAddConfirm = async () => {
     const montoNum = parseNumberInput(addForm.monto);
     if (!montoNum || Number(montoNum) <= 0) return;
+    const cacNum = plan?.indexacion === 'CAC' ? parseFloat(String(addUnidades).replace(',', '.')) : null;
     try {
       await agregarCuota({
         monto: Number(montoNum),
+        ...(cacNum > 0 ? { monto_cac: cacNum } : {}),
         fecha_vencimiento: addForm.fecha_vencimiento || undefined,
         descripcion: addForm.descripcion || undefined,
       });
       setShowAddCuota(false);
       setAddForm({ monto: '', fecha_vencimiento: '', descripcion: '' });
+      setAddUnidades('');
       setAlert({ open: true, message: 'Cuota agregada', severity: 'success' });
     } catch (err) {
       setAlert({ open: true, message: err.message || 'Error al agregar cuota', severity: 'error' });
@@ -307,6 +450,10 @@ const DetallePlanPage = () => {
     resumen.total > 0 ? Math.round(((resumen.cobrado || 0) / resumen.total) * 100) : 0;
   const showCAC = !!plan.indexacion;
   const cacIndiceBase = plan.cotizacion_snapshot?.cac_indice || null;
+  const usdIndiceBase = plan.cotizacion_snapshot?.dolar_indice || null;
+  // Índice base efectivo para el diálogo de agregar cuota (CAC o USD).
+  const addIndiceBase = plan.indexacion === 'CAC' ? cacIndiceBase : plan.indexacion === 'USD' ? usdIndiceBase : null;
+  const addUnidadLabel = plan.indexacion === 'CAC' ? 'CAC' : 'USD';
   const isCuotaVencida = (cuota) => cuota?.estado_ui === 'vencida' || cuota?.estado_ui === 'cobrada_parcial_vencida';
   const cuotasOrdenadas = [...allCuotas].sort((a, b) => {
     const numeroA = Number(a?.numero || 0);
@@ -332,12 +479,14 @@ const DetallePlanPage = () => {
       (plan.indexacion === 'USD' && !!usdActual) ||
       (plan.indexacion !== 'USD' && !!cacActual)
     );
-  const totalAjustado = hasIndiceActual
-    ? allCuotas.reduce((acc, c) => acc + getMontoCuota(c), 0)
-    : null;
+  // Pendiente = lo que resta cobrar de cuotas no saldadas, a valor actualizado.
   const pendienteAjustado = hasIndiceActual
-    ? allCuotas.filter((c) => c.estado !== 'cobrada').reduce((acc, c) => acc + getMontoCuota(c), 0)
+    ? allCuotas
+        .filter((c) => c.estado !== 'cobrada')
+        .reduce((acc, c) => acc + Math.max(0, getMontoCuota(c) - (c.monto_cobrado || 0)), 0)
     : null;
+  // Total = cobrado REAL + pendiente actualizado (no reajusta lo ya cobrado a valor de hoy).
+  const totalAjustado = hasIndiceActual ? (resumen.cobrado || 0) + pendienteAjustado : null;
 
   return (
     <>
@@ -406,6 +555,26 @@ const DetallePlanPage = () => {
               >
                 Exportar PDF
               </Button>
+              {plan.estado === 'activo' && (
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<EditIcon />}
+                  onClick={() => { setEditTotalValue(String(plan.monto_total || resumen.total || '')); setShowEditTotal(true); }}
+                >
+                  Editar total
+                </Button>
+              )}
+              {plan.estado === 'activo' && plan.indexacion === 'manual' && (
+                <Button variant="outlined" size="small" onClick={() => setShowAjuste(true)}>
+                  Aplicar ajuste
+                </Button>
+              )}
+              {plan.estado === 'activo' && (
+                <Button variant="outlined" size="small" onClick={() => setShowAnexo(true)}>
+                  Agregar anexo
+                </Button>
+              )}
               {plan.estado === 'borrador' && (
                 <>
                   <Button
@@ -455,6 +624,7 @@ const DetallePlanPage = () => {
                 value: formatCurrency(resumen.cobrado || 0, monedaDisplay),
                 borderColor: '#2E7D32',
                 subtitle: `${cuotasCobradas} de ${totalCuotas} cuotas`,
+                expandable: cuotasCobradas > 0,
               },
               {
                 label: 'PENDIENTE',
@@ -466,10 +636,13 @@ const DetallePlanPage = () => {
               <Grid item xs={12} sm={4} key={m.label}>
                 <Paper
                   variant="outlined"
+                  onClick={m.expandable ? () => setShowCobradoDetail((v) => !v) : undefined}
                   sx={{
                     p: 2,
                     textAlign: 'center',
                     borderTop: `3px solid ${m.borderColor}`,
+                    cursor: m.expandable ? 'pointer' : 'default',
+                    '&:hover': m.expandable ? { bgcolor: 'grey.50' } : undefined,
                   }}
                 >
                   <Typography variant="overline" color="text.secondary" display="block">
@@ -483,10 +656,165 @@ const DetallePlanPage = () => {
                       {m.subtitle}
                     </Typography>
                   )}
+                  {m.expandable && (
+                    <Stack direction="row" spacing={0.5} justifyContent="center" alignItems="center" mt={0.5}>
+                      <Typography variant="caption" color="success.main" fontWeight={600}>
+                        {showCobradoDetail ? 'Ocultar detalle' : 'Ver detalle'}
+                      </Typography>
+                      <KeyboardArrowDownIcon
+                        sx={{
+                          fontSize: 16,
+                          color: 'success.main',
+                          transition: 'transform 0.2s',
+                          transform: showCobradoDetail ? 'rotate(180deg)' : 'none',
+                        }}
+                      />
+                    </Stack>
+                  )}
                 </Paper>
               </Grid>
             ))}
           </Grid>
+
+          {/* A2: detalle de cuotas cobradas que componen el total */}
+          <Collapse in={showCobradoDetail} unmountOnExit>
+            <Paper variant="outlined" sx={{ p: 2, mb: 3, borderRadius: 2 }}>
+              <Typography variant="subtitle2" fontWeight={700} mb={1}>
+                Detalle de lo cobrado
+              </Typography>
+              <Stack spacing={0.75}>
+                {allCuotas
+                  .filter((c) => c.monto_cobrado > 0)
+                  .sort((a, b) => new Date(a.fecha_cobrado || 0) - new Date(b.fecha_cobrado || 0))
+                  .map((c) => {
+                    const actualizado = getValorActualizado(c);
+                    const mostrarActualizado =
+                      actualizado != null && Math.abs(actualizado - (c.monto_cobrado || 0)) > 1;
+                    return (
+                      <Stack
+                        key={c._id}
+                        direction="row"
+                        justifyContent="space-between"
+                        alignItems="center"
+                        sx={{ py: 0.5, borderBottom: '1px solid', borderColor: 'divider' }}
+                      >
+                        <Box>
+                          <Typography variant="body2" fontWeight={600}>
+                            Cuota {c.numero}
+                            {c.estado === 'cobrada_parcial' ? ' (parcial)' : ''}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {c.fecha_cobrado
+                              ? `Cobrada: ${new Date(c.fecha_cobrado).toLocaleDateString('es-AR')}`
+                              : 'Sin fecha de cobro'}
+                            {c.descripcion ? ` · ${c.descripcion}` : ''}
+                          </Typography>
+                        </Box>
+                        <Stack alignItems="flex-end">
+                          <Typography variant="body2" fontWeight={700}>
+                            {formatCurrency(c.monto_cobrado || 0, monedaDisplay)}
+                          </Typography>
+                          {mostrarActualizado && (
+                            <Typography variant="caption" color="text.secondary">
+                              Valor actualizado hoy: {formatCurrency(actualizado, monedaDisplay)}
+                            </Typography>
+                          )}
+                          {(c.movimientos || []).map((m) => (
+                            <Typography key={m._id} variant="caption" color="text.secondary">
+                              {m.codigo_operacion ? `#${m.codigo_operacion} · ` : ''}
+                              {m.fecha ? new Date(m.fecha).toLocaleDateString('es-AR') : 's/f'}
+                              {' · '}
+                              {formatCurrency(m.monto || 0, m.moneda || monedaDisplay)}
+                              {m.proyecto_nombre ? ` · ${m.proyecto_nombre}` : ''}
+                            </Typography>
+                          ))}
+                        </Stack>
+                      </Stack>
+                    );
+                  })}
+                <Stack direction="row" justifyContent="space-between" sx={{ pt: 0.5 }}>
+                  <Typography variant="body2" fontWeight={700}>Total cobrado</Typography>
+                  <Typography variant="body2" fontWeight={700} color="success.main">
+                    {formatCurrency(resumen.cobrado || 0, monedaDisplay)}
+                  </Typography>
+                </Stack>
+              </Stack>
+            </Paper>
+          </Collapse>
+
+          {/* Fase 4: saldo sin asignar (solo plan activo) */}
+          {plan.estado === 'activo' && resumen.hay_saldo && (
+            <Paper
+              variant="outlined"
+              sx={{ p: 2, mb: 3, borderRadius: 2, borderColor: '#FFB74D', bgcolor: '#FFF8E1' }}
+            >
+              <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ sm: 'center' }} spacing={1.5}>
+                <Box>
+                  <Typography variant="subtitle2" fontWeight={700}>
+                    Saldo sin asignar: {formatCurrency(resumen.saldo_sin_asignar, monedaDisplay)}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {resumen.saldo_sin_asignar > 0
+                      ? 'El total del plan es mayor a lo distribuido en cuotas.'
+                      : 'Las cuotas suman más que el total del plan.'}
+                  </Typography>
+                </Box>
+                <Stack direction="row" spacing={1} flexWrap="wrap">
+                  <Button size="small" variant="outlined" onClick={() => setShowAsignarSaldo(true)}>
+                    Asignar a una cuota
+                  </Button>
+                  {resumen.saldo_sin_asignar > 0 && (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      disabled={savingSaldo}
+                      onClick={() => runSaldoAction(
+                        () => planCobroService.agregarCuotaDesdeSaldo(id, { empresa_id: empresaId }),
+                        'Cuota creada con el saldo',
+                      )}
+                    >
+                      Crear cuota nueva
+                    </Button>
+                  )}
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    color="warning"
+                    disabled={savingSaldo}
+                    onClick={() => runSaldoAction(
+                      () => planCobroService.ajustarTotalAlDistribuido(id, empresaId),
+                      'Total ajustado a lo distribuido',
+                    )}
+                  >
+                    Achicar plan al distribuido
+                  </Button>
+                </Stack>
+              </Stack>
+            </Paper>
+          )}
+
+          {/* Historial de anexos */}
+          {(plan.anexos || []).length > 0 && (
+            <Paper variant="outlined" sx={{ p: 2, mb: 3, borderRadius: 2 }}>
+              <Typography variant="subtitle2" fontWeight={700} mb={1}>Anexos</Typography>
+              <Stack spacing={0.5}>
+                {(plan.anexos || []).map((a) => (
+                  <Stack key={a.id} direction="row" justifyContent="space-between" alignItems="center"
+                    sx={{ py: 0.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+                    <Box>
+                      <Typography variant="body2">{a.motivo || 'Anexo'}</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {a.fecha ? new Date(a.fecha).toLocaleDateString('es-AR') : ''} · {a.modo === 'nueva_cuota' ? 'cuota nueva' : 'prorrateado'}
+                      </Typography>
+                    </Box>
+                    <Typography variant="body2" fontWeight={700} color={a.monto >= 0 ? 'success.main' : 'error.main'}>
+                      {a.monto >= 0 ? '+' : ''}{formatCurrency(a.monto, monedaDisplay)}
+                    </Typography>
+                  </Stack>
+                ))}
+              </Stack>
+            </Paper>
+          )}
 
           {/* Barra de progreso */}
           <Box mb={4}>
@@ -750,9 +1078,21 @@ const DetallePlanPage = () => {
                           </Typography>
                         </Box>
                         <Stack alignItems={{ xs: 'flex-start', sm: 'flex-end' }} spacing={0.75}>
-                          <Typography variant="body2" fontWeight={700}>
-                            {formatCurrency(getMontoCuota(cuota), monedaDisplay)}
-                          </Typography>
+                          {(() => {
+                            const actualizado = getValorActualizado(cuota);
+                            const mostrarTooltip =
+                              actualizado != null && Math.abs(actualizado - (cuota.monto_cobrado || 0)) > 1;
+                            const montoTxt = (
+                              <Typography variant="body2" fontWeight={700}>
+                                {formatCurrency(getMontoDisplay(cuota), monedaDisplay)}
+                              </Typography>
+                            );
+                            return mostrarTooltip ? (
+                              <Tooltip title={`Valor actualizado a hoy: ${formatCurrency(actualizado, monedaDisplay)}`}>
+                                {montoTxt}
+                              </Tooltip>
+                            ) : montoTxt;
+                          })()}
                           {plan.estado === 'activo' && (
                             <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent={{ sm: 'flex-end' }}>
                               {esCobrada || esParcial ? (
@@ -854,8 +1194,57 @@ const DetallePlanPage = () => {
                   />
                 )}
 
+                {/* Modo: crear ingreso, vincular uno existente, o solo estado */}
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 2 }}>
+                  ¿Cómo lo registramos?
+                </Typography>
+                <ToggleButtonGroup
+                  value={modoCobro}
+                  exclusive
+                  onChange={(_, val) => { if (val) { setModoCobro(val); setMovSel(null); } }}
+                  size="small"
+                  sx={{ mt: 0.5, flexWrap: 'wrap' }}
+                >
+                  <ToggleButton value="nuevo">Nuevo ingreso</ToggleButton>
+                  <ToggleButton value="vincular">Vincular pago existente</ToggleButton>
+                  <ToggleButton value="solo_estado">Solo marcar</ToggleButton>
+                </ToggleButtonGroup>
+
+                {modoCobro === 'vincular' && (
+                  <Box sx={{ mt: 1.5, maxHeight: 200, overflowY: 'auto', border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+                    {movVinculables.length === 0 ? (
+                      <Typography variant="body2" color="text.secondary" sx={{ p: 1.5 }}>
+                        No hay ingresos sin vincular.
+                      </Typography>
+                    ) : movVinculables.map((m) => (
+                      <Stack
+                        key={m._id}
+                        direction="row"
+                        justifyContent="space-between"
+                        alignItems="center"
+                        onClick={() => setMovSel(m)}
+                        sx={{ px: 1.5, py: 1, cursor: 'pointer', bgcolor: movSel?._id === m._id ? 'primary.50' : 'transparent', borderBottom: '1px solid', borderColor: 'divider' }}
+                      >
+                        <Box>
+                          <Typography variant="body2" fontWeight={movSel?._id === m._id ? 700 : 500}>
+                            {m.codigo_operacion ? `#${m.codigo_operacion} · ` : ''}{formatCurrency(m.monto || 0, m.moneda || monedaDisplay)}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {m.fecha ? new Date(m.fecha).toLocaleDateString('es-AR') : 's/f'}{m.detalle ? ` · ${m.detalle}` : ''}
+                          </Typography>
+                        </Box>
+                        {movSel?._id === m._id && <CheckCircleIcon color="primary" fontSize="small" />}
+                      </Stack>
+                    ))}
+                  </Box>
+                )}
+
                 <Typography variant="body2" color="text.secondary" mt={2}>
-                  Se registrará un movimiento de caja automáticamente.
+                  {modoCobro === 'nuevo'
+                    ? 'Se registrará un movimiento de caja automáticamente.'
+                    : modoCobro === 'vincular'
+                      ? 'Se vinculará el pago ya cargado, sin duplicar el ingreso.'
+                      : 'Se marcará como cobrada sin generar movimiento de caja.'}
                 </Typography>
               </>
             );
@@ -867,9 +1256,12 @@ const DetallePlanPage = () => {
             color="success"
             variant="contained"
             onClick={handleCobrarConfirm}
-            disabled={tipoCobro === 'parcial' && (!montoParcial || Number(montoParcial) <= 0)}
+            disabled={
+              (tipoCobro === 'parcial' && (!montoParcial || Number(montoParcial) <= 0)) ||
+              (modoCobro === 'vincular' && !movSel)
+            }
           >
-            {tipoCobro === 'parcial' ? 'Cobrar parcial' : 'Confirmar cobro'}
+            {modoCobro === 'solo_estado' ? 'Marcar cobrada' : tipoCobro === 'parcial' ? 'Cobrar parcial' : 'Confirmar cobro'}
           </Button>
         </DialogActions>
       </Dialog>
@@ -940,6 +1332,9 @@ const DetallePlanPage = () => {
 
           <Stack spacing={2}>
             {plan?.indexacion === 'CAC' && editCuota?.monto_cac ? (
+              (() => {
+                const refEfectivo = editCacRef || cacIndiceBase;
+                return (
               <Stack spacing={1.5}>
                 <TextField
                   label="Unidades CAC *"
@@ -948,8 +1343,8 @@ const DetallePlanPage = () => {
                     const raw = e.target.value.replace(/[^\d.,]/g, '');
                     setEditCacInput(raw);
                     const num = parseFloat(raw.replace(',', '.'));
-                    if (!isNaN(num) && cacActual) {
-                      setEditForm((f) => ({ ...f, monto: String(Math.round(num * cacActual * 100) / 100) }));
+                    if (!isNaN(num) && refEfectivo) {
+                      setEditForm((f) => ({ ...f, monto: String(Math.round(num * refEfectivo * 100) / 100) }));
                     }
                   }}
                   fullWidth
@@ -958,23 +1353,44 @@ const DetallePlanPage = () => {
                   InputProps={{ endAdornment: <InputAdornment position="end">CAC</InputAdornment> }}
                 />
                 <TextField
-                  label={cacActual ? 'Equivalente en ARS (índice actual)' : 'Equivalente en ARS (nominal)'}
+                  label="Equivalente en ARS"
                   value={formatNumberInput(editForm.monto)}
                   onChange={(e) => {
                     const raw = parseNumberInput(e.target.value);
                     setEditForm((f) => ({ ...f, monto: raw }));
                     const num = parseFloat(raw);
-                    if (!isNaN(num) && cacActual) {
-                      setEditCacInput(String(Math.round((num / cacActual) * 100) / 100));
+                    if (!isNaN(num) && refEfectivo) {
+                      setEditCacInput(String(Math.round((num / refEfectivo) * 100) / 100));
                     }
                   }}
                   fullWidth
                   size="small"
                   inputProps={{ inputMode: 'decimal' }}
                   InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
-                  helperText={cacActual ? `Índice CAC actual: ${cacActual.toLocaleString('es-AR')}` : 'Índice CAC no cargado'}
+                  helperText={
+                    refEfectivo
+                      ? `Índice CAC de referencia: ${refEfectivo.toLocaleString('es-AR')}${editCacRef ? ' (personalizado)' : ' (base del plan)'}`
+                      : 'Índice CAC base no disponible'
+                  }
                 />
+                <TextField
+                  label="Fijar índice por mes (opcional)"
+                  type="month"
+                  value={editCacRefMes}
+                  onChange={(e) => handleEditCacRefMes(e.target.value)}
+                  fullWidth
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                  helperText="Usa el valor de CAC publicado de ese mes como referencia de la cuota"
+                />
+                {editCacRef && (
+                  <Button size="small" onClick={() => { setEditCacRef(null); setEditCacRefMes(''); const p = parseFloat(parseNumberInput(editForm.monto)); if (!isNaN(p) && cacIndiceBase) setEditCacInput(String(Math.round((p / cacIndiceBase) * 100) / 100)); }}>
+                    Volver al índice base del plan
+                  </Button>
+                )}
               </Stack>
+                );
+              })()
             ) : (
               <TextField
                 label="Monto *"
@@ -1050,15 +1466,49 @@ const DetallePlanPage = () => {
         <DialogTitle>Agregar cuota</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
-            <TextField
-              label="Monto *"
-              value={formatNumberInput(addForm.monto)}
-              onChange={(e) => setAddForm((f) => ({ ...f, monto: parseNumberInput(e.target.value) }))}
-              fullWidth
-              size="small"
-              inputProps={{ inputMode: 'decimal' }}
-              InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
-            />
+            {addIndiceBase ? (
+              <>
+                <TextField
+                  label={`Unidades ${addUnidadLabel}`}
+                  value={addUnidades}
+                  onChange={(e) => {
+                    const raw = e.target.value.replace(/[^\d.,]/g, '');
+                    setAddUnidades(raw);
+                    const num = parseFloat(raw.replace(',', '.'));
+                    if (!isNaN(num)) setAddForm((f) => ({ ...f, monto: String(Math.round(num * addIndiceBase * 100) / 100) }));
+                  }}
+                  fullWidth
+                  size="small"
+                  inputProps={{ inputMode: 'decimal' }}
+                  InputProps={{ endAdornment: <InputAdornment position="end">{addUnidadLabel}</InputAdornment> }}
+                />
+                <TextField
+                  label="Equivalente en ARS (índice base)"
+                  value={formatNumberInput(addForm.monto)}
+                  onChange={(e) => {
+                    const raw = parseNumberInput(e.target.value);
+                    setAddForm((f) => ({ ...f, monto: raw }));
+                    const num = parseFloat(raw);
+                    if (!isNaN(num)) setAddUnidades(String(Math.round((num / addIndiceBase) * 100) / 100));
+                  }}
+                  fullWidth
+                  size="small"
+                  inputProps={{ inputMode: 'decimal' }}
+                  InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                  helperText={`Índice base del plan: ${addIndiceBase.toLocaleString('es-AR')}. En la lista se muestra el equivalente al índice de hoy.`}
+                />
+              </>
+            ) : (
+              <TextField
+                label="Monto *"
+                value={formatNumberInput(addForm.monto)}
+                onChange={(e) => setAddForm((f) => ({ ...f, monto: parseNumberInput(e.target.value) }))}
+                fullWidth
+                size="small"
+                inputProps={{ inputMode: 'decimal' }}
+                InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+              />
+            )}
             <TextField
               label="Fecha de vencimiento"
               type="date"
@@ -1110,6 +1560,138 @@ const DetallePlanPage = () => {
           <Button color="error" variant="contained" onClick={handleEliminar}>
             Eliminar
           </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Fase 4: editar total del plan activo */}
+      <Dialog open={showEditTotal} onClose={() => setShowEditTotal(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Editar total del plan</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>
+            La diferencia con lo ya distribuido en cuotas quedará como <strong>saldo sin asignar</strong>.
+            Las cuotas ya cobradas no se modifican.
+          </DialogContentText>
+          <TextField
+            label="Nuevo total"
+            value={formatNumberInput(editTotalValue)}
+            onChange={(e) => setEditTotalValue(parseNumberInput(e.target.value))}
+            fullWidth
+            size="small"
+            autoFocus
+            inputProps={{ inputMode: 'decimal' }}
+            InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowEditTotal(false)}>Cancelar</Button>
+          <Button variant="contained" onClick={handleEditTotalConfirm} disabled={savingSaldo || !editTotalValue}>
+            Guardar
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Anexo: agregado con recálculo */}
+      <Dialog open={showAnexo} onClose={() => setShowAnexo(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Agregar anexo</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>
+            Un anexo suma (o resta) al total del plan y queda en el historial. Elegí cómo distribuirlo.
+          </DialogContentText>
+          <Stack spacing={2}>
+            <TextField
+              label="Monto del anexo"
+              value={formatNumberInput(anexoForm.monto)}
+              onChange={(e) => setAnexoForm((f) => ({ ...f, monto: parseNumberInput(e.target.value) }))}
+              fullWidth size="small" autoFocus
+              inputProps={{ inputMode: 'decimal' }}
+              InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+              helperText="Podés usar negativos para reducir el alcance."
+            />
+            <ToggleButtonGroup
+              value={anexoForm.modo}
+              exclusive
+              size="small"
+              onChange={(_, v) => { if (v) setAnexoForm((f) => ({ ...f, modo: v })); }}
+            >
+              <ToggleButton value="prorratear">Prorratear en pendientes</ToggleButton>
+              <ToggleButton value="nueva_cuota">Crear cuota nueva</ToggleButton>
+            </ToggleButtonGroup>
+            <TextField
+              label="Motivo"
+              value={anexoForm.motivo}
+              onChange={(e) => setAnexoForm((f) => ({ ...f, motivo: e.target.value }))}
+              fullWidth size="small"
+              placeholder="Ej: ampliación de obra"
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowAnexo(false)}>Cancelar</Button>
+          <Button variant="contained" onClick={handleAnexoConfirm} disabled={savingSaldo || !anexoForm.monto}>
+            Aplicar anexo
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Fase 5: aplicar ajuste manual a las cuotas pendientes */}
+      <Dialog open={showAjuste} onClose={() => setShowAjuste(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Aplicar ajuste a cuotas pendientes</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>
+            Se reajustan solo las cuotas pendientes por el porcentaje indicado. Las cuotas cobradas no se tocan.
+          </DialogContentText>
+          <TextField
+            label="Porcentaje de ajuste"
+            value={ajustePct}
+            onChange={(e) => setAjustePct(e.target.value.replace(/[^\d.,-]/g, ''))}
+            fullWidth
+            size="small"
+            autoFocus
+            inputProps={{ inputMode: 'decimal' }}
+            InputProps={{ endAdornment: <InputAdornment position="end">%</InputAdornment> }}
+            helperText="Ej.: 10 para +10%. Podés usar negativos."
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowAjuste(false)}>Cancelar</Button>
+          <Button variant="contained" onClick={handleAplicarAjuste} disabled={savingSaldo || ajustePct === ''}>
+            Aplicar
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Fase 4: asignar el saldo a una cuota pendiente */}
+      <Dialog open={showAsignarSaldo} onClose={() => setShowAsignarSaldo(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Asignar saldo a una cuota</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>
+            Se sumará el saldo ({formatCurrency(resumen.saldo_sin_asignar || 0, monedaDisplay)}) al monto de la cuota elegida.
+          </DialogContentText>
+          <Stack spacing={1}>
+            {(plan.cuotas || [])
+              .filter((c) => c.estado !== 'cobrada' && c.estado !== 'cobrada_parcial')
+              .map((c) => (
+                <Button
+                  key={c._id}
+                  variant="outlined"
+                  disabled={savingSaldo}
+                  onClick={() => runSaldoAction(
+                    () => planCobroService.asignarSaldoACuota(id, c._id, empresaId),
+                    'Saldo asignado a la cuota',
+                  )}
+                  sx={{ justifyContent: 'space-between' }}
+                >
+                  <span>Cuota {c.numero}</span>
+                  <span>{formatCurrency(getMontoCuota(c), monedaDisplay)}</span>
+                </Button>
+              ))}
+            {(plan.cuotas || []).filter((c) => c.estado !== 'cobrada' && c.estado !== 'cobrada_parcial').length === 0 && (
+              <Typography variant="body2" color="text.secondary">No hay cuotas pendientes para asignar.</Typography>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowAsignarSaldo(false)}>Cerrar</Button>
         </DialogActions>
       </Dialog>
 

--- a/src/pages/cobros/nuevo.js
+++ b/src/pages/cobros/nuevo.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import {
+  Autocomplete,
   Box,
   Button,
   Chip,
@@ -43,6 +44,7 @@ import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
 import { getProyectosFromUser } from 'src/services/proyectosService';
+import clienteService from 'src/services/clienteService';
 import PresupuestoService from 'src/services/presupuestoService';
 import planCobroService from 'src/services/planCobroService';
 import { CuotasTableEdit } from 'src/components/planCobro/CuotasTable';
@@ -98,6 +100,10 @@ const NuevoPlanPage = () => {
   const [empresaId, setEmpresaId] = useState(null);
   const [proyectos, setProyectos] = useState([]);
   const [presupuestos, setPresupuestos] = useState([]);
+  const [clientes, setClientes] = useState([]);
+  const [clienteSel, setClienteSel] = useState(null); // {_id, nombre} o {nombre} nuevo
+  const [plantillas, setPlantillas] = useState([]); // plantillas de configuración (localStorage)
+  const [nombrePlantilla, setNombrePlantilla] = useState('');
   const [planData, setPlanData] = useState(defaultPlan);
   const [cuotas, setCuotas] = useState([]);
   const [errors, setErrors] = useState({});
@@ -111,7 +117,8 @@ const NuevoPlanPage = () => {
   const [usdLoading, setUsdLoading] = useState(false);
 
   // Generador de cuotas
-  const [generador, setGenerador] = useState({ cantidad: '', frecuencia: 'mensual', fecha_inicio: '', monto_cuota: '', custom_meses: '2' });
+  // Bloques componibles: anticipo / refuerzos / ajuste manual, activables por separado.
+  const [generador, setGenerador] = useState({ cantidad: '', frecuencia: 'mensual', fecha_inicio: '', monto_cuota: '', custom_meses: '2', usarAnticipo: false, usarRefuerzo: false, usarAjusteManual: false, anticipo_pct: '20', refuerzo_pct: '15', intervalo_meses: '6', refuerzo_modo: 'sumar' });
   const [modoDistribucion, setModoDistribucion] = useState('iguales'); // 'iguales' | 'personalizados'
   const [cantPersonalizados, setCantPersonalizados] = useState('');
   const [usaPorcentaje, setUsaPorcentaje] = useState(false);
@@ -122,6 +129,7 @@ const NuevoPlanPage = () => {
     getEmpresaDetailsFromUser(user).then((empresa) => {
       if (empresa?.id) {
         setEmpresaId(empresa.id);
+        clienteService.getByEmpresa(empresa.id).then((list) => setClientes(list || [])).catch(() => {});
         PresupuestoService.listarPresupuestos(empresa.id)
           .then((response) => {
             const lista = Array.isArray(response)
@@ -208,33 +216,100 @@ const NuevoPlanPage = () => {
     }));
   };
 
-  const handleGenerar = () => {
+  // Plantillas de plan (persistidas en localStorage por empresa).
+  const PLANTILLAS_KEY = 'cobros_plantillas';
+  useEffect(() => {
+    try {
+      const raw = typeof window !== 'undefined' ? window.localStorage.getItem(PLANTILLAS_KEY) : null;
+      if (raw) setPlantillas(JSON.parse(raw));
+    } catch { /* ignore */ }
+  }, []);
+  const persistirPlantillas = (lista) => {
+    setPlantillas(lista);
+    try { window.localStorage.setItem(PLANTILLAS_KEY, JSON.stringify(lista)); } catch { /* ignore */ }
+  };
+  const guardarPlantilla = () => {
+    const nombre = nombrePlantilla.trim();
+    if (!nombre) return;
+    const cfg = {
+      nombre,
+      generador: { ...generador, cantidad: generador.cantidad, fecha_inicio: '' },
+      indexacion: planData.indexacion,
+      cac_tipo: planData.cac_tipo,
+      moneda: planData.moneda,
+    };
+    persistirPlantillas([...plantillas.filter((p) => p.nombre !== nombre), cfg]);
+    setNombrePlantilla('');
+  };
+  const cargarPlantilla = (p) => {
+    setGenerador((g) => ({ ...g, ...p.generador, fecha_inicio: g.fecha_inicio }));
+    setPlanData((d) => ({ ...d, indexacion: p.indexacion ?? d.indexacion, cac_tipo: p.cac_tipo ?? d.cac_tipo, moneda: p.moneda ?? d.moneda }));
+  };
+  const borrarPlantilla = (nombre) => persistirPlantillas(plantillas.filter((p) => p.nombre !== nombre));
+
+  // Genera la lista de cuotas a partir de la config actual (pura, sin efectos).
+  // La usa tanto la vista previa en vivo como el commit al avanzar de paso.
+  const buildCuotas = () => {
     const cant = parseInt(generador.cantidad, 10);
-    if (!cant || cant < 1) return;
+    if (!cant || cant < 1) return [];
     const freq = FRECUENCIAS.find((f) => f.value === generador.frecuencia);
     const mesesEfectivos = freq.value === 'custom' ? parseInt(generador.custom_meses, 10) || 1 : freq.meses;
-    if (mesesEfectivos !== null && !generador.fecha_inicio) return;
-    const montoTotal = Number(planData.monto_total) || 0;
-    const montoCuota = generador.monto_cuota
-      ? Number(generador.monto_cuota)
-      : montoTotal > 0
-        ? Math.round((montoTotal / cant) * 100) / 100
-        : 0;
+    if (mesesEfectivos !== null && !generador.fecha_inicio) return [];
+    const montoT = Number(planData.monto_total) || 0;
+    const inicio = generador.fecha_inicio;
+    const fechaDe = (i) => (mesesEfectivos !== null && inicio ? addMonths(inicio, mesesEfectivos * i) : '');
+    const r2 = (n) => Math.round(n * 100) / 100;
 
-    const nuevas = Array.from({ length: cant }, (_, i) => ({
-      fecha_vencimiento: mesesEfectivos !== null && generador.fecha_inicio
-        ? addMonths(generador.fecha_inicio, mesesEfectivos * i)
-        : '',
+    const usarAnticipo = !!generador.usarAnticipo && montoT > 0;
+    const usarRefuerzo = !!generador.usarRefuerzo && montoT > 0;
+    const intervalo = Math.max(1, parseInt(generador.intervalo_meses, 10) || 6);
+    const anticipo = usarAnticipo ? r2(montoT * (Number(generador.anticipo_pct) || 0) / 100) : 0;
+    const refuerzo = usarRefuerzo ? r2(montoT * (Number(generador.refuerzo_pct) || 0) / 100) : 0;
+    const nRefuerzos = usarRefuerzo
+      ? Array.from({ length: cant }, (_, i) => i + 1).filter((m) => m % intervalo === 0).length
+      : 0;
+
+    if (montoT > 0) {
+      // 'reemplazar': el refuerzo ocupa el lugar de la cuota de ese mes (no se suma),
+      // así que la base se reparte solo entre las cuotas que NO son refuerzo.
+      const reemplaza = usarRefuerzo && generador.refuerzo_modo === 'reemplazar';
+      const resto = r2(montoT - anticipo - refuerzo * nRefuerzos);
+      const baseDiv = reemplaza ? Math.max(1, cant - nRefuerzos) : cant;
+      // Nunca generar cuotas negativas: si anticipo + refuerzos superan el total,
+      // la base queda en 0 (la UI avisa la sobre-asignación para que se corrija).
+      const base = Math.max(0, r2(resto / baseDiv));
+      return [
+        ...(usarAnticipo ? [{ fecha_vencimiento: inicio || '', monto: String(anticipo), descripcion: 'Anticipo' }] : []),
+        ...Array.from({ length: cant }, (_, i) => {
+          const mes = i + 1;
+          const esRefuerzo = usarRefuerzo && mes % intervalo === 0;
+          const monto = esRefuerzo ? (reemplaza ? refuerzo : r2(base + refuerzo)) : base;
+          return {
+            fecha_vencimiento: fechaDe(usarAnticipo ? mes : i),
+            monto: String(monto),
+            descripcion: esRefuerzo ? (reemplaza ? `Refuerzo ${mes}` : `Cuota ${mes} + refuerzo`) : `Cuota ${mes}`,
+          };
+        }),
+      ];
+    }
+    const montoCuota = generador.monto_cuota ? Number(generador.monto_cuota) : 0;
+    return Array.from({ length: cant }, (_, i) => ({
+      fecha_vencimiento: fechaDe(i),
       monto: montoCuota > 0 ? String(montoCuota) : '',
       descripcion: `Cuota ${i + 1}`,
     }));
-    setCuotas(nuevas);
   };
+
+  const handleGenerar = () => setCuotas(buildCuotas());
 
   const sumaCuotas = useMemo(
     () => cuotas.reduce((s, c) => s + (Number(c.monto) || 0), 0),
     [cuotas]
   );
+
+  // Vista previa en vivo de las cuotas según la config (sin tocar `cuotas`).
+  const previewCuotas = useMemo(buildCuotas, [generador, planData.monto_total]); // eslint-disable-line react-hooks/exhaustive-deps
+  const previewSuma = previewCuotas.reduce((s, c) => s + (Number(c.monto) || 0), 0);
 
   const montoTotal = Number(planData.monto_total) || 0;
   const usdIndiceEfectivo = (() => {
@@ -262,16 +337,17 @@ const NuevoPlanPage = () => {
     if (!planData.nombre.trim()) errs.nombre = 'El nombre es requerido';
     if (!planData.moneda) errs.moneda = 'La moneda es requerida';
     if (!montoTotal || montoTotal <= 0) errs.monto_total = 'El monto total debe ser mayor a 0';
-    if (planData.indexacion && !planData.fecha_base)
+    if (planData.indexacion && planData.indexacion !== 'manual' && !planData.fecha_base)
       errs.fecha_base = 'La fecha base es requerida para planes indexados';
     return errs;
   };
 
   const validarStep2 = () => {
     const errs = {};
-    if (modoDistribucion === 'iguales') {
-      if (!generador.cantidad || parseInt(generador.cantidad, 10) < 1)
-        errs.generador = 'Ingresá la cantidad de cuotas';
+    // La cantidad no es obligatoria para avanzar: si no la cargás, pasás al paso
+    // siguiente con la tabla vacía y armás las cuotas a mano. Solo si cargaste una
+    // cantidad válida pedimos la fecha (para poder fechar las cuotas generadas).
+    if (modoDistribucion === 'iguales' && generador.cantidad && parseInt(generador.cantidad, 10) >= 1) {
       const freq = FRECUENCIAS.find((f) => f.value === generador.frecuencia);
       const mesesEff = freq?.value === 'custom' ? parseInt(generador.custom_meses, 10) || 1 : freq?.meses;
       if (mesesEff !== null && !generador.fecha_inicio)
@@ -336,14 +412,41 @@ const NuevoPlanPage = () => {
 
     setSaving(true);
     try {
+      // La modalidad "ajuste manual" implica un plan de indexación 'manual'
+      // (se ajusta con aplicarAjusteManual después de crearlo).
+      const indexacionEfectiva = planData.indexacion || null;
+      const modalidadDerivada = modoDistribucion !== 'iguales'
+        ? 'cuotas'
+        : generador.usarAnticipo && generador.usarRefuerzo
+          ? 'anticipo_refuerzo'
+          : generador.usarAnticipo
+            ? 'anticipo_cuotas'
+            : 'cuotas';
+
+      // Cliente: usar el elegido o dar de alta uno "ocasional" al vuelo.
+      let clienteId = clienteSel && clienteSel._id ? clienteSel._id : null;
+      const clienteNombre = clienteSel?.nombre || null;
+      if (!clienteId && clienteNombre) {
+        try {
+          const nuevo = await clienteService.crear(empresaId, { nombre: clienteNombre, ocasional: true });
+          clienteId = nuevo?._id || nuevo?.id || null;
+        } catch { /* si falla el alta, se guarda solo el nombre */ }
+      }
+
       const payload = {
         empresa_id: empresaId,
         nombre: planData.nombre.trim(),
         proyecto_id: planData.proyecto_id || undefined,
         presupuesto_id: planData.presupuesto_id || undefined,
+        cliente_id: clienteId || undefined,
+        cliente_nombre: clienteNombre || undefined,
         monto_total: montoTotal || undefined,
         moneda: planData.moneda,
-        indexacion: planData.indexacion || null,
+        indexacion: indexacionEfectiva,
+        modalidad: modalidadDerivada,
+        anticipo_pct: generador.usarAnticipo ? Number(generador.anticipo_pct) || null : null,
+        refuerzo_pct: generador.usarRefuerzo ? Number(generador.refuerzo_pct) || null : null,
+        intervalo_meses: generador.usarRefuerzo ? Number(generador.intervalo_meses) || null : null,
         cac_tipo: planData.indexacion === 'CAC' ? planData.cac_tipo : null,
         usd_fuente: planData.indexacion === 'USD' ? planData.usd_fuente : null,
         cotizacion_snapshot: planData.indexacion === 'USD' && usdIndiceEfectivo
@@ -440,6 +543,18 @@ const NuevoPlanPage = () => {
                       {errors.proyecto_id && <FormHelperText>{errors.proyecto_id}</FormHelperText>}
                     </FormControl>
 
+                    <Autocomplete
+                      freeSolo
+                      options={clientes}
+                      getOptionLabel={(o) => (typeof o === 'string' ? o : (o?.nombre || ''))}
+                      value={clienteSel}
+                      onChange={(_, v) => setClienteSel(v)}
+                      onInputChange={(_, v, reason) => { if (reason === 'input') setClienteSel(v ? { nombre: v } : null); }}
+                      renderInput={(params) => (
+                        <TextField {...params} label="Cliente (opcional)" helperText="Elegí uno o escribí uno nuevo (se crea al guardar)" fullWidth />
+                      )}
+                    />
+
                     {presupuestos.length > 0 && (
                       <Box>
                         <FormControl fullWidth disabled={!planData.proyecto_id}>
@@ -522,6 +637,26 @@ const NuevoPlanPage = () => {
                       />
                     </Stack>
 
+                    {/* CAC manual: ingresar el total directamente en unidades CAC (TAR-445) */}
+                    {planData.indexacion === 'CAC' && cacPreview?.cac_indice && (
+                      <TextField
+                        label="…o ingresá el total en CAC"
+                        value={montoTotalEnCAC ? String(Math.round(montoTotalEnCAC * 100) / 100) : ''}
+                        onChange={(e) => {
+                          const raw = e.target.value.replace(/[^\d.,]/g, '').replace(',', '.');
+                          const units = parseFloat(raw);
+                          const pesos = !isNaN(units) ? Math.round(units * cacPreview.cac_indice * 100) / 100 : '';
+                          setPlanData((prev) => ({ ...prev, monto_total: pesos === '' ? '' : String(pesos) }));
+                        }}
+                        size="small"
+                        sx={{ mt: 1.5 }}
+                        inputProps={{ inputMode: 'decimal' }}
+                        InputProps={{ endAdornment: <InputAdornment position="end">CAC</InputAdornment> }}
+                        helperText={`Se convierte a pesos con el índice base ${cacPreview.cac_indice.toLocaleString('es-AR')}`}
+                        fullWidth
+                      />
+                    )}
+
                     <TextField
                       label="Notas"
                       value={planData.notas}
@@ -561,6 +696,7 @@ const NuevoPlanPage = () => {
                             { value: '', label: 'Sin ajuste (pesos fijos)' },
                             { value: 'CAC', label: 'CAC (Cámara de la Construcción)' },
                             { value: 'USD', label: 'Dólar (indexado a tipo de cambio)' },
+                            { value: 'manual', label: 'Ajuste manual (lo ajustás vos cada tanto)' },
                           ].map((opt) => (
                             <Paper
                               key={opt.value}
@@ -804,147 +940,203 @@ const NuevoPlanPage = () => {
           {/* ─── PASO 1: DISTRIBUCIÓN ─── */}
           <Fade in={step === 1} mountOnEnter unmountOnExit>
             <Box sx={{ display: step === 1 ? 'block' : 'none' }}>
-              <Typography variant="h6" fontWeight={600} mb={1}>
-                ¿Cómo distribuir los pagos?
-              </Typography>
-              <Typography variant="body2" color="text.secondary" mb={3}>
-                Total a cobrar: <strong>{formatCurrency(montoTotal, monedaDisplay)}</strong>
-              </Typography>
-
-              {/* Tarjetas de modo */}
-              <Grid container spacing={3} mb={4}>
-                {[
-                  {
-                    value: 'iguales',
-                    icon: <GridViewIcon sx={{ fontSize: 36 }} />,
-                    title: 'Cuotas iguales',
-                    desc: 'Dividí el total en N cuotas del mismo monto, con frecuencia fija.',
-                  },
-                  {
-                    value: 'personalizados',
-                    icon: <ViewListIcon sx={{ fontSize: 36 }} />,
-                    title: 'Montos personalizados',
-                    desc: 'Definí cada cuota a mano con el monto y la fecha que quieras.',
-                  },
-                ].map((modo) => (
-                  <Grid item xs={12} sm={6} key={modo.value}>
-                    <Paper
-                      variant="outlined"
-                      onClick={() => setModoDistribucion(modo.value)}
-                      sx={{
-                        p: 3,
-                        cursor: 'pointer',
-                        textAlign: 'center',
-                        borderColor: modoDistribucion === modo.value ? 'primary.main' : 'divider',
-                        borderWidth: modoDistribucion === modo.value ? 2 : 1,
-                        bgcolor: modoDistribucion === modo.value ? 'primary.50' : 'background.paper',
-                        transition: 'all 0.15s',
-                        '&:hover': { borderColor: 'primary.light', bgcolor: 'grey.50' },
-                      }}
-                    >
-                      <Box sx={{ color: modoDistribucion === modo.value ? 'primary.main' : 'text.secondary', mb: 1 }}>
-                        {modo.icon}
-                      </Box>
-                      <Typography variant="subtitle1" fontWeight={600}>
-                        {modo.title}
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary" mt={0.5}>
-                        {modo.desc}
-                      </Typography>
-                    </Paper>
-                  </Grid>
-                ))}
-              </Grid>
+              <Stack direction="row" justifyContent="space-between" alignItems="baseline" mb={3} flexWrap="wrap" useFlexGap>
+                <Box>
+                  <Typography variant="h6" fontWeight={600} mb={0.5}>
+                    {modoDistribucion === 'personalizados' ? 'Definí tus cuotas' : '¿Cómo distribuir los pagos?'}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Total a cobrar: <strong>{formatCurrency(montoTotal, monedaDisplay)}</strong>
+                  </Typography>
+                </Box>
+                {/* Montos personalizados como excepción, no como card gigante */}
+                <Button
+                  variant="text"
+                  size="small"
+                  startIcon={modoDistribucion === 'iguales' ? <ViewListIcon /> : <GridViewIcon />}
+                  onClick={() => setModoDistribucion(modoDistribucion === 'iguales' ? 'personalizados' : 'iguales')}
+                  sx={{ textTransform: 'none' }}
+                >
+                  {modoDistribucion === 'iguales' ? 'Prefiero cargar montos personalizados' : 'Volver a cuotas iguales'}
+                </Button>
+              </Stack>
 
               <Grid container spacing={3}>
                 <Grid item xs={12} xl={8}>
                   {modoDistribucion === 'iguales' && (
                     <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
                       <Stack spacing={2}>
-                        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="flex-end" flexWrap="wrap">
-                          <TextField
-                            label="Cantidad de cuotas"
-                            type="number"
-                            size="small"
-                            value={generador.cantidad}
-                            onChange={(e) => setGenerador((g) => ({ ...g, cantidad: e.target.value }))}
-                            error={!!errors.generador}
-                            sx={{ width: 140 }}
-                            inputProps={{ min: 1 }}
-                          />
-                          <Stack spacing={0.5}>
-                            <Typography variant="caption" color="text.secondary">Frecuencia</Typography>
-                            <Stack direction="row" spacing={1} flexWrap="wrap">
-                              {FRECUENCIAS.map((f) => (
-                                <Button
-                                  key={f.value}
-                                  variant={generador.frecuencia === f.value ? 'contained' : 'outlined'}
-                                  size="small"
-                                  onClick={() => setGenerador((g) => ({ ...g, frecuencia: f.value }))}
-                                  sx={{ borderRadius: 2, textTransform: 'none', minWidth: 0 }}
-                                >
-                                  {f.label}
-                                </Button>
-                              ))}
-                            </Stack>
+                        {/* Plantillas (Fase D.2) */}
+                        <Stack spacing={0.75}>
+                          <Typography variant="caption" color="text.secondary">Plantillas</Typography>
+                          <Stack direction="row" spacing={1} flexWrap="wrap" alignItems="center">
+                            {plantillas.length === 0 && (
+                              <Typography variant="caption" color="text.disabled">Sin plantillas guardadas</Typography>
+                            )}
+                            {plantillas.map((p) => (
+                              <Chip
+                                key={p.nombre}
+                                label={p.nombre}
+                                size="small"
+                                onClick={() => cargarPlantilla(p)}
+                                onDelete={() => borrarPlantilla(p.nombre)}
+                                variant="outlined"
+                              />
+                            ))}
                           </Stack>
-                          {generador.frecuencia === 'custom' && (
+                          <Stack direction="row" spacing={1}>
                             <TextField
-                              label="Cada cuántos meses"
-                              type="number"
-                              size="small"
-                              value={generador.custom_meses}
-                              onChange={(e) => setGenerador((g) => ({ ...g, custom_meses: e.target.value }))}
-                              sx={{ width: 130 }}
-                              inputProps={{ min: 1, max: 24 }}
+                              label="Guardar config. como plantilla" size="small"
+                              value={nombrePlantilla}
+                              onChange={(e) => setNombrePlantilla(e.target.value)}
+                              sx={{ flex: 1, maxWidth: 320 }}
                             />
-                          )}
-                          {generador.frecuencia !== 'avance_obra' && (
-                            <TextField
-                              label="Fecha primera cuota"
-                              type="date"
-                              size="small"
-                              value={generador.fecha_inicio}
-                              onChange={(e) => setGenerador((g) => ({ ...g, fecha_inicio: e.target.value }))}
-                              InputLabelProps={{ shrink: true }}
-                              sx={{ width: 180 }}
-                            />
-                          )}
+                            <Button size="small" variant="outlined" onClick={guardarPlantilla} disabled={!nombrePlantilla.trim()}>
+                              Guardar
+                            </Button>
+                          </Stack>
                         </Stack>
-                        {errors.generador && (
-                          <Typography color="error" variant="caption">{errors.generador}</Typography>
-                        )}
-                        {generador.cantidad && (generador.frecuencia === 'avance_obra' || generador.fecha_inicio) && montoTotal > 0 && (() => {
-                          const freq = FRECUENCIAS.find((f) => f.value === generador.frecuencia);
-                          const mesesEff = freq?.value === 'custom' ? parseInt(generador.custom_meses, 10) || 1 : freq?.meses;
-                          const cant = parseInt(generador.cantidad, 10);
-                          return (
-                            <Paper sx={{ p: 2, bgcolor: '#F0FAF7', border: '1px solid #B2DFDB', borderRadius: 1.5 }}>
-                              <Stack direction="row" alignItems="center" spacing={1}>
-                                <CalendarTodayIcon sx={{ fontSize: 18, color: '#1B9E85' }} />
-                                <Typography variant="body2">
-                                  <strong>{cant} cuotas</strong>
-                                  {freq?.value === 'custom'
-                                    ? <> cada <strong>{mesesEff} mes{mesesEff !== 1 ? 'es' : ''}</strong></>
-                                    : <> {FRECUENCIA_LABELS[generador.frecuencia] || generador.frecuencia}</>}
-                                  {' '}de <strong>{formatCurrency(Math.round((montoTotal / cant) * 100) / 100, monedaDisplay)}</strong>
-                                  {generador.fecha_inicio && (
-                                    <>{' '}desde el <strong>{new Date(generador.fecha_inicio + 'T12:00:00').toLocaleDateString('es-AR')}</strong></>
-                                  )}
-                                </Typography>
+
+                        {/* Bloque 1 — Cuotas base (siempre) */}
+                        <Paper variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+                          <Typography variant="subtitle2" fontWeight={700}>Cuotas</Typography>
+                          <Typography variant="caption" color="text.secondary">La base del plan: en cuántas cuotas se reparte y con qué frecuencia.</Typography>
+                          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="flex-start" flexWrap="wrap" mt={1.5}>
+                            <TextField
+                              label="Cantidad de cuotas" type="number" size="small"
+                              value={generador.cantidad}
+                              onChange={(e) => setGenerador((g) => ({ ...g, cantidad: e.target.value }))}
+                              error={!!errors.generador}
+                              sx={{ width: 140 }} inputProps={{ min: 1 }}
+                            />
+                            <Stack spacing={0.5}>
+                              <Typography variant="caption" color="text.secondary">Frecuencia</Typography>
+                              <Stack direction="row" spacing={1} flexWrap="wrap">
+                                {FRECUENCIAS.map((f) => (
+                                  <Button
+                                    key={f.value}
+                                    variant={generador.frecuencia === f.value ? 'contained' : 'outlined'}
+                                    size="small"
+                                    onClick={() => setGenerador((g) => ({ ...g, frecuencia: f.value }))}
+                                    sx={{ borderRadius: 2, textTransform: 'none', minWidth: 0 }}
+                                  >
+                                    {f.label}
+                                  </Button>
+                                ))}
                               </Stack>
+                            </Stack>
+                            {generador.frecuencia === 'custom' && (
+                              <TextField
+                                label="Cada cuántos meses" type="number" size="small"
+                                value={generador.custom_meses}
+                                onChange={(e) => setGenerador((g) => ({ ...g, custom_meses: e.target.value }))}
+                                sx={{ width: 150 }} inputProps={{ min: 1, max: 24 }}
+                              />
+                            )}
+                            {generador.frecuencia !== 'avance_obra' && (
+                              <TextField
+                                label="Fecha primera cuota" type="date" size="small"
+                                value={generador.fecha_inicio}
+                                onChange={(e) => setGenerador((g) => ({ ...g, fecha_inicio: e.target.value }))}
+                                InputLabelProps={{ shrink: true }}
+                                sx={{ width: 180 }}
+                              />
+                            )}
+                          </Stack>
+                        </Paper>
+
+                        {/* Bloque 2 — Anticipo (opcional) */}
+                        {(() => {
+                          const activo = generador.usarAnticipo;
+                          return (
+                            <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, borderColor: activo ? 'primary.main' : 'divider' }}>
+                              <FormControlLabel
+                                control={<Switch checked={!!activo} onChange={() => setGenerador((g) => ({ ...g, usarAnticipo: !g.usarAnticipo }))} />}
+                                label={<Typography variant="subtitle2" fontWeight={700}>Anticipo</Typography>}
+                              />
+                              <Typography variant="caption" color="text.secondary" display="block">Un pago inicial al arrancar, antes de las cuotas.</Typography>
+                              {activo && (
+                                <TextField
+                                  label="Anticipo (%)" type="number" size="small"
+                                  value={generador.anticipo_pct}
+                                  onChange={(e) => setGenerador((g) => ({ ...g, anticipo_pct: e.target.value }))}
+                                  sx={{ width: 180, mt: 1.5 }} inputProps={{ min: 0, max: 100 }}
+                                  helperText={montoTotal > 0 ? `= ${formatCurrency(Math.round(montoTotal * (Number(generador.anticipo_pct) || 0) / 100), monedaDisplay)} del total` : ' '}
+                                />
+                              )}
                             </Paper>
                           );
                         })()}
-                        <Button
-                          variant="contained"
-                          onClick={handleGenerar}
-                          disabled={!generador.cantidad || (!generador.fecha_inicio && generador.frecuencia !== 'avance_obra')}
-                          startIcon={<AutorenewIcon />}
-                          sx={{ alignSelf: 'flex-start', textTransform: 'none', borderRadius: 2 }}
-                        >
-                          Generar cuotas
-                        </Button>
+
+                        {/* Bloque 3 — Refuerzos (opcional) */}
+                        {(() => {
+                          const activo = generador.usarRefuerzo;
+                          return (
+                            <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, borderColor: activo ? 'primary.main' : 'divider' }}>
+                              <FormControlLabel
+                                control={<Switch checked={!!activo} onChange={() => setGenerador((g) => ({ ...g, usarRefuerzo: !g.usarRefuerzo }))} />}
+                                label={<Typography variant="subtitle2" fontWeight={700}>Refuerzos</Typography>}
+                              />
+                              <Typography variant="caption" color="text.secondary" display="block">Pagos extra cada cierto tiempo (ej. cada 6 meses), además de las cuotas.</Typography>
+                              {activo && (
+                                <Stack spacing={1.5} mt={1.5}>
+                                  <Stack direction="row" spacing={2} flexWrap="wrap">
+                                    <TextField
+                                      label="Refuerzo (%)" type="number" size="small"
+                                      value={generador.refuerzo_pct}
+                                      onChange={(e) => setGenerador((g) => ({ ...g, refuerzo_pct: e.target.value }))}
+                                      sx={{ width: 160 }} inputProps={{ min: 0, max: 100 }}
+                                      helperText={montoTotal > 0 ? `= ${formatCurrency(Math.round(montoTotal * (Number(generador.refuerzo_pct) || 0) / 100), monedaDisplay)} c/u` : ' '}
+                                    />
+                                    <TextField
+                                      label="Cada (meses)" type="number" size="small"
+                                      value={generador.intervalo_meses}
+                                      onChange={(e) => setGenerador((g) => ({ ...g, intervalo_meses: e.target.value }))}
+                                      sx={{ width: 130 }} inputProps={{ min: 1 }}
+                                    />
+                                  </Stack>
+                                  <Box>
+                                    <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>En el mes del refuerzo</Typography>
+                                    <ToggleButtonGroup
+                                      value={generador.refuerzo_modo}
+                                      exclusive size="small"
+                                      onChange={(_, v) => { if (v) setGenerador((g) => ({ ...g, refuerzo_modo: v })); }}
+                                    >
+                                      <ToggleButton value="sumar">Se suma a la cuota</ToggleButton>
+                                      <ToggleButton value="reemplazar">Reemplaza la cuota</ToggleButton>
+                                    </ToggleButtonGroup>
+                                  </Box>
+                                </Stack>
+                              )}
+                            </Paper>
+                          );
+                        })()}
+
+                        {/* Aviso de sobre-asignación (#4 bug) */}
+                        {(() => {
+                          const cant = parseInt(generador.cantidad, 10) || 0;
+                          if (!cant || montoTotal <= 0) return null;
+                          const intervalo = Math.max(1, parseInt(generador.intervalo_meses, 10) || 6);
+                          const nRef = generador.usarRefuerzo ? Array.from({ length: cant }, (_, i) => i + 1).filter((m) => m % intervalo === 0).length : 0;
+                          const pctComprometido = (generador.usarAnticipo ? Number(generador.anticipo_pct) || 0 : 0) + nRef * (generador.usarRefuerzo ? Number(generador.refuerzo_pct) || 0 : 0);
+                          if (pctComprometido <= 100) return null;
+                          return (
+                            <Paper sx={{ p: 1.5, bgcolor: '#FFF5F5', border: '1px solid #F2B8B5', borderRadius: 1.5 }}>
+                              <Typography variant="caption" color="error.main">
+                                ⚠ El anticipo + los refuerzos suman <strong>{Math.round(pctComprometido)}%</strong> del total (más de 100%).
+                                Las cuotas base quedarían en 0. Bajá el % de refuerzo, la cantidad de refuerzos o el anticipo.
+                              </Typography>
+                            </Paper>
+                          );
+                        })()}
+
+                        {errors.generador && (
+                          <Typography color="error" variant="caption">{errors.generador}</Typography>
+                        )}
+                        <Stack direction="row" alignItems="center" spacing={1} sx={{ color: 'text.secondary' }}>
+                          <AutorenewIcon sx={{ fontSize: 18 }} />
+                          <Typography variant="caption">Las cuotas se arman solas — mirá la vista previa. Podrás ajustarlas en el paso siguiente.</Typography>
+                        </Stack>
                       </Stack>
                     </Paper>
                   )}
@@ -1080,22 +1272,74 @@ const NuevoPlanPage = () => {
                       <Divider sx={{ my: 0.5 }} />
 
                       {modoDistribucion === 'iguales' ? (
-                        <>
-                          <Typography variant="body2" fontWeight={600}>Generación automática</Typography>
-                          <Typography variant="body2" color="text.secondary">
-                            Definís cantidad, frecuencia y fecha inicial. Después en el siguiente paso podés corregir monto, CAC o fecha cuota por cuota.
-                          </Typography>
-                          {generador.cantidad && (
-                            <Typography variant="caption" color="text.secondary">
-                              Se generarán {generador.cantidad} cuota{parseInt(generador.cantidad, 10) !== 1 ? 's' : ''}
-                              {generador.frecuencia !== 'avance_obra' && generador.fecha_inicio
-                                ? ` desde ${new Date(generador.fecha_inicio + 'T12:00:00').toLocaleDateString('es-AR')}`
-                                : generador.frecuencia === 'avance_obra'
-                                  ? ' por avance de obra'
-                                  : ''}.
-                            </Typography>
-                          )}
-                        </>
+                        (() => {
+                          const cant = parseInt(generador.cantidad, 10) || 0;
+                          const antMonto = generador.usarAnticipo ? Math.round(montoTotal * (Number(generador.anticipo_pct) || 0) / 100) : 0;
+                          const intervalo = Math.max(1, parseInt(generador.intervalo_meses, 10) || 6);
+                          const nRef = generador.usarRefuerzo ? Array.from({ length: cant }, (_, i) => i + 1).filter((m) => m % intervalo === 0).length : 0;
+                          const refMonto = generador.usarRefuerzo ? Math.round(montoTotal * (Number(generador.refuerzo_pct) || 0) / 100) : 0;
+                          const refTotal = refMonto * nRef;
+                          const cuotasTotal = Math.max(0, montoTotal - antMonto - refTotal);
+                          const pct = (n) => (montoTotal > 0 ? Math.round(n / montoTotal * 100) : 0);
+                          const freqLabel = generador.frecuencia === 'custom' ? `cada ${generador.custom_meses} meses` : (FRECUENCIA_LABELS[generador.frecuencia] || generador.frecuencia);
+                          return (
+                            <>
+                              {/* Resumen en lenguaje natural (#2) */}
+                              <Typography variant="body2">
+                                {generador.usarAnticipo && <><strong>{generador.anticipo_pct}%</strong> de anticipo ({formatCurrency(antMonto, monedaDisplay)}) + </>}
+                                <strong>{cant || '—'}</strong> cuota{cant !== 1 ? 's' : ''} {freqLabel}
+                                {cant > 0 && <> de ~{formatCurrency(Math.round(cuotasTotal / cant), monedaDisplay)}</>}
+                                {generador.usarRefuerzo && <>, con refuerzo del <strong>{generador.refuerzo_pct}%</strong> cada {intervalo} meses ({generador.refuerzo_modo === 'reemplazar' ? 'reemplaza esa cuota' : 'se suma'})</>}
+                                {generador.fecha_inicio && <> desde el {new Date(generador.fecha_inicio + 'T12:00:00').toLocaleDateString('es-AR')}</>}
+                                {planData.indexacion === 'manual' && <> · ajuste manual</>}.
+                              </Typography>
+
+                              {/* Barra de composición (#4) */}
+                              {montoTotal > 0 && (
+                                <Box>
+                                  <Box sx={{ display: 'flex', height: 10, borderRadius: 5, overflow: 'hidden', bgcolor: 'grey.200' }}>
+                                    {antMonto > 0 && <Box sx={{ width: `${pct(antMonto)}%`, bgcolor: '#7E57C2' }} />}
+                                    <Box sx={{ width: `${pct(cuotasTotal)}%`, bgcolor: '#42A5F5' }} />
+                                    {refTotal > 0 && <Box sx={{ width: `${pct(refTotal)}%`, bgcolor: '#26A69A' }} />}
+                                  </Box>
+                                  <Stack direction="row" spacing={1.5} mt={0.5} flexWrap="wrap">
+                                    {antMonto > 0 && <Typography variant="caption" sx={{ color: '#7E57C2' }}>Anticipo {pct(antMonto)}%</Typography>}
+                                    <Typography variant="caption" sx={{ color: '#42A5F5' }}>Cuotas {pct(cuotasTotal)}%</Typography>
+                                    {refTotal > 0 && <Typography variant="caption" sx={{ color: '#26A69A' }}>Refuerzos {pct(refTotal)}%</Typography>}
+                                  </Stack>
+                                </Box>
+                              )}
+
+                              {/* Vista previa en vivo (#1) */}
+                              <Divider sx={{ my: 0.5 }} />
+                              <Typography variant="caption" color="text.secondary">Vista previa ({previewCuotas.length} cuota{previewCuotas.length !== 1 ? 's' : ''})</Typography>
+                              {previewCuotas.length === 0 ? (
+                                <Typography variant="caption" color="text.disabled">Completá cantidad y fecha para ver el detalle.</Typography>
+                              ) : (
+                                <Stack spacing={0.25} sx={{ maxHeight: 220, overflowY: 'auto' }}>
+                                  {previewCuotas.slice(0, 12).map((c, i) => (
+                                    <Stack key={i} direction="row" justifyContent="space-between">
+                                      <Typography variant="caption" color="text.secondary" noWrap sx={{ maxWidth: 140 }}>
+                                        {c.descripcion}{c.fecha_vencimiento ? ` · ${new Date(c.fecha_vencimiento + 'T12:00:00').toLocaleDateString('es-AR')}` : ''}
+                                      </Typography>
+                                      <Typography variant="caption" fontWeight={600}>{formatCurrency(Number(c.monto) || 0, monedaDisplay)}</Typography>
+                                    </Stack>
+                                  ))}
+                                  {previewCuotas.length > 12 && (
+                                    <Typography variant="caption" color="text.disabled">…y {previewCuotas.length - 12} más</Typography>
+                                  )}
+                                  <Divider sx={{ my: 0.5 }} />
+                                  <Stack direction="row" justifyContent="space-between">
+                                    <Typography variant="caption" fontWeight={700}>Suma</Typography>
+                                    <Typography variant="caption" fontWeight={700} color={Math.abs(previewSuma - montoTotal) < 1 || montoTotal === 0 ? 'success.main' : 'warning.main'}>
+                                      {formatCurrency(previewSuma, monedaDisplay)}{montoTotal > 0 && Math.abs(previewSuma - montoTotal) >= 1 ? ` (total ${formatCurrency(montoTotal, monedaDisplay)})` : ''}
+                                    </Typography>
+                                  </Stack>
+                                </Stack>
+                              )}
+                            </>
+                          );
+                        })()
                       ) : (
                         <>
                           <Typography variant="body2" fontWeight={600}>Edición manual</Typography>

--- a/src/pages/control-obra/[id].js
+++ b/src/pages/control-obra/[id].js
@@ -10,6 +10,7 @@ import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
 import ControlObraService from 'src/services/controlObra/controlObraService';
 import CertificadosTab from 'src/components/controlObra/CertificadosTab';
+import CobrosObraTab from 'src/components/controlObra/CobrosObraTab';
 import EjecucionTab from 'src/components/controlObra/EjecucionTab';
 import CronogramaTab from 'src/components/controlObra/CronogramaTab';
 import ManoObraTab from 'src/components/controlObra/ManoObraTab';
@@ -77,6 +78,7 @@ function ObraDetallePage() {
               <Tab label="Ejecución" />
               <Tab label="Cronograma" />
               <Tab label="Certificados" />
+              <Tab label="Cobros" />
               <Tab label="Mano de obra" />
               <Tab label="Reportes" />
             </Tabs>
@@ -89,8 +91,9 @@ function ObraDetallePage() {
 
             {tab === 3 && <CertificadosTab obra={obra} certs={certsQ.data || []} empresaId={empresaId} />}
 
-            {tab === 4 && <ManoObraTab obra={obra} empresaId={empresaId} />}
-            {tab === 5 && <ReportesTab obra={obra} empresaId={empresaId} />}
+            {tab === 4 && <CobrosObraTab obra={obra} empresaId={empresaId} />}
+            {tab === 5 && <ManoObraTab obra={obra} empresaId={empresaId} />}
+            {tab === 6 && <ReportesTab obra={obra} empresaId={empresaId} />}
           </Stack>
         )}
       </Container>

--- a/src/services/controlObra/controlObraService.js
+++ b/src/services/controlObra/controlObraService.js
@@ -161,6 +161,12 @@ const ControlObraService = {
   anularCertificado: async (certId, empresa_id, motivo) => unwrap(await api.post(`${BASE}/certificados/${certId}/anular`, { empresa_id, motivo })),
   cobrarCertificado: async (certId, empresa_id, montoParcial = null, fechaCobrado = null) =>
     unwrap(await api.post(`${BASE}/certificados/${certId}/cobrar`, { empresa_id, monto_parcial: montoParcial, fecha_cobrado: fechaCobrado })),
+
+  // Fase F: modo de cobro de la obra + planes adicionales (multi-plan)
+  setModoCobro: async (obraId, empresa_id, modo_cobro) =>
+    unwrap(await api.patch(`${BASE}/${obraId}/modo-cobro`, { empresa_id, modo_cobro })),
+  agregarPlan: async (obraId, empresa_id, { nombre = null, monto_total = 0 } = {}) =>
+    unwrap(await api.post(`${BASE}/${obraId}/planes`, { empresa_id, nombre, monto_total })),
 };
 
 export default ControlObraService;

--- a/src/services/planCobroService.js
+++ b/src/services/planCobroService.js
@@ -41,6 +41,32 @@ const planCobroService = {
 
   agregarCuota: (planId, data) =>
     api.post(`/cobros/${planId}/cuotas`, data),
+
+  // Saldo sin asignar (Fase 4)
+  asignarSaldoACuota: (planId, cuotaId, empresaId) =>
+    api.post(`/cobros/${planId}/cuotas/${cuotaId}/asignar-saldo`, { empresa_id: empresaId }),
+
+  agregarCuotaDesdeSaldo: (planId, data) =>
+    api.post(`/cobros/${planId}/saldo/nueva-cuota`, data),
+
+  ajustarTotalAlDistribuido: (planId, empresaId) =>
+    api.post(`/cobros/${planId}/saldo/ajustar-total`, { empresa_id: empresaId }),
+
+  // Ajuste manual periódico (Fase 5)
+  aplicarAjusteManual: (planId, data) =>
+    api.post(`/cobros/${planId}/ajuste-manual`, data),
+
+  // Movimientos de ingreso no vinculados (para cobro por "vincular existente")
+  listarMovimientosVinculables: (empresaId, proyectoId = null) =>
+    api.get('/cobros/movimientos-vinculables', { params: { empresa_id: empresaId, proyecto_id: proyectoId || undefined } }),
+
+  // Anexos / agregados (Fase 6 ronda 2)
+  agregarAnexo: (planId, data) =>
+    api.post(`/cobros/${planId}/anexos`, data),
+
+  // Cashflow proyectado agregado (Fase G)
+  getCashflow: (empresaId, proyectoId = null, granularidad = 'mes', { incluirHistorico = false } = {}) =>
+    api.get('/cobros/cashflow', { params: { empresa_id: empresaId, proyecto_id: proyectoId || undefined, granularidad, incluir_historico: incluirHistorico || undefined } }),
 };
 
 export default planCobroService;


### PR DESCRIPTION
Cambios de frontend de la ronda de mejoras de Plan de Cobros y Control de Obra. Acompaña a fedemaidan/sorby_bot_wa#241 (backend).

## Plan de Cobros
- **Wizard de creación rediseñado**: bloques componibles (anticipo / refuerzos / cuotas base) con **vista previa en vivo**, resumen en lenguaje natural, barra de composición y montos junto a cada %.
- **Refuerzos**: opción "se suma a la cuota" o "reemplaza la cuota del mes".
- Modo "montos personalizados" como excepción (link, no card gigante); la cantidad de cuotas ya no es obligatoria para avanzar.
- **CAC manual** (total y por cuota) + override de índice por mes en edición.
- **Saldo sin asignar** (banner + acciones); **anexos** con historial; **ajuste manual** periódico.
- **Cobro flexible**: nuevo / vincular movimiento existente / solo estado.
- **Cliente** en el plan (reusa `Cliente`, alta ocasional al vuelo) + **vista de tabla**.
- **Header de KPIs** (vencido / este mes / próx. 90 días) **siempre visible**; tab **Cashflow** (gráfico + tabla, acumulado, mes/semana/auto, ver histórico).
- Fixes: monto real vs actualizado en cobradas, conversión CAC contra índice base, detalle de "Cobrado" desplegable.

## Control de Obra
- Pestaña **"Cobros"** en la obra (plan(es) asociados + avance de cobro) con link al plan.
- Toggle **modo de cobro** certificados|plan en el Resumen.
- Origen **"desde categorías"** en el alta de obra; categoría/subcategoría en editar tarea (con autocomplete).

> QA funcional con datos reales pendiente (login + planes con cuotas fechadas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)