### PR TITLE
fix(cajas): totales filtrados dolarizados muestran US$ 0 al filtrar por moneda (TAR-515)

### DIFF
--- a/src/pages/cajas.js
+++ b/src/pages/cajas.js
@@ -2050,16 +2050,36 @@ const getTime = (v) => {
 };
 
   
-  const totalesDetallados = useMemo(() => ({
-    ARS: {
-      ingreso: dashboardTotals?.currencies?.ARS?.ingreso || 0,
-      egreso: dashboardTotals?.currencies?.ARS?.egreso || 0,
-    },
-    USD: {
-      ingreso: dashboardTotals?.currencies?.USD?.ingreso || 0,
-      egreso: dashboardTotals?.currencies?.USD?.egreso || 0,
-    },
-  }), [dashboardTotals]);
+  const totalesDetallados = useMemo(() => {
+    // Cajas con equivalencia (p. ej. dolarizada = usd_referencia) totalizan TODOS
+    // los movimientos convertidos a la moneda de salida. El balde `currencies` sólo
+    // suma por moneda nativa, así que al filtrar por moneda daría 0 (TAR-515).
+    // Espejamos la lógica de getCajaNetFromTotals: leemos el balde de equivalencia.
+    const equivalencia = activeCaja?.equivalencia && activeCaja.equivalencia !== 'none'
+      ? activeCaja.equivalencia
+      : null;
+
+    if (equivalencia) {
+      const eq = dashboardTotals?.equivalencias?.[equivalencia] || {};
+      const outCur = EQUIV_META[equivalencia]?.out || 'USD';
+      return {
+        ARS: { ingreso: 0, egreso: 0 },
+        USD: { ingreso: 0, egreso: 0 },
+        [outCur]: { ingreso: eq.ingreso || 0, egreso: eq.egreso || 0 },
+      };
+    }
+
+    return {
+      ARS: {
+        ingreso: dashboardTotals?.currencies?.ARS?.ingreso || 0,
+        egreso: dashboardTotals?.currencies?.ARS?.egreso || 0,
+      },
+      USD: {
+        ingreso: dashboardTotals?.currencies?.USD?.ingreso || 0,
+        egreso: dashboardTotals?.currencies?.USD?.egreso || 0,
+      },
+    };
+  }, [dashboardTotals, activeCaja]);
 
   const movimientosConProrrateo = useMemo(() => dashboardItems, [dashboardItems]);
 


### PR DESCRIPTION
## Ticket
TAR-515 — *Caja dolarizada muestra US$ 0 al filtrar por moneda ARS* (Impacto: Alta, módulo Caja)

## Problema
En una caja **dolarizada** (equivalencia `usd_referencia`), al activar el filtro **Moneda: ARS** el panel **Totales filtrados** muestra **US$ 0,00**, aunque los movimientos ARS aparecen en el listado y forman parte de la caja (convertidos a USD Referencia).

## Causa raíz
El memo `totalesDetallados` (`src/pages/cajas.js`) se alimentaba **solo** de `dashboardTotals.currencies.ARS/USD`, que suman por **moneda nativa**. Para una caja dolarizada el número correcto vive en `dashboardTotals.equivalencias.usd_referencia` (que el backend ya calcula sobre el set filtrado). Al filtrar por ARS, `currencies.USD` queda en 0 → el panel muestra US$ 0.

Los **cards grandes** ("Caja Dolarizada Total") ya usaban el balde correcto vía `getCajaNetFromTotals`, por eso mostraban el valor bien y el panel no: quedaban inconsistentes.

## Fix
`totalesDetallados` ahora es **equivalencia-aware**, espejando la lógica de `getCajaNetFromTotals`:
- Caja con equivalencia (ej. `usd_referencia`) → lee `equivalencias[equivalencia]`, ubicado bajo la moneda de salida (USD).
- Caja sin equivalencia (Pesos / Dólares) → sigue leyendo `currencies[moneda]` **sin cambios**.

Backend intacto: el dato ya venía correcto y filtrado.

## QA sugerido
En una caja dolarizada con movimientos ARS + USD:
- **Sin filtro** → suma de todos (ARS convertidos + USD).
- **Filtro Moneda: ARS** → equivalente USD de solo los ARS (antes: `US$ 0`).
- **Filtro Moneda: USD** → solo los USD.

No-regresión:
- Caja en **Pesos** + filtro ARS → sigue mostrando pesos.
- Caja en **Dólares** → sigue mostrando USD nativos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)