### PR TITLE
feat(cobros): fecha y CAC configurables al crear un anexo (TAR-520)

### DIFF
--- a/src/pages/cobros/[id].js
+++ b/src/pages/cobros/[id].js
@@ -334,22 +334,33 @@ const DetallePlanPage = () => {
     fecha: new Date().toISOString().split('T')[0], cacInput: '', cacRef: null, cacRefMes: '',
   });
 
-  // Al elegir un mes, busca el índice CAC publicado y lo fija como referencia del anexo,
-  // recalculando las unidades CAC contra ese índice para mantener los pesos ingresados.
+  // Al elegir un mes, busca el índice CAC publicado y lo fija como referencia del anexo.
+  // Si ya hay unidades CAC cargadas, mantiene las unidades y recalcula el monto en ARS
+  // (el monto en pesos sigue al índice seleccionado); si no, deriva las unidades del
+  // monto en pesos ya ingresado. Si el mes no tiene índice publicado, avisa y no rompe.
   const handleAnexoCacRefMes = async (mes) => {
     setAnexoForm((f) => ({ ...f, cacRefMes: mes }));
     if (!mes) { setAnexoForm((f) => ({ ...f, cacRef: null })); return; }
     try {
       const res = await planCobroService.previewCAC(`${mes}-01`, plan?.cac_tipo || 'general');
       const idx = res?.data?.data?.cac_indice || null;
-      if (idx) {
-        setAnexoForm((f) => {
-          const pesos = parseFloat(parseNumberInput(f.monto));
-          return { ...f, cacRef: idx, cacInput: isNaN(pesos) ? f.cacInput : String(Math.round((pesos / idx) * 100) / 100) };
-        });
+      if (!idx) {
+        setAnexoForm((f) => ({ ...f, cacRef: null }));
+        setAlert({ open: true, message: `No hay índice CAC publicado para ${mes}. Se mantiene el índice base del plan.`, severity: 'warning' });
+        return;
       }
-    } catch {
-      /* si falla el preview, se mantiene la referencia base del plan */
+      setAnexoForm((f) => {
+        const unidades = parseFloat(String(f.cacInput).replace(',', '.'));
+        if (!isNaN(unidades) && unidades !== 0) {
+          // Mantener unidades CAC → el monto en ARS sigue al índice del mes elegido.
+          return { ...f, cacRef: idx, monto: String(Math.round(unidades * idx * 100) / 100) };
+        }
+        const pesos = parseFloat(parseNumberInput(f.monto));
+        return { ...f, cacRef: idx, cacInput: isNaN(pesos) ? f.cacInput : String(Math.round((pesos / idx) * 100) / 100) };
+      });
+    } catch (err) {
+      setAnexoForm((f) => ({ ...f, cacRef: null }));
+      setAlert({ open: true, message: err?.response?.data?.error || `No se pudo obtener el índice CAC de ${mes}`, severity: 'warning' });
     }
   };
 

--- a/src/pages/cobros/[id].js
+++ b/src/pages/cobros/[id].js
@@ -93,9 +93,18 @@ const DetallePlanPage = () => {
   // Fase 5 — ajuste manual periódico
   const [showAjuste, setShowAjuste] = useState(false);
   const [ajustePct, setAjustePct] = useState('');
-  // Anexos (Fase 6 ronda 2)
+  // Anexos (Fase 6 ronda 2). fecha = fecha del anexo (default hoy). Para planes CAC:
+  // cacInput = unidades CAC, cacRef = índice de referencia (override), cacRefMes = mes elegido.
   const [showAnexo, setShowAnexo] = useState(false);
-  const [anexoForm, setAnexoForm] = useState({ monto: '', motivo: '', modo: 'prorratear' });
+  const [anexoForm, setAnexoForm] = useState({
+    monto: '',
+    motivo: '',
+    modo: 'prorratear',
+    fecha: new Date().toISOString().split('T')[0],
+    cacInput: '',
+    cacRef: null,
+    cacRefMes: '',
+  });
 
   useEffect(() => {
     if (!user) return;
@@ -320,9 +329,35 @@ const DetallePlanPage = () => {
     }
   };
 
+  const resetAnexoForm = () => setAnexoForm({
+    monto: '', motivo: '', modo: 'prorratear',
+    fecha: new Date().toISOString().split('T')[0], cacInput: '', cacRef: null, cacRefMes: '',
+  });
+
+  // Al elegir un mes, busca el índice CAC publicado y lo fija como referencia del anexo,
+  // recalculando las unidades CAC contra ese índice para mantener los pesos ingresados.
+  const handleAnexoCacRefMes = async (mes) => {
+    setAnexoForm((f) => ({ ...f, cacRefMes: mes }));
+    if (!mes) { setAnexoForm((f) => ({ ...f, cacRef: null })); return; }
+    try {
+      const res = await planCobroService.previewCAC(`${mes}-01`, plan?.cac_tipo || 'general');
+      const idx = res?.data?.data?.cac_indice || null;
+      if (idx) {
+        setAnexoForm((f) => {
+          const pesos = parseFloat(parseNumberInput(f.monto));
+          return { ...f, cacRef: idx, cacInput: isNaN(pesos) ? f.cacInput : String(Math.round((pesos / idx) * 100) / 100) };
+        });
+      }
+    } catch {
+      /* si falla el preview, se mantiene la referencia base del plan */
+    }
+  };
+
   const handleAnexoConfirm = async () => {
     const montoNum = parseFloat(parseNumberInput(anexoForm.monto));
     if (!montoNum) return;
+    const esCac = plan?.indexacion === 'CAC' && cacIndiceBase;
+    const cacNum = esCac ? parseFloat(String(anexoForm.cacInput).replace(',', '.')) : null;
     setSavingSaldo(true);
     try {
       await planCobroService.agregarAnexo(id, {
@@ -330,9 +365,13 @@ const DetallePlanPage = () => {
         monto: montoNum,
         motivo: anexoForm.motivo || undefined,
         modo: anexoForm.modo,
+        fecha: anexoForm.fecha || undefined,
+        // Planes CAC: mandamos las unidades pactadas y el índice del mes elegido (si hay).
+        ...(esCac && cacNum > 0 ? { monto_cac: cacNum } : {}),
+        ...(esCac ? { cac_indice_ref: anexoForm.cacRef || null } : {}),
       });
       setShowAnexo(false);
-      setAnexoForm({ monto: '', motivo: '', modo: 'prorratear' });
+      resetAnexoForm();
       await refresh();
       setAlert({ open: true, message: 'Anexo aplicado', severity: 'success' });
     } catch (err) {
@@ -805,6 +844,7 @@ const DetallePlanPage = () => {
                       <Typography variant="body2">{a.motivo || 'Anexo'}</Typography>
                       <Typography variant="caption" color="text.secondary">
                         {a.fecha ? new Date(a.fecha).toLocaleDateString('es-AR') : ''} · {a.modo === 'nueva_cuota' ? 'cuota nueva' : 'prorrateado'}
+                        {a.monto_cac ? ` · ${Math.round(a.monto_cac * 100) / 100} CAC${a.cac_indice_ref ? ` @ ${a.cac_indice_ref.toLocaleString('es-AR')}` : ''}` : ''}
                       </Typography>
                     </Box>
                     <Typography variant="body2" fontWeight={700} color={a.monto >= 0 ? 'success.main' : 'error.main'}>
@@ -1598,14 +1638,92 @@ const DetallePlanPage = () => {
             Un anexo suma (o resta) al total del plan y queda en el historial. Elegí cómo distribuirlo.
           </DialogContentText>
           <Stack spacing={2}>
+            {plan?.indexacion === 'CAC' && cacIndiceBase ? (
+              (() => {
+                const refEfectivo = anexoForm.cacRef || cacIndiceBase;
+                return (
+                  <Stack spacing={1.5}>
+                    <TextField
+                      label="Unidades CAC del anexo"
+                      value={anexoForm.cacInput}
+                      onChange={(e) => {
+                        const raw = e.target.value.replace(/[^\d.,-]/g, '');
+                        const num = parseFloat(raw.replace(',', '.'));
+                        setAnexoForm((f) => ({
+                          ...f,
+                          cacInput: raw,
+                          monto: !isNaN(num) && refEfectivo ? String(Math.round(num * refEfectivo * 100) / 100) : f.monto,
+                        }));
+                      }}
+                      fullWidth size="small" autoFocus
+                      inputProps={{ inputMode: 'decimal' }}
+                      InputProps={{ endAdornment: <InputAdornment position="end">CAC</InputAdornment> }}
+                    />
+                    <TextField
+                      label="Monto del anexo en ARS"
+                      value={formatNumberInput(anexoForm.monto)}
+                      onChange={(e) => {
+                        const raw = parseNumberInput(e.target.value);
+                        const num = parseFloat(raw);
+                        setAnexoForm((f) => ({
+                          ...f,
+                          monto: raw,
+                          cacInput: !isNaN(num) && refEfectivo ? String(Math.round((num / refEfectivo) * 100) / 100) : f.cacInput,
+                        }));
+                      }}
+                      fullWidth size="small"
+                      inputProps={{ inputMode: 'decimal' }}
+                      InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                      helperText={
+                        refEfectivo
+                          ? `Índice CAC de referencia: ${refEfectivo.toLocaleString('es-AR')}${anexoForm.cacRef ? ' (mes elegido)' : ' (base del plan)'}. Podés usar negativos para reducir el alcance.`
+                          : 'Índice CAC base no disponible'
+                      }
+                    />
+                    <TextField
+                      label="Mes / índice CAC de referencia (opcional)"
+                      type="month"
+                      value={anexoForm.cacRefMes}
+                      onChange={(e) => handleAnexoCacRefMes(e.target.value)}
+                      fullWidth size="small"
+                      InputLabelProps={{ shrink: true }}
+                      helperText="Usa el CAC publicado de ese mes como referencia del anexo"
+                    />
+                    {anexoForm.cacRef && (
+                      <Button
+                        size="small"
+                        onClick={() => setAnexoForm((f) => {
+                          const pesos = parseFloat(parseNumberInput(f.monto));
+                          return {
+                            ...f, cacRef: null, cacRefMes: '',
+                            cacInput: !isNaN(pesos) && cacIndiceBase ? String(Math.round((pesos / cacIndiceBase) * 100) / 100) : f.cacInput,
+                          };
+                        })}
+                      >
+                        Volver al índice base del plan
+                      </Button>
+                    )}
+                  </Stack>
+                );
+              })()
+            ) : (
+              <TextField
+                label="Monto del anexo"
+                value={formatNumberInput(anexoForm.monto)}
+                onChange={(e) => setAnexoForm((f) => ({ ...f, monto: parseNumberInput(e.target.value) }))}
+                fullWidth size="small" autoFocus
+                inputProps={{ inputMode: 'decimal' }}
+                InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                helperText="Podés usar negativos para reducir el alcance."
+              />
+            )}
             <TextField
-              label="Monto del anexo"
-              value={formatNumberInput(anexoForm.monto)}
-              onChange={(e) => setAnexoForm((f) => ({ ...f, monto: parseNumberInput(e.target.value) }))}
-              fullWidth size="small" autoFocus
-              inputProps={{ inputMode: 'decimal' }}
-              InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
-              helperText="Podés usar negativos para reducir el alcance."
+              label="Fecha del anexo"
+              type="date"
+              value={anexoForm.fecha}
+              onChange={(e) => setAnexoForm((f) => ({ ...f, fecha: e.target.value }))}
+              fullWidth size="small"
+              InputLabelProps={{ shrink: true }}
             />
             <ToggleButtonGroup
               value={anexoForm.modo}


### PR DESCRIPTION
## TAR-520 · Agregar fecha y CAC al crear un anexo en un plan de cobro (frontend)

> Backend companion: `fedemaidan/sorby_bot_wa` → rama `feat/tar-520-anexo-fecha-cac`
> Ticket: [TAR-520](https://app.notion.com/p/39550a1e534180789e8bcc8959752efe)

### Problema
El diálogo **"Agregar anexo"** (`src/pages/cobros/[id].js`) solo permitía cargar **monto**, **modo de distribución** y **motivo**. No se podía indicar la **fecha del anexo** ni, en planes indexados por CAC, las **unidades CAC** ni el **mes / índice CAC de referencia**.

### Solución
Extiendo el diálogo reutilizando **el mismo patrón de UX que ya usa el editor de cuota** para CAC, así la experiencia es consistente.

**Nuevos campos del diálogo**
- **Fecha del anexo** — `type="date"`, default hoy. Siempre visible.
- **Solo en planes CAC** (`plan.indexacion === 'CAC'`), trío indexado:
  - **Unidades CAC del anexo** ↔ **Monto del anexo en ARS**: campos **bidireccionales** (editar uno recalcula el otro con el índice efectivo).
  - **Mes / índice CAC de referencia (opcional)**: `type="month"`; al elegir un mes se consulta `previewCAC` y se fija el índice publicado como referencia.
  - **"Volver al índice base del plan"**: descarta el override y recalcula contra el CAC base.
  - El helper muestra el índice efectivo y si es "mes elegido" o "base del plan".
- En planes **no CAC** se mantiene el campo único de monto en ARS.

**Envío** — `handleAnexoConfirm` agrega al payload:
- `fecha`,
- `monto_cac` (unidades) y `cac_indice_ref` (índice del mes elegido, o `null` si se usa la base), solo en planes CAC.

**Historial de anexos** — cada anexo ahora muestra, además de fecha y modo, las **unidades CAC** y el **índice de referencia** cuando corresponde.

### Notas de implementación
- El estado `anexoForm` se amplió con `fecha`, `cacInput`, `cacRef`, `cacRefMes` y se resetea tras aplicar el anexo (`resetAnexoForm`).
- `handleAnexoCacRefMes` replica la lógica de `handleEditCacRefMes` del editor de cuota (misma llamada a `previewCAC`, mismo recálculo de unidades manteniendo los pesos).
- Sin dependencias nuevas. `eslint` sobre el archivo modificado: sin errores.

### Cómo probar
1. Abrir un plan de cobro **indexado por CAC** → **Agregar anexo**.
2. Cargar unidades CAC → verificar que el equivalente en ARS se completa solo (y viceversa).
3. Elegir un mes en "Mes / índice CAC de referencia" → el índice de referencia cambia y las unidades se recalculan; "Volver al índice base" lo revierte.
4. Setear una fecha, aplicar, y confirmar en el historial que aparecen fecha + unidades CAC + índice.
5. En un plan **no** CAC: el diálogo muestra solo monto ARS + fecha (comportamiento previo intacto).
