### PR TITLE
TAR-552 — DHN: mostrar ambas licencias duplicadas

### DIFF
--- a/src/components/dhn/sync/ResolverDuplicadoModal.js
+++ b/src/components/dhn/sync/ResolverDuplicadoModal.js
@@ -155,7 +155,7 @@ const ComprobanteCard = ({
   onClick,
   fullHeight,
   viewerState,
-  /** Sin clic, sin zoom embebido ni cambio de tamaño (p. ej. asistente «dos trabajos»). */
+  /** Sin clic ni cambio de tamaño (la selección la maneja el asistente «dos trabajos»); el zoom/rotación sí queda disponible. */
   readOnly = false,
 }) => {
   const theme = useTheme();
@@ -163,7 +163,9 @@ const ComprobanteCard = ({
   const showAsSelected = readOnly ? false : selected;
   const previewFlex = fullHeight ? (readOnly ? 1 : showAsSelected ? 1 : 0.45) : 1;
   const previewHeight = fullHeight ? "100%" : 160;
-  const useViewer = !readOnly && showAsSelected && url && viewerState;
+  // En el asistente (readOnly) igual mostramos el visor en ambas tarjetas para poder
+  // ampliar/rotar el comprobante mientras se decide la división en dos trabajos.
+  const useViewer = Boolean(url) && Boolean(viewerState) && (readOnly || showAsSelected);
 
   const handleContentClick = useCallback(
     (e) => {
@@ -189,7 +191,7 @@ const ComprobanteCard = ({
         flexDirection: "column",
         flex: readOnly ? 1 : showAsSelected ? 3 : 1,
         minWidth: 0,
-        pointerEvents: readOnly ? "none" : "auto",
+        pointerEvents: readOnly && !useViewer ? "none" : "auto",
         userSelect: readOnly ? "none" : "auto",
         ...(fullHeight ? { height: "100%" } : {}),
       }}

--- a/src/hooks/dhn/useTrabajoDiarioPage.js
+++ b/src/hooks/dhn/useTrabajoDiarioPage.js
@@ -61,6 +61,56 @@ const getCustomRange = (fromISO, toISO) => {
   return { from: start.toISOString(), to: end.toISOString() };
 };
 
+const trabajadorKey = (doc) => {
+  const tid = doc?.trabajadorId;
+  if (tid && typeof tid === 'object') return String(tid._id || tid.id || '');
+  return String(tid || '');
+};
+
+const fechaKey = (doc) => {
+  if (!doc?.fecha) return '';
+  const d = new Date(doc.fecha);
+  return Number.isNaN(d.getTime()) ? String(doc.fecha) : d.toISOString().slice(0, 10);
+};
+
+// Normalmente hay un solo TrabajoDiarioRegistrado por trabajador+día, pero cuando
+// se resuelve una licencia con "agregar ambos" quedan dos documentos (cada uno con
+// su PDF). Para que la fila del día muestre ambos comprobantes (chips en la tabla y
+// tabs en el modal de editar) agrupamos por trabajador+fecha y fusionamos los
+// `comprobantes`. Para días sin duplicados es un no-op (grupo de 1). El `total`/stats
+// siguen viniendo del server (cuenta documentos), así que la paginación puede diferir
+// en unas pocas filas cuando hay duplicados; es aceptable dado lo infrecuente.
+const agruparPorTrabajadorFecha = (docs) => {
+  const grupos = new Map();
+  const orden = [];
+  for (const doc of docs) {
+    const key = `${trabajadorKey(doc)}|${fechaKey(doc)}`;
+    if (!grupos.has(key)) {
+      grupos.set(key, []);
+      orden.push(key);
+    }
+    grupos.get(key).push(doc);
+  }
+  return orden.map((key) => {
+    const grupo = grupos.get(key);
+    if (grupo.length === 1) return grupo[0];
+    // Primario para acciones/edición: el que tenga horas (no solo licencia); si no, el primero.
+    const primario = grupo.find((d) => !d.fechaLicencia) || grupo[0];
+    const vistos = new Set();
+    const comprobantes = [];
+    for (const d of grupo) {
+      for (const comp of d.comprobantes || []) {
+        const url = comp?.url || comp?.url_storage;
+        const dedupKey = url || `${comp?.type}-${comprobantes.length}`;
+        if (vistos.has(dedupKey)) continue;
+        vistos.add(dedupKey);
+        comprobantes.push(comp);
+      }
+    }
+    return { ...primario, comprobantes, _grupoIds: grupo.map((d) => d._id) };
+  });
+};
+
 export default function useTrabajoDiarioPage(options = {}) {
   const {
     enabled = true,
@@ -176,7 +226,10 @@ export default function useTrabajoDiarioPage(options = {}) {
     }
   );
 
-  const data = Array.isArray(response?.data) ? response.data : [];
+  const data = useMemo(
+    () => agruparPorTrabajadorFecha(Array.isArray(response?.data) ? response.data : []),
+    [response?.data]
+  );
   const stats = response?.stats || DEFAULT_STATS;
   const total = Number.isFinite(response?.total) ? response.total : Number(response?.total) || 0;
 


### PR DESCRIPTION
# TAR-552 — DHN: mostrar ambas licencias duplicadas

Frontend de las correcciones de DHN. Ticket: https://app.notion.com/p/DHN-Correcci-n-de-horas-redondas-en-feriados-39d50a1e5341807bb01ec8e484427639 · PR hermano (backend, cálculo de horas y errores): https://github.com/fedemaidan/sorby_bot_wa/pull/252

---

## Licencias duplicadas: se veía solo una

**Causa raíz / Problema:** cuando una licencia entra dos veces (una foto subida en el momento + el escaneo que llega después) y se resuelve con "agregar ambos", quedan **dos registros** del mismo trabajador y día, cada uno con su PDF. En las tablas (trabajadores, control diario, control quincenal) y en el editar se veía una sola, y el otro PDF no aparecía.

**Cómo lo hicimos (funcional):** ahora el día muestra **las dos licencias juntas**: en la columna de comprobantes aparecen los dos chips (cada uno abre su PDF) y el modal de editar las lista como dos solapas. Se conservan ambos documentos (no se deduplica), como pidió el cliente: a veces son casos legítimos distintos (ej. un Franco "salvado" con los mismos datos).

**Decisiones y por qué:**
- Conservar los dos documentos y arreglar solo la visualización → pedido explícito del cliente (prefieren ver ambas y elegir antes que auto-deduplicar).
- Resolver en el frontend, agrupando por trabajador+fecha → no toca el backend ni el modelo; la celda del chip y el modal ya saben renderizar varios comprobantes, así que alcanza con juntarlos.

**Cómo lo implementamos (técnico):**
- `src/hooks/dhn/useTrabajoDiarioPage.js`: nuevo `agruparPorTrabajadorFecha(docs)` que colapsa los documentos del mismo `trabajadorId + fecha` en una fila y fusiona sus `comprobantes` (dedup por url). El hook lo alimenta a las tres tablas. Para el día sin duplicados es un no-op (grupo de 1).
- La fila fusionada elige un documento "primario" para las acciones/edición (el que tenga horas; si no, el primero) y llega tal cual al `CorreccionConciliacionModal`, que ya arma una solapa por comprobante. `ComprobantesCell` ya pinta un chip por comprobante con su propio `href`.

**Producción / compatibilidad:** sin cambios de datos ni backend. El `total`/stats siguen viniendo del server (cuenta documentos), así que en días con duplicados la paginación puede diferir en unas pocas filas; es aceptable dado lo infrecuente.

**Verificación:** en la tabla del trabajador / control diario / quincenal, un día con dos licencias muestra **dos chips** (ambos abren su PDF) y el editar lista **dos solapas**. Días duplicados reales en la copia local para probar: `2026-05-08`, `2026-02-09`, `2026-02-10`, `2026-02-26`.

**Notas al código:**
- `agruparPorTrabajadorFecha` → normalmente hay un solo registro por trabajador+día; el agrupado solo colapsa cuando hay duplicados (licencias con "agregar ambos"). Se elige primario no-licencia para que el editar de horas apunte al documento con datos.

> La rama también incluye un commit previo (`303f565`) que habilita zoom/rotación de comprobantes en el wizard de duplicado, parte del mismo ticket.

---

## TL;DR
- **Licencias duplicadas:** el día ahora muestra las dos licencias — dos chips (cada uno abre su PDF) en las tablas y dos solapas en el editar. Se conservan los dos documentos; no se toca el backend.
- **Archivo clave:** `src/hooks/dhn/useTrabajoDiarioPage.js` (`agruparPorTrabajadorFecha`: agrupa por trabajador+fecha y fusiona comprobantes). `ComprobantesCell` y `CorreccionConciliacionModal` ya soportaban varios comprobantes.
- **Sin migración.** Solo cambia la vista; paginación puede diferir en pocas filas cuando hay duplicados.
- **Verificación:** probar con días duplicados reales de local (`2026-05-08`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
