### PR TITLE
feat(cobros): fecha efectiva de cobro editable (TAR-442 A)

### DIFF
--- a/src/pages/cobros/[id].js
+++ b/src/pages/cobros/[id].js
@@ -62,6 +62,8 @@ const DetallePlanPage = () => {
   const [tipoCobro, setTipoCobro] = useState('total'); // 'total' | 'parcial'
   const [montoParcial, setMontoParcial] = useState('');
   const [modoCobro, setModoCobro] = useState('nuevo'); // 'nuevo' | 'vincular' | 'solo_estado'
+  // Fecha efectiva de cobro (TAR-442): default hoy, editable para registrar cobros históricos.
+  const [fechaCobro, setFechaCobro] = useState(new Date().toISOString().split('T')[0]);
   const [movVinculables, setMovVinculables] = useState([]);
   const [movSel, setMovSel] = useState(null);
 
@@ -162,6 +164,7 @@ const DetallePlanPage = () => {
     setMontoParcial('');
     setModoCobro('nuevo');
     setMovSel(null);
+    setFechaCobro(new Date().toISOString().split('T')[0]);
     // Precargar movimientos vinculables (por si el usuario elige "vincular")
     planCobroService.listarMovimientosVinculables(empresaId, plan?.proyecto_id)
       .then((res) => setMovVinculables(res?.data?.data || []))
@@ -181,7 +184,7 @@ const DetallePlanPage = () => {
     setCobrandoId(cuotaId);
     try {
       await marcarCobrada(cuotaId, {
-        fecha_cobrado: new Date().toISOString().split('T')[0],
+        fecha_cobrado: fechaCobro || new Date().toISOString().split('T')[0],
         monto_parcial: parcial ? Number(parcial) : undefined,
         modo: modoCobro,
         movimiento_id: modoCobro === 'vincular' ? movSel?._id : undefined,
@@ -1191,6 +1194,23 @@ const DetallePlanPage = () => {
                         ? `Resto después de este pago: ${formatCurrency(Math.max(0, montoRestante - (Number(montoParcial) || 0)), monedaDisplay)}`
                         : ''
                     }
+                  />
+                )}
+
+                {/* Fecha efectiva de cobro (TAR-442): editable para registrar cobros históricos.
+                    En modo "vincular" la fecha la define el movimiento ya cargado. */}
+                {modoCobro !== 'vincular' && (
+                  <TextField
+                    label="Fecha efectiva de cobro"
+                    type="date"
+                    value={fechaCobro}
+                    onChange={(e) => setFechaCobro(e.target.value)}
+                    fullWidth
+                    size="small"
+                    sx={{ mt: 2 }}
+                    InputLabelProps={{ shrink: true }}
+                    inputProps={{ max: new Date().toISOString().split('T')[0] }}
+                    helperText="El ingreso en caja se registra con esta fecha. Podés indicar una fecha pasada."
                   />
                 )}
 


### PR DESCRIPTION
## TAR-442 (Parte A) · Fecha efectiva de cobro

> Ticket: [TAR-442](https://app.notion.com/p/38450a1e5341801e9245db28231c64a2)
> Parte B (tablero consolidado de proyección financiera) ya está implementada; este PR cubre **solo la Parte A**.

### Problema
Al registrar un cobro desde una cuota ("Cobrar ahora"), el sistema tomaba **siempre la fecha de hoy**. Eso impide cargar cobros históricos con su fecha real, y desalinea reportes, flujo de fondos y análisis histórico (una cuota cobrada el 15/05 quedaba registrada con la fecha de carga).

### Solución
El **backend ya soportaba** `fecha_cobrado` de punta a punta: `marcarCuotaCobrada()` lo usa para el snapshot CAC/USD del día del cobro, para la `fecha_factura` del `MovimientoCaja` que genera, y para `cuota.fecha_cobrado`. Lo único que faltaba era exponerlo en la UI — el front mandaba `fecha_cobrado` **hardcodeado a hoy**.

Este PR agrega el campo en el diálogo "Registrar cobro" (`src/pages/cobros/[id].js`):
- **Campo "Fecha efectiva de cobro"** (`type="date"`), con default = hoy y `max` = hoy (permite fechas pasadas, no futuras).
- Al confirmar, se envía la fecha elegida como `fecha_cobrado` (antes: `new Date()` fijo).
- Se **resetea a hoy** cada vez que se abre el diálogo (`handleCobrarClick`).
- Se **oculta en modo "Vincular pago existente"**, porque en ese caso la fecha la define el movimiento de caja ya cargado; se muestra para "Nuevo ingreso" y "Solo marcar".

### Flujo de datos
`Dialog (fechaCobro) → handleCobrarConfirm → marcarCobrada(opciones) → planCobroService.marcarCuotaCobrada → POST /cobros/:id/cuotas/:cuotaId/cobrar → ctrl.marcarCuotaCobrada → svc.marcarCuotaCobrada`
→ el `MovimientoCaja` se crea con `fecha_factura = fechaCobro` y la cuota guarda `fecha_cobrado = fechaCobro`. Las vistas de caja ordenan/filtran por `fecha_factura`, por lo que el ingreso queda en el período correcto.

### Alcance
- **Solo frontend.** No toca el backend (ya estaba listo).
- No cambia el comportamiento por defecto: si el usuario no toca el campo, se cobra con la fecha de hoy igual que antes.

### Cómo probar
1. Abrir un plan con una cuota pendiente → **Cobrar ahora**.
2. Cambiar "Fecha efectiva de cobro" a una fecha pasada (ej. 15/05/2026) → Confirmar cobro.
3. Verificar que el movimiento de caja generado quedó con esa fecha (no la de hoy) y que la cuota muestra "Cobrada: 15/05/2026".
4. En un plan CAC: confirmar que el monto ajustado usa el índice correspondiente a la fecha efectiva, no al día de carga.
5. Modo "Vincular pago existente": el campo de fecha no aparece (la fecha la aporta el movimiento vinculado).

### Verificación realizada
- `eslint` del archivo modificado: sin errores.
- Camino backend de `fecha_cobrado` revisado en `planCobroService.marcarCuotaCobrada` y `MovimientoCajaService.createMovimiento` (usa `fecha_factura`). Falta smoke test manual en el browser con una cuota pendiente.
