### PR TITLE
fix(TAR-566): catálogo de importación de proveedores desde la colección

### DIFF
--- a/src/sections/importMovimientos/PasoRevisarProveedores.js
+++ b/src/sections/importMovimientos/PasoRevisarProveedores.js
@@ -30,6 +30,7 @@ import {
   Delete as DeleteIcon
 } from '@mui/icons-material';
 import importMovimientosService from 'src/services/importMovimientosService';
+import proveedorService from 'src/services/proveedorService';
 import { buscarCanonicoEnLista } from 'src/utils/normalizarNombre';
 
 const PasoRevisarProveedores = forwardRef(({
@@ -142,7 +143,15 @@ const PasoRevisarProveedores = forwardRef(({
       // Defensa redundante: matchear cada proveedor detectado contra el catálogo
       // de la empresa con normalización estricta (case/acentos/espacios). Si el
       // backend marcó como nuevo pero hay un canónico, lo reclasificamos.
-      const catalogo = empresa?.proveedores_data || empresa?.proveedores || [];
+      // Catálogo desde la colección Proveedor (fuente única, TAR-566): antes salía
+      // de empresa.proveedores_data (array embebido) que quedaba con nombres viejos
+      // al renombrar/borrar. La colección es la que edita/muestra la web.
+      let catalogo = [];
+      try {
+        catalogo = await proveedorService.getByEmpresa(empresaId);
+      } catch (err) {
+        console.warn('[PasoRevisarProveedores] No se pudo cargar el catálogo de proveedores:', err);
+      }
       const getNombre = (p) => (typeof p === 'string' ? p : (p?.nombre || p?.name || ''));
       const proveedoresFinales = proveedoresNormalizados.map((prov) => {
         if (prov.estado === 'existe' || prov.estado === 'variante' || prov.accion === 'usar_existente') {


### PR DESCRIPTION
## Contexto (TAR-566)

Parte front del fix de TAR-566 (backend: sorby_bot_wa#258). El bot y la web usaban dos fuentes distintas para los proveedores: la colección `Proveedor` (autoritativa, la que edita la web) y `empresa.proveedores_data` (array embebido legacy que quedaba con nombres viejos al renombrar/borrar).

## Cambio

El paso **"Revisar proveedores"** del wizard de importación de movimientos ([PasoRevisarProveedores.js](src/sections/importMovimientos/PasoRevisarProveedores.js)) usaba `empresa.proveedores_data` como catálogo para reclasificar proveedores detectados (nuevo vs. usar-existente). Ahora el catálogo sale de la **colección** vía `proveedorService.getByEmpresa(empresaId)` — el mismo endpoint que usa la pantalla de Proveedores.

- Bajo riesgo: es un match redundante con revisión humana en pantalla.
- `buscarCanonicoEnLista` solo depende de `.nombre`, que los docs de la colección tienen.
- `try/catch` defensivo: si falla el fetch, el catálogo queda vacío (el backend ya clasificó igual).

Con esto **ningún lector consume ya `empresa.proveedores_data`**, lo que habilita borrarlo del schema en el follow-up.

Diseño técnico: `docs/PROVEEDORES_CONTEXTO_BOT_FIXES_TECNICO.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)