### PR TITLE
Control de Obra: curva multi-serie + UI multi-plan (TAR-547/548)

### DIFF
--- a/src/components/controlObra/CobrosObraTab.js
+++ b/src/components/controlObra/CobrosObraTab.js
@@ -1,22 +1,21 @@
-import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { Box, Chip, LinearProgress, Paper, Stack, Typography, Button } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import planCobroService from 'src/services/planCobroService';
-import ControlObraService from 'src/services/controlObra/controlObraService';
 
 const money = (n, moneda) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: moneda === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
 
-// Pestaña "Cobros" de la obra: muestra el/los plan(es) de cobro asociados y cómo
-// vienen. En modo 'plan' el cobro va por acá; en modo 'certificados' el plan se
-// alimenta de los certificados aprobados.
+// Pestaña "Cobros" de la obra: muestra el/los plan(es) de cobro asociados (0..N).
+// "Nuevo plan" abre el asistente de creación con la obra ya asignada; al guardar,
+// el plan queda asociado a la obra. Los certificados se cobran directo (otra pestaña).
 export default function CobrosObraTab({ obra, empresaId }) {
   const router = useRouter();
-  const queryClient = useQueryClient();
-  const nuevoPlanMut = useMutation({
-    mutationFn: () => ControlObraService.agregarPlan(obra._id, empresaId, { nombre: `Plan ${(obra.plan_cobro_ids || []).length + 1}` }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['control-obra'] }),
+  // Abre el asistente de plan de cobro con la obra (y su proyecto) precargados.
+  const nuevoPlan = () => router.push({
+    pathname: '/cobros/nuevo',
+    query: { obra: obra._id, ...(obra.proyecto_id ? { proyecto: obra.proyecto_id } : {}) },
   });
   const planIds = (obra.plan_cobro_ids && obra.plan_cobro_ids.length)
     ? obra.plan_cobro_ids
@@ -39,7 +38,7 @@ export default function CobrosObraTab({ obra, empresaId }) {
         <Typography variant="caption" color="text.secondary" sx={{ flexGrow: 1 }}>
           Una obra puede tener 0..N planes de cobro (fijos). Los certificados se cobran directo (pestaña Certificados).
         </Typography>
-        <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={() => nuevoPlanMut.mutate()} disabled={nuevoPlanMut.isPending}>
+        <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={nuevoPlan}>
           Nuevo plan
         </Button>
       </Stack>

--- a/src/components/controlObra/CobrosObraTab.js
+++ b/src/components/controlObra/CobrosObraTab.js
@@ -9,8 +9,10 @@ import AddIcon from '@mui/icons-material/Add';
 import LinkIcon from '@mui/icons-material/Link';
 import LinkOffIcon from '@mui/icons-material/LinkOff';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import LinkOffRoundedIcon from '@mui/icons-material/LinkOffRounded';
 import planCobroService from 'src/services/planCobroService';
 import ControlObraService from 'src/services/controlObra/controlObraService';
+import ConfirmDialog from 'src/components/controlObra/ConfirmDialog';
 
 const money = (n, moneda) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: moneda === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
 
@@ -22,6 +24,7 @@ export default function CobrosObraTab({ obra, empresaId }) {
   const queryClient = useQueryClient();
   const [openAsociar, setOpenAsociar] = useState(false);
   const [selPlan, setSelPlan] = useState('');
+  const [confirmDes, setConfirmDes] = useState(null); // plan a desasociar (abre el diálogo)
 
   const planIds = (obra.plan_cobro_ids && obra.plan_cobro_ids.length)
     ? obra.plan_cobro_ids.map(String)
@@ -62,14 +65,8 @@ export default function CobrosObraTab({ obra, empresaId }) {
 
   const desasociarMut = useMutation({
     mutationFn: (planId) => ControlObraService.desasociarPlan(obra._id, empresaId, planId),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['control-obra'] }),
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['control-obra'] }); setConfirmDes(null); },
   });
-  const desasociar = (plan) => {
-    // eslint-disable-next-line no-alert
-    if (window.confirm(`¿Desasociar "${plan.nombre}" de esta obra? El plan no se borra, solo se desvincula.`)) {
-      desasociarMut.mutate(plan._id);
-    }
-  };
 
   return (
     <Box>
@@ -123,8 +120,7 @@ export default function CobrosObraTab({ obra, empresaId }) {
                     size="small"
                     color="error"
                     startIcon={<LinkOffIcon fontSize="small" />}
-                    disabled={desasociarMut.isPending}
-                    onClick={() => desasociar(plan)}
+                    onClick={() => setConfirmDes(plan)}
                   >
                     Desasociar
                   </Button>
@@ -192,6 +188,19 @@ export default function CobrosObraTab({ obra, empresaId }) {
           </Button>
         </DialogActions>
       </Dialog>
+
+      <ConfirmDialog
+        open={!!confirmDes}
+        icon={<LinkOffRoundedIcon color="error" />}
+        title="Desasociar plan de cobro"
+        message={`¿Desasociar "${confirmDes?.nombre || ''}" de esta obra?`}
+        detail="El plan no se borra ni cambia de estado; solo se desvincula de la obra."
+        confirmLabel="Desasociar"
+        confirmColor="error"
+        loading={desasociarMut.isPending}
+        onConfirm={() => desasociarMut.mutate(confirmDes._id)}
+        onClose={() => setConfirmDes(null)}
+      />
     </Box>
   );
 }

--- a/src/components/controlObra/CobrosObraTab.js
+++ b/src/components/controlObra/CobrosObraTab.js
@@ -1,8 +1,10 @@
-import { useQuery, useQueries } from '@tanstack/react-query';
+import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { Box, Chip, LinearProgress, Paper, Stack, Typography, Button } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import planCobroService from 'src/services/planCobroService';
+import ControlObraService from 'src/services/controlObra/controlObraService';
 
 const money = (n, moneda) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: moneda === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
 
@@ -11,6 +13,11 @@ const money = (n, moneda) => (n || 0).toLocaleString('es-AR', { style: 'currency
 // alimenta de los certificados aprobados.
 export default function CobrosObraTab({ obra, empresaId }) {
   const router = useRouter();
+  const queryClient = useQueryClient();
+  const nuevoPlanMut = useMutation({
+    mutationFn: () => ControlObraService.agregarPlan(obra._id, empresaId, { nombre: `Plan ${(obra.plan_cobro_ids || []).length + 1}` }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['control-obra'] }),
+  });
   const planIds = (obra.plan_cobro_ids && obra.plan_cobro_ids.length)
     ? obra.plan_cobro_ids
     : (obra.plan_cobro_id ? [obra.plan_cobro_id] : []);
@@ -28,23 +35,19 @@ export default function CobrosObraTab({ obra, empresaId }) {
   return (
     <Box>
       <Stack direction="row" alignItems="center" spacing={1} mb={2} flexWrap="wrap">
-        <Typography variant="subtitle2" fontWeight={700}>Cobro de la obra:</Typography>
-        <Chip
-          size="small"
-          color={obra.modo_cobro === 'plan' ? 'primary' : 'default'}
-          label={obra.modo_cobro === 'plan' ? 'Por plan de cobro' : 'Por certificados'}
-        />
-        <Typography variant="caption" color="text.secondary">
-          {obra.modo_cobro === 'plan'
-            ? 'El cobro va por el cronograma del/los plan(es). Los certificados registran avance pero no generan cuotas.'
-            : 'Cada certificado aprobado agrega una cuota al plan.'}
+        <Typography variant="subtitle2" fontWeight={700}>Planes de cobro de la obra</Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ flexGrow: 1 }}>
+          Una obra puede tener 0..N planes de cobro (fijos). Los certificados se cobran directo (pestaña Certificados).
         </Typography>
+        <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={() => nuevoPlanMut.mutate()} disabled={nuevoPlanMut.isPending}>
+          Nuevo plan
+        </Button>
       </Stack>
 
       {loading && <LinearProgress sx={{ mb: 2 }} />}
 
       {!loading && planes.length === 0 && (
-        <Typography variant="body2" color="text.secondary">La obra no tiene plan de cobro asociado.</Typography>
+        <Typography variant="body2" color="text.secondary">La obra no tiene planes de cobro asociados.</Typography>
       )}
 
       <Stack spacing={1.5}>

--- a/src/components/controlObra/CobrosObraTab.js
+++ b/src/components/controlObra/CobrosObraTab.js
@@ -7,6 +7,7 @@ import {
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import LinkIcon from '@mui/icons-material/Link';
+import LinkOffIcon from '@mui/icons-material/LinkOff';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import planCobroService from 'src/services/planCobroService';
 import ControlObraService from 'src/services/controlObra/controlObraService';
@@ -59,6 +60,17 @@ export default function CobrosObraTab({ obra, empresaId }) {
     },
   });
 
+  const desasociarMut = useMutation({
+    mutationFn: (planId) => ControlObraService.desasociarPlan(obra._id, empresaId, planId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['control-obra'] }),
+  });
+  const desasociar = (plan) => {
+    // eslint-disable-next-line no-alert
+    if (window.confirm(`¿Desasociar "${plan.nombre}" de esta obra? El plan no se borra, solo se desvincula.`)) {
+      desasociarMut.mutate(plan._id);
+    }
+  };
+
   return (
     <Box>
       <Stack direction="row" alignItems="center" spacing={1} mb={2} flexWrap="wrap">
@@ -98,14 +110,25 @@ export default function CobrosObraTab({ obra, empresaId }) {
                     {r.proxima_cuota?.fecha_vencimiento ? ` · Próxima: ${new Date(r.proxima_cuota.fecha_vencimiento).toLocaleDateString('es-AR')}` : ''}
                   </Typography>
                 </Box>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  endIcon={<OpenInNewIcon fontSize="small" />}
-                  onClick={() => router.push(`/cobros/${plan._id}`)}
-                >
-                  Ver plan
-                </Button>
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    endIcon={<OpenInNewIcon fontSize="small" />}
+                    onClick={() => router.push(`/cobros/${plan._id}`)}
+                  >
+                    Ver plan
+                  </Button>
+                  <Button
+                    size="small"
+                    color="error"
+                    startIcon={<LinkOffIcon fontSize="small" />}
+                    disabled={desasociarMut.isPending}
+                    onClick={() => desasociar(plan)}
+                  >
+                    Desasociar
+                  </Button>
+                </Stack>
               </Stack>
 
               <Stack direction="row" spacing={3} mt={1.5} flexWrap="wrap">

--- a/src/components/controlObra/CobrosObraTab.js
+++ b/src/components/controlObra/CobrosObraTab.js
@@ -1,25 +1,36 @@
-import { useQuery, useQueries } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
-import { Box, Chip, LinearProgress, Paper, Stack, Typography, Button } from '@mui/material';
+import {
+  Box, Chip, LinearProgress, Paper, Stack, Typography, Button,
+  Dialog, DialogTitle, DialogContent, DialogActions, TextField, MenuItem, Alert,
+} from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
+import LinkIcon from '@mui/icons-material/Link';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import planCobroService from 'src/services/planCobroService';
+import ControlObraService from 'src/services/controlObra/controlObraService';
 
 const money = (n, moneda) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: moneda === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
 
 // Pestaña "Cobros" de la obra: muestra el/los plan(es) de cobro asociados (0..N).
-// "Nuevo plan" abre el asistente de creación con la obra ya asignada; al guardar,
-// el plan queda asociado a la obra. Los certificados se cobran directo (otra pestaña).
+// "Nuevo plan" abre el asistente de creación con la obra ya asignada; "Asociar
+// existente" engancha un plan ya creado. Los certificados se cobran directo (otra pestaña).
 export default function CobrosObraTab({ obra, empresaId }) {
   const router = useRouter();
+  const queryClient = useQueryClient();
+  const [openAsociar, setOpenAsociar] = useState(false);
+  const [selPlan, setSelPlan] = useState('');
+
+  const planIds = (obra.plan_cobro_ids && obra.plan_cobro_ids.length)
+    ? obra.plan_cobro_ids.map(String)
+    : (obra.plan_cobro_id ? [String(obra.plan_cobro_id)] : []);
+
   // Abre el asistente de plan de cobro con la obra (y su proyecto) precargados.
   const nuevoPlan = () => router.push({
     pathname: '/cobros/nuevo',
     query: { obra: obra._id, ...(obra.proyecto_id ? { proyecto: obra.proyecto_id } : {}) },
   });
-  const planIds = (obra.plan_cobro_ids && obra.plan_cobro_ids.length)
-    ? obra.plan_cobro_ids
-    : (obra.plan_cobro_id ? [obra.plan_cobro_id] : []);
 
   const planesQ = useQueries({
     queries: planIds.map((pid) => ({
@@ -31,6 +42,23 @@ export default function CobrosObraTab({ obra, empresaId }) {
   const planes = planesQ.map((q) => q.data).filter(Boolean);
   const loading = planesQ.some((q) => q.isLoading);
 
+  // Planes de la empresa disponibles para asociar (los que no están ya en la obra).
+  const disponiblesQ = useQuery({
+    queryKey: ['plan-cobro', 'empresa', empresaId],
+    queryFn: async () => (await planCobroService.listarPlanes(empresaId))?.data?.data || [],
+    enabled: !!empresaId && openAsociar,
+  });
+  const disponibles = (disponiblesQ.data || []).filter((p) => !planIds.includes(String(p._id)));
+
+  const asociarMut = useMutation({
+    mutationFn: (planId) => ControlObraService.agregarPlan(obra._id, empresaId, { plan_cobro_id: planId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['control-obra'] });
+      setOpenAsociar(false);
+      setSelPlan('');
+    },
+  });
+
   return (
     <Box>
       <Stack direction="row" alignItems="center" spacing={1} mb={2} flexWrap="wrap">
@@ -38,6 +66,9 @@ export default function CobrosObraTab({ obra, empresaId }) {
         <Typography variant="caption" color="text.secondary" sx={{ flexGrow: 1 }}>
           Una obra puede tener 0..N planes de cobro (fijos). Los certificados se cobran directo (pestaña Certificados).
         </Typography>
+        <Button size="small" variant="text" startIcon={<LinkIcon />} onClick={() => setOpenAsociar(true)}>
+          Asociar existente
+        </Button>
         <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={nuevoPlan}>
           Nuevo plan
         </Button>
@@ -94,6 +125,50 @@ export default function CobrosObraTab({ obra, empresaId }) {
           );
         })}
       </Stack>
+
+      {/* Diálogo: asociar un plan de cobro ya existente */}
+      <Dialog open={openAsociar} onClose={() => setOpenAsociar(false)} fullWidth maxWidth="sm">
+        <DialogTitle>Asociar plan de cobro existente</DialogTitle>
+        <DialogContent>
+          {disponiblesQ.isLoading && <LinearProgress sx={{ mb: 2 }} />}
+          {!disponiblesQ.isLoading && disponibles.length === 0 && (
+            <Alert severity="info" sx={{ mt: 1 }}>
+              No hay planes de cobro disponibles para asociar. Podés crear uno con &quot;Nuevo plan&quot;.
+            </Alert>
+          )}
+          {disponibles.length > 0 && (
+            <TextField
+              select
+              fullWidth
+              label="Plan de cobro"
+              value={selPlan}
+              onChange={(e) => setSelPlan(e.target.value)}
+              sx={{ mt: 1 }}
+            >
+              {disponibles.map((p) => (
+                <MenuItem key={p._id} value={p._id}>
+                  {(p.codigo ? `#${p.codigo} — ` : '') + p.nombre}
+                  {p.estado ? ` · ${p.estado}` : ''}
+                  {p.cliente_nombre ? ` · ${p.cliente_nombre}` : ''}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+          {asociarMut.isError && (
+            <Alert severity="error" sx={{ mt: 2 }}>No se pudo asociar el plan. Reintentá.</Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenAsociar(false)}>Cancelar</Button>
+          <Button
+            variant="contained"
+            disabled={!selPlan || asociarMut.isPending}
+            onClick={() => asociarMut.mutate(selPlan)}
+          >
+            Asociar
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/src/components/controlObra/ConfirmDialog.js
+++ b/src/components/controlObra/ConfirmDialog.js
@@ -1,0 +1,43 @@
+import {
+  Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Stack, Box,
+} from '@mui/material';
+
+// Diálogo de confirmación reutilizable (reemplaza window.confirm).
+export default function ConfirmDialog({
+  open,
+  title,
+  message,
+  detail = null,
+  confirmLabel = 'Aceptar',
+  cancelLabel = 'Cancelar',
+  confirmColor = 'primary',
+  icon = null,
+  loading = false,
+  onConfirm,
+  onClose,
+}) {
+  return (
+    <Dialog open={open} onClose={loading ? undefined : onClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ pb: 1 }}>
+        <Stack direction="row" spacing={1.5} alignItems="center">
+          {icon && <Box sx={{ display: 'flex' }}>{icon}</Box>}
+          <span>{title}</span>
+        </Stack>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ whiteSpace: 'pre-line' }}>{message}</DialogContentText>
+        {detail && (
+          <DialogContentText variant="caption" sx={{ mt: 1.5, display: 'block', whiteSpace: 'pre-line' }}>
+            {detail}
+          </DialogContentText>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={loading} color="inherit">{cancelLabel}</Button>
+        <Button onClick={onConfirm} disabled={loading} color={confirmColor} variant="contained" disableElevation>
+          {confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/controlObra/ResumenTab.js
+++ b/src/components/controlObra/ResumenTab.js
@@ -1,5 +1,5 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Box, Divider, Paper, Stack, Typography, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
+import { Box, Divider, Paper, Stack, Typography } from '@mui/material';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { LineChart } from '@mui/x-charts/LineChart';
 import DashboardIcon from '@mui/icons-material/Dashboard';
@@ -13,11 +13,6 @@ import { KpiCard, fmt, fmtM } from 'src/components/controlObra/ui';
 
 // Tablero de la obra (cockpit): snapshot financiero + qué necesita atención + circuito de plata.
 export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
-  const queryClient = useQueryClient();
-  const modoCobroMut = useMutation({
-    mutationFn: (modo) => ControlObraService.setModoCobro(obra._id, empresaId, modo),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['control-obra'] }),
-  });
   const carteraQ = useQuery({
     queryKey: ['control-obra', 'cartera', empresaId],
     queryFn: () => ControlObraService.resumenCartera(empresaId),
@@ -58,26 +53,6 @@ export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
 
   return (
     <Box>
-      {/* Fase F: cómo se cobra la obra */}
-      <Stack direction="row" alignItems="center" spacing={1.5} mb={2} flexWrap="wrap">
-        <Typography variant="body2" color="text.secondary">Cobro de la obra:</Typography>
-        <ToggleButtonGroup
-          size="small"
-          exclusive
-          value={obra.modo_cobro || 'certificados'}
-          onChange={(_, v) => { if (v) modoCobroMut.mutate(v); }}
-          disabled={modoCobroMut.isPending}
-        >
-          <ToggleButton value="certificados">Por certificados</ToggleButton>
-          <ToggleButton value="plan">Por plan de cobro</ToggleButton>
-        </ToggleButtonGroup>
-        {(obra.modo_cobro === 'plan') && (
-          <Typography variant="caption" color="text.secondary">
-            Los certificados registran avance pero no generan cuotas; el cobro va por el cronograma del plan.
-          </Typography>
-        )}
-      </Stack>
-
       <Stack direction="row" spacing={2} flexWrap="wrap" mb={3} useFlexGap>
         <KpiCard label="Contrato" value={fmtM(total)} sub="presupuesto total" />
         <KpiCard label="Avance físico" value={`${avance.toFixed(1)}%`} sub="ponderado por monto" />
@@ -126,15 +101,17 @@ export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
 
       {curva.meses.length > 0 && (
         <Paper variant="outlined" sx={{ p: 2, mt: 2 }}>
-          <Typography variant="subtitle2" fontWeight={600} mb={0.5}>Curva S — plan vs certificado vs cobrado ($M)</Typography>
+          <Typography variant="subtitle2" fontWeight={600} mb={0.5}>Curva financiera — plan vs certificado vs cobrado vs egresos ($M)</Typography>
           <Typography variant="caption" color="text.secondary" display="block" mb={1}>
-            Acumulado mensual. {curva.plan?.length ? 'Gris = plan (cronograma) · ' : ''}Naranja = certificado · Verde = cobrado.
+            Acumulado mensual. {curva.plan?.length ? 'Gris = plan (cronograma) · ' : ''}Naranja = certificado · Verde = cobrado{curva.ingresos_proyectados?.length ? ' · Verde claro = ingresos proyectados' : ''}{curva.egresos?.length ? ' · Rojo = egresos reales' : ''}.
           </Typography>
           <LineChart
             series={[
               ...(curva.plan?.length ? [{ data: curva.plan, label: 'Plan', color: '#9e9e9e' }] : []),
               { data: curva.certificado, label: 'Certificado', color: '#f57c00' },
               { data: curva.cobrado, label: 'Cobrado', color: '#388e3c' },
+              ...(curva.ingresos_proyectados?.length ? [{ data: curva.ingresos_proyectados, label: 'Ingresos proyectados', color: '#81c784' }] : []),
+              ...(curva.egresos?.length ? [{ data: curva.egresos, label: 'Egresos reales', color: '#d32f2f' }] : []),
             ]}
             xAxis={[{ data: curva.meses, scaleType: 'band' }]}
             height={240}

--- a/src/components/controlObra/carteraFiltros.js
+++ b/src/components/controlObra/carteraFiltros.js
@@ -1,0 +1,38 @@
+// Filtro + orden client-side reutilizable para las vistas de cartera (Cobranzas, Pagos a obra).
+
+// Obras únicas presentes en los ítems → [{ id, titulo }] ordenadas por título.
+export function obrasDeItems(items = []) {
+  const map = new Map();
+  for (const i of items) {
+    if (i.obra_id && !map.has(i.obra_id)) map.set(i.obra_id, i.obra_titulo || '(sin título)');
+  }
+  return [...map.entries()]
+    .map(([id, titulo]) => ({ id, titulo }))
+    .sort((a, b) => a.titulo.localeCompare(b.titulo, 'es'));
+}
+
+function comparar(a, b, key) {
+  const va = a?.[key];
+  const vb = b?.[key];
+  if (va == null && vb == null) return 0;
+  if (va == null) return 1; // nulls al final
+  if (vb == null) return -1;
+  if (key.startsWith('fecha')) return new Date(va) - new Date(vb);
+  if (typeof va === 'number' && typeof vb === 'number') return va - vb;
+  return String(va).localeCompare(String(vb), 'es', { numeric: true });
+}
+
+/**
+ * Filtra por obra y por rango de fecha, y ordena por una columna.
+ * @param {Array} items
+ * @param {{filtroObra?:string, desde?:string, hasta?:string, campoFecha?:string, orderBy?:string, order?:'asc'|'desc'}} opts
+ */
+export function aplicarFiltroOrden(items = [], opts = {}) {
+  const { filtroObra = '', desde = '', hasta = '', campoFecha = 'fecha_vencimiento', orderBy = null, order = 'asc' } = opts;
+  let out = items;
+  if (filtroObra) out = out.filter((i) => String(i.obra_id) === String(filtroObra));
+  if (desde) { const d = new Date(desde); out = out.filter((i) => i[campoFecha] && new Date(i[campoFecha]) >= d); }
+  if (hasta) { const h = new Date(hasta); h.setHours(23, 59, 59, 999); out = out.filter((i) => i[campoFecha] && new Date(i[campoFecha]) <= h); }
+  if (orderBy) out = [...out].sort((a, b) => { const c = comparar(a, b, orderBy); return order === 'asc' ? c : -c; });
+  return out;
+}

--- a/src/pages/cobros/nuevo.js
+++ b/src/pages/cobros/nuevo.js
@@ -46,6 +46,7 @@ import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
 import { getProyectosFromUser } from 'src/services/proyectosService';
 import clienteService from 'src/services/clienteService';
 import PresupuestoService from 'src/services/presupuestoService';
+import ControlObraService from 'src/services/controlObra/controlObraService';
 import planCobroService from 'src/services/planCobroService';
 import { CuotasTableEdit } from 'src/components/planCobro/CuotasTable';
 import { formatCurrency, formatNumberInput, parseNumberInput } from 'src/utils/formatters';
@@ -96,6 +97,8 @@ const todayIso = () => new Date().toISOString().split('T')[0];
 const NuevoPlanPage = () => {
   const { user } = useAuthContext();
   const router = useRouter();
+  // Si se llega desde una obra (?obra=...&proyecto=...), el plan se asocia a esa obra al guardar.
+  const obraId = router.query.obra ? String(router.query.obra) : null;
   const [step, setStep] = useState(0);
   const [empresaId, setEmpresaId] = useState(null);
   const [proyectos, setProyectos] = useState([]);
@@ -144,6 +147,13 @@ const NuevoPlanPage = () => {
     });
     getProyectosFromUser(user).then((list) => setProyectos(list || []));
   }, [user]);
+
+  // Pre-selecciona el proyecto de la obra cuando se llega desde una obra.
+  useEffect(() => {
+    if (!router.isReady) return;
+    const proyQ = router.query.proyecto ? String(router.query.proyecto) : null;
+    if (proyQ) setPlanData((prev) => (prev.proyecto_id ? prev : { ...prev, proyecto_id: proyQ }));
+  }, [router.isReady, router.query.proyecto]);
 
   const presupuestosDelProyecto = useMemo(() => {
     if (!planData.proyecto_id) return [];
@@ -480,6 +490,15 @@ const NuevoPlanPage = () => {
       });
       const dc = resConfirm?.data;
       if (!dc?.ok) throw new Error(dc?.error || 'Error al confirmar');
+
+      // Si se creó desde una obra, asociar el plan al control de obra y volver a la obra.
+      if (obraId) {
+        try {
+          await ControlObraService.agregarPlan(obraId, empresaId, { plan_cobro_id: plan._id });
+        } catch { /* si falla la asociación, el plan igual quedó creado */ }
+        router.push(`/control-obra/${obraId}`);
+        return;
+      }
 
       router.push(`/cobros/${plan._id}`);
     } catch (err) {

--- a/src/pages/control-obra/cobranzas.js
+++ b/src/pages/control-obra/cobranzas.js
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
-  Button, Card, CardContent, Chip, Container, LinearProgress, Stack,
-  Table, TableBody, TableCell, TableHead, TableRow, Typography,
+  Box, Button, Card, CardContent, Chip, Container, LinearProgress, Stack,
+  Table, TableBody, TableCell, TableHead, TableRow, TableSortLabel, TextField, MenuItem, Typography,
 } from '@mui/material';
 import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
@@ -12,15 +12,29 @@ import ControlObraService from 'src/services/controlObra/controlObraService';
 import CarteraNav from 'src/components/controlObra/CarteraNav';
 import SinPermisoControlObra, { puedeVerControlObra } from 'src/components/controlObra/AccesoControlObra';
 import { KpiCard, fmt } from 'src/components/controlObra/ui';
+import { aplicarFiltroOrden, obrasDeItems } from 'src/components/controlObra/carteraFiltros';
 
 const fecha = (d) => (d ? new Date(d).toLocaleDateString('es-AR') : '—');
 const vencida = (d) => d && new Date(d) < new Date();
+
+const COLS = [
+  { key: 'obra_titulo', label: 'Obra' },
+  { key: 'descripcion', label: 'Concepto' },
+  { key: 'fecha_vencimiento', label: 'Vencimiento' },
+  { key: 'estado', label: 'Estado' },
+  { key: 'pendiente', label: 'Pendiente', align: 'right' },
+];
 
 function CobranzasPage() {
   const { user } = useAuthContext();
   const router = useRouter();
   const qc = useQueryClient();
   const [empresaId, setEmpresaId] = useState(null);
+  const [filtroObra, setFiltroObra] = useState('');
+  const [desde, setDesde] = useState('');
+  const [hasta, setHasta] = useState('');
+  const [orderBy, setOrderBy] = useState('fecha_vencimiento');
+  const [order, setOrder] = useState('asc');
 
   useEffect(() => {
     if (!user) return;
@@ -35,10 +49,21 @@ function CobranzasPage() {
   const refresh = () => qc.invalidateQueries({ queryKey: ['control-obra'] });
   const accion = useMutation({ mutationFn: ({ fn }) => fn(), onSuccess: refresh });
 
-  const items = q.data || [];
+  const rows = q.data || [];
+  const obras = useMemo(() => obrasDeItems(rows), [rows]);
+  const items = useMemo(
+    () => aplicarFiltroOrden(rows, { filtroObra, desde, hasta, campoFecha: 'fecha_vencimiento', orderBy, order }),
+    [rows, filtroObra, desde, hasta, orderBy, order],
+  );
+
   const totalPendiente = items.reduce((a, i) => a + (i.pendiente || 0), 0);
   const vencidas = items.filter((i) => vencida(i.fecha_vencimiento));
   const totalVencido = vencidas.reduce((a, i) => a + (i.pendiente || 0), 0);
+
+  const sortHandler = (key) => {
+    if (orderBy === key) setOrder(order === 'asc' ? 'desc' : 'asc');
+    else { setOrderBy(key); setOrder('asc'); }
+  };
 
   if (user && !puedeVerControlObra(user)) return <SinPermisoControlObra />;
 
@@ -49,51 +74,66 @@ function CobranzasPage() {
         <CarteraNav />
 
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} mb={2} useFlexGap flexWrap="wrap">
-          <KpiCard label="Pendiente de cobro" value={fmt(totalPendiente)} color="warning.main" sub="todas las obras" />
-          <KpiCard label="Vencido" value={fmt(totalVencido)} color="error.main" sub={`${vencidas.length} cuota(s)`} />
-          <KpiCard label="Cuotas" value={items.length} sub="por cobrar en total" />
+          <KpiCard label="Pendiente de cobro" value={fmt(totalPendiente)} color="warning.main" sub="filtrado" />
+          <KpiCard label="Vencido" value={fmt(totalVencido)} color="error.main" sub={`${vencidas.length} ítem(s)`} />
+          <KpiCard label="Ítems" value={items.length} sub="por cobrar (filtrado)" />
         </Stack>
 
         <Card>
           <CardContent>
-            <Typography variant="subtitle1" fontWeight={600} mb={1}>Cuotas a cobrar</Typography>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} mb={2} flexWrap="wrap" useFlexGap>
+              <TextField select size="small" label="Obra" value={filtroObra} onChange={(e) => setFiltroObra(e.target.value)} sx={{ minWidth: 200 }}>
+                <MenuItem value="">Todas</MenuItem>
+                {obras.map((o) => <MenuItem key={o.id} value={o.id}>{o.titulo}</MenuItem>)}
+              </TextField>
+              <TextField size="small" type="date" label="Vence desde" InputLabelProps={{ shrink: true }} value={desde} onChange={(e) => setDesde(e.target.value)} />
+              <TextField size="small" type="date" label="Vence hasta" InputLabelProps={{ shrink: true }} value={hasta} onChange={(e) => setHasta(e.target.value)} />
+              {(filtroObra || desde || hasta) && (
+                <Button size="small" onClick={() => { setFiltroObra(''); setDesde(''); setHasta(''); }}>Limpiar</Button>
+              )}
+            </Stack>
+
             {q.isLoading && <LinearProgress sx={{ mb: 1 }} />}
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Obra</TableCell>
-                  <TableCell>Concepto</TableCell>
-                  <TableCell>Vencimiento</TableCell>
-                  <TableCell>Estado</TableCell>
-                  <TableCell align="right">Pendiente</TableCell>
-                  <TableCell align="right">Acciones</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {items.map((i) => (
-                  <TableRow key={i.cuota_id || i.certificado_id} hover>
-                    <TableCell>{i.obra_titulo || '(sin título)'}</TableCell>
-                    <TableCell>{i.descripcion || '—'}{i.tipo === 'certificado' ? ' · certificado' : ''}</TableCell>
-                    <TableCell sx={{ color: vencida(i.fecha_vencimiento) ? 'error.main' : undefined }}>{fecha(i.fecha_vencimiento)}</TableCell>
-                    <TableCell>
-                      <Chip size="small" label={vencida(i.fecha_vencimiento) ? 'vencida' : i.estado} color={vencida(i.fecha_vencimiento) ? 'error' : (i.estado === 'cobrada_parcial' ? 'info' : 'warning')} />
-                    </TableCell>
-                    <TableCell align="right">{fmt(i.pendiente)}</TableCell>
-                    <TableCell align="right">
-                      <Stack direction="row" spacing={1} justifyContent="flex-end">
-                        <Button size="small" variant="contained" onClick={() => accion.mutate({ fn: () => (i.tipo === 'certificado'
-                          ? ControlObraService.cobrarCertificado(i.certificado_id, empresaId)
-                          : ControlObraService.cobrarCuota(i.obra_id, i.cuota_id, empresaId)) })}>Cobrar</Button>
-                        <Button size="small" onClick={() => router.push(`/control-obra/${i.obra_id}`)}>Ver obra</Button>
-                      </Stack>
-                    </TableCell>
+            <Box sx={{ overflowX: 'auto' }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    {COLS.map((c) => (
+                      <TableCell key={c.key} align={c.align || 'left'} sortDirection={orderBy === c.key ? order : false}>
+                        <TableSortLabel active={orderBy === c.key} direction={orderBy === c.key ? order : 'asc'} onClick={() => sortHandler(c.key)}>
+                          {c.label}
+                        </TableSortLabel>
+                      </TableCell>
+                    ))}
+                    <TableCell align="right">Acciones</TableCell>
                   </TableRow>
-                ))}
-                {!q.isLoading && items.length === 0 && (
-                  <TableRow><TableCell colSpan={6}><Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>No hay cobros pendientes.</Typography></TableCell></TableRow>
-                )}
-              </TableBody>
-            </Table>
+                </TableHead>
+                <TableBody>
+                  {items.map((i) => (
+                    <TableRow key={i.cuota_id || i.certificado_id} hover>
+                      <TableCell>{i.obra_titulo || '(sin título)'}</TableCell>
+                      <TableCell>{i.descripcion || '—'}{i.tipo === 'certificado' ? ' · certificado' : ''}</TableCell>
+                      <TableCell sx={{ color: vencida(i.fecha_vencimiento) ? 'error.main' : undefined }}>{fecha(i.fecha_vencimiento)}</TableCell>
+                      <TableCell>
+                        <Chip size="small" label={vencida(i.fecha_vencimiento) ? 'vencida' : i.estado} color={vencida(i.fecha_vencimiento) ? 'error' : (i.estado === 'cobrada_parcial' ? 'info' : 'warning')} />
+                      </TableCell>
+                      <TableCell align="right">{fmt(i.pendiente)}</TableCell>
+                      <TableCell align="right">
+                        <Stack direction="row" spacing={1} justifyContent="flex-end">
+                          <Button size="small" variant="contained" onClick={() => accion.mutate({ fn: () => (i.tipo === 'certificado'
+                            ? ControlObraService.cobrarCertificado(i.certificado_id, empresaId)
+                            : ControlObraService.cobrarCuota(i.obra_id, i.cuota_id, empresaId)) })}>Cobrar</Button>
+                          <Button size="small" onClick={() => router.push(`/control-obra/${i.obra_id}`)}>Ver obra</Button>
+                        </Stack>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {!q.isLoading && items.length === 0 && (
+                    <TableRow><TableCell colSpan={6}><Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>No hay cobros pendientes.</Typography></TableCell></TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </Box>
           </CardContent>
         </Card>
       </Container>

--- a/src/pages/control-obra/cobranzas.js
+++ b/src/pages/control-obra/cobranzas.js
@@ -71,9 +71,9 @@ function CobranzasPage() {
               </TableHead>
               <TableBody>
                 {items.map((i) => (
-                  <TableRow key={i.cuota_id} hover>
+                  <TableRow key={i.cuota_id || i.certificado_id} hover>
                     <TableCell>{i.obra_titulo || '(sin título)'}</TableCell>
-                    <TableCell>{i.descripcion || '—'}</TableCell>
+                    <TableCell>{i.descripcion || '—'}{i.tipo === 'certificado' ? ' · certificado' : ''}</TableCell>
                     <TableCell sx={{ color: vencida(i.fecha_vencimiento) ? 'error.main' : undefined }}>{fecha(i.fecha_vencimiento)}</TableCell>
                     <TableCell>
                       <Chip size="small" label={vencida(i.fecha_vencimiento) ? 'vencida' : i.estado} color={vencida(i.fecha_vencimiento) ? 'error' : (i.estado === 'cobrada_parcial' ? 'info' : 'warning')} />
@@ -81,14 +81,16 @@ function CobranzasPage() {
                     <TableCell align="right">{fmt(i.pendiente)}</TableCell>
                     <TableCell align="right">
                       <Stack direction="row" spacing={1} justifyContent="flex-end">
-                        <Button size="small" variant="contained" onClick={() => accion.mutate({ fn: () => ControlObraService.cobrarCuota(i.obra_id, i.cuota_id, empresaId) })}>Cobrar</Button>
+                        <Button size="small" variant="contained" onClick={() => accion.mutate({ fn: () => (i.tipo === 'certificado'
+                          ? ControlObraService.cobrarCertificado(i.certificado_id, empresaId)
+                          : ControlObraService.cobrarCuota(i.obra_id, i.cuota_id, empresaId)) })}>Cobrar</Button>
                         <Button size="small" onClick={() => router.push(`/control-obra/${i.obra_id}`)}>Ver obra</Button>
                       </Stack>
                     </TableCell>
                   </TableRow>
                 ))}
                 {!q.isLoading && items.length === 0 && (
-                  <TableRow><TableCell colSpan={6}><Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>No hay cuotas pendientes.</Typography></TableCell></TableRow>
+                  <TableRow><TableCell colSpan={6}><Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>No hay cobros pendientes.</Typography></TableCell></TableRow>
                 )}
               </TableBody>
             </Table>

--- a/src/pages/control-obra/index.js
+++ b/src/pages/control-obra/index.js
@@ -44,7 +44,7 @@ function MisObrasPage() {
   const onEliminar = (o) => {
     cerrarMenu();
     // eslint-disable-next-line no-alert
-    if (window.confirm(`¿Eliminar la obra "${o.titulo || 'sin título'}"? Sale de la lista (no se borra el historial).`)) eliminarMut.mutate(o);
+    if (window.confirm(`¿Eliminar la obra "${o.titulo || 'sin título'}"?\n\nLos gastos y cobros quedan en la caja (sin imputar a la obra) y los planes se desasocian. No se toca la plata. Recuperable solo desde soporte.`)) eliminarMut.mutate(o);
   };
 
   const obras = carteraQ.data || [];

--- a/src/pages/control-obra/index.js
+++ b/src/pages/control-obra/index.js
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Box, Button, Card, CardContent, Chip, Container, LinearProgress, Stack,
   Table, TableBody, TableCell, TableHead, TableRow, Typography,
+  IconButton, Menu, MenuItem, FormControlLabel, Switch,
 } from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
@@ -17,8 +19,11 @@ import { KpiCard, fmt } from 'src/components/controlObra/ui';
 function MisObrasPage() {
   const { user } = useAuthContext();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [empresaId, setEmpresaId] = useState(null);
   const [nuevaObra, setNuevaObra] = useState(false);
+  const [verArchivadas, setVerArchivadas] = useState(false);
+  const [menu, setMenu] = useState({ anchor: null, obra: null }); // menú de acciones por obra
 
   useEffect(() => {
     if (!user) return;
@@ -26,10 +31,21 @@ function MisObrasPage() {
   }, [user]);
 
   const carteraQ = useQuery({
-    queryKey: ['control-obra', 'cartera', empresaId],
-    queryFn: () => ControlObraService.resumenCartera(empresaId),
+    queryKey: ['control-obra', 'cartera', empresaId, verArchivadas],
+    queryFn: () => ControlObraService.resumenCartera(empresaId, { incluir_archivadas: verArchivadas }),
     enabled: !!empresaId,
   });
+
+  const refetchObras = () => queryClient.invalidateQueries({ queryKey: ['control-obra'] });
+  const cerrarMenu = () => setMenu({ anchor: null, obra: null });
+  const archivarMut = useMutation({ mutationFn: (o) => ControlObraService.archivarObra(o._id, empresaId), onSuccess: refetchObras });
+  const desarchivarMut = useMutation({ mutationFn: (o) => ControlObraService.desarchivarObra(o._id, empresaId), onSuccess: refetchObras });
+  const eliminarMut = useMutation({ mutationFn: (o) => ControlObraService.eliminarObra(o._id, empresaId), onSuccess: refetchObras });
+  const onEliminar = (o) => {
+    cerrarMenu();
+    // eslint-disable-next-line no-alert
+    if (window.confirm(`¿Eliminar la obra "${o.titulo || 'sin título'}"? Sale de la lista (no se borra el historial).`)) eliminarMut.mutate(o);
+  };
 
   const obras = carteraQ.data || [];
   const totalContrato = obras.reduce((a, o) => a + (o.total_contrato || 0), 0);
@@ -43,7 +59,13 @@ function MisObrasPage() {
       <Container maxWidth="xl" sx={{ py: 3 }}>
         <Stack direction="row" justifyContent="space-between" alignItems="center" mb={1}>
           <Typography variant="h4">Control de Obra</Typography>
-          <Button variant="contained" onClick={() => setNuevaObra(true)} disabled={!empresaId}>Nueva obra</Button>
+          <Stack direction="row" spacing={2} alignItems="center">
+            <FormControlLabel
+              control={<Switch size="small" checked={verArchivadas} onChange={(e) => setVerArchivadas(e.target.checked)} />}
+              label="Ver archivadas"
+            />
+            <Button variant="contained" onClick={() => setNuevaObra(true)} disabled={!empresaId}>Nueva obra</Button>
+          </Stack>
         </Stack>
         <CarteraNav />
 
@@ -69,6 +91,7 @@ function MisObrasPage() {
                   <TableCell align="right">Cobrado</TableCell>
                   <TableCell align="right">Pendiente</TableCell>
                   <TableCell align="right">Margen</TableCell>
+                  <TableCell align="right" />
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -96,16 +119,28 @@ function MisObrasPage() {
                         <span style={{ color: (o.margen ?? 0) >= 0 ? undefined : '#d32f2f' }}>{fmt(o.margen)}</span>
                       </Stack>
                     </TableCell>
+                    <TableCell align="right" onClick={(e) => e.stopPropagation()}>
+                      <IconButton size="small" onClick={(e) => setMenu({ anchor: e.currentTarget, obra: o })}>
+                        <MoreVertIcon fontSize="small" />
+                      </IconButton>
+                    </TableCell>
                   </TableRow>
                 ))}
                 {!carteraQ.isLoading && obras.length === 0 && (
-                  <TableRow><TableCell colSpan={7}><Typography variant="body2" color="text.secondary">Sin obras todavía. Creá la primera.</Typography></TableCell></TableRow>
+                  <TableRow><TableCell colSpan={8}><Typography variant="body2" color="text.secondary">Sin obras todavía. Creá la primera.</Typography></TableCell></TableRow>
                 )}
               </TableBody>
             </Table>
           </CardContent>
         </Card>
       </Container>
+
+      <Menu anchorEl={menu.anchor} open={!!menu.anchor} onClose={cerrarMenu}>
+        {menu.obra?.estado === 'archivada'
+          ? <MenuItem onClick={() => { desarchivarMut.mutate(menu.obra); cerrarMenu(); }}>Desarchivar</MenuItem>
+          : <MenuItem onClick={() => { archivarMut.mutate(menu.obra); cerrarMenu(); }}>Archivar</MenuItem>}
+        <MenuItem onClick={() => onEliminar(menu.obra)} sx={{ color: 'error.main' }}>Eliminar</MenuItem>
+      </Menu>
 
       <NuevaObraDialog
         open={nuevaObra}

--- a/src/pages/control-obra/index.js
+++ b/src/pages/control-obra/index.js
@@ -7,6 +7,8 @@ import {
   IconButton, Menu, MenuItem, FormControlLabel, Switch,
 } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
+import ConfirmDialog from 'src/components/controlObra/ConfirmDialog';
 import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
@@ -24,6 +26,7 @@ function MisObrasPage() {
   const [nuevaObra, setNuevaObra] = useState(false);
   const [verArchivadas, setVerArchivadas] = useState(false);
   const [menu, setMenu] = useState({ anchor: null, obra: null }); // menú de acciones por obra
+  const [confirmDel, setConfirmDel] = useState(null); // obra a eliminar (abre el diálogo)
 
   useEffect(() => {
     if (!user) return;
@@ -40,12 +43,8 @@ function MisObrasPage() {
   const cerrarMenu = () => setMenu({ anchor: null, obra: null });
   const archivarMut = useMutation({ mutationFn: (o) => ControlObraService.archivarObra(o._id, empresaId), onSuccess: refetchObras });
   const desarchivarMut = useMutation({ mutationFn: (o) => ControlObraService.desarchivarObra(o._id, empresaId), onSuccess: refetchObras });
-  const eliminarMut = useMutation({ mutationFn: (o) => ControlObraService.eliminarObra(o._id, empresaId), onSuccess: refetchObras });
-  const onEliminar = (o) => {
-    cerrarMenu();
-    // eslint-disable-next-line no-alert
-    if (window.confirm(`¿Eliminar la obra "${o.titulo || 'sin título'}"?\n\nLos gastos y cobros quedan en la caja (sin imputar a la obra) y los planes se desasocian. No se toca la plata. Recuperable solo desde soporte.`)) eliminarMut.mutate(o);
-  };
+  const eliminarMut = useMutation({ mutationFn: (o) => ControlObraService.eliminarObra(o._id, empresaId), onSuccess: () => { refetchObras(); setConfirmDel(null); } });
+  const onEliminar = (o) => { cerrarMenu(); setConfirmDel(o); };
 
   const obras = carteraQ.data || [];
   const totalContrato = obras.reduce((a, o) => a + (o.total_contrato || 0), 0);
@@ -141,6 +140,19 @@ function MisObrasPage() {
           : <MenuItem onClick={() => { archivarMut.mutate(menu.obra); cerrarMenu(); }}>Archivar</MenuItem>}
         <MenuItem onClick={() => onEliminar(menu.obra)} sx={{ color: 'error.main' }}>Eliminar</MenuItem>
       </Menu>
+
+      <ConfirmDialog
+        open={!!confirmDel}
+        icon={<WarningAmberRoundedIcon color="error" />}
+        title={`Eliminar "${confirmDel?.titulo || 'sin título'}"`}
+        message="La obra se saca de la lista. Los gastos y cobros quedan en la caja (sin imputar a la obra) y los planes de cobro se desasocian."
+        detail="No se toca la plata. Recuperable solo desde soporte."
+        confirmLabel="Eliminar"
+        confirmColor="error"
+        loading={eliminarMut.isPending}
+        onConfirm={() => eliminarMut.mutate(confirmDel)}
+        onClose={() => setConfirmDel(null)}
+      />
 
       <NuevaObraDialog
         open={nuevaObra}

--- a/src/pages/control-obra/pagos.js
+++ b/src/pages/control-obra/pagos.js
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
-  Button, Card, CardContent, Chip, Container, LinearProgress, Stack,
-  Table, TableBody, TableCell, TableHead, TableRow, Typography,
+  Box, Button, Card, CardContent, Chip, Container, LinearProgress, Stack,
+  Table, TableBody, TableCell, TableHead, TableRow, TableSortLabel, TextField, MenuItem, Typography,
 } from '@mui/material';
 import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
@@ -12,8 +12,17 @@ import ControlObraService from 'src/services/controlObra/controlObraService';
 import CarteraNav from 'src/components/controlObra/CarteraNav';
 import SinPermisoControlObra, { puedeVerControlObra } from 'src/components/controlObra/AccesoControlObra';
 import { KpiCard, fmt } from 'src/components/controlObra/ui';
+import { aplicarFiltroOrden, obrasDeItems } from 'src/components/controlObra/carteraFiltros';
 
 const COLOR = { borrador: 'default', aprobada: 'info' };
+
+const COLS = [
+  { key: 'obra_titulo', label: 'Obra' },
+  { key: 'numero', label: '#' },
+  { key: 'contratista_nombre', label: 'Contratista' },
+  { key: 'monto_neto', label: 'Neto', align: 'right' },
+  { key: 'estado', label: 'Estado' },
+];
 
 // "Jueves de pagos": cola de órdenes de pago a contratistas de TODAS las obras.
 function PagosObraPage() {
@@ -21,6 +30,9 @@ function PagosObraPage() {
   const router = useRouter();
   const qc = useQueryClient();
   const [empresaId, setEmpresaId] = useState(null);
+  const [filtroObra, setFiltroObra] = useState('');
+  const [orderBy, setOrderBy] = useState('obra_titulo');
+  const [order, setOrder] = useState('asc');
 
   useEffect(() => {
     if (!user) return;
@@ -35,9 +47,20 @@ function PagosObraPage() {
   const refresh = () => qc.invalidateQueries({ queryKey: ['control-obra'] });
   const accion = useMutation({ mutationFn: ({ fn }) => fn(), onSuccess: refresh });
 
-  const items = q.data || [];
+  const rows = q.data || [];
+  const obras = useMemo(() => obrasDeItems(rows), [rows]);
+  const items = useMemo(
+    () => aplicarFiltroOrden(rows, { filtroObra, orderBy, order }),
+    [rows, filtroObra, orderBy, order],
+  );
+
   const aDesembolsar = items.filter((i) => i.estado === 'aprobada').reduce((a, i) => a + (i.monto_neto || 0), 0);
   const enBorrador = items.filter((i) => i.estado === 'borrador').reduce((a, i) => a + (i.monto_neto || 0), 0);
+
+  const sortHandler = (key) => {
+    if (orderBy === key) setOrder(order === 'asc' ? 'desc' : 'asc');
+    else { setOrderBy(key); setOrder('asc'); }
+  };
 
   if (user && !puedeVerControlObra(user)) return <SinPermisoControlObra />;
 
@@ -50,50 +73,61 @@ function PagosObraPage() {
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} mb={2} useFlexGap flexWrap="wrap">
           <KpiCard label="A desembolsar" value={fmt(aDesembolsar)} color="warning.main" sub="órdenes aprobadas" />
           <KpiCard label="En borrador" value={fmt(enBorrador)} sub="por aprobar" />
-          <KpiCard label="Órdenes" value={items.length} sub="pendientes en total" />
+          <KpiCard label="Órdenes" value={items.length} sub="pendientes (filtrado)" />
         </Stack>
 
         <Card>
           <CardContent>
-            <Typography variant="subtitle1" fontWeight={600} mb={1}>Órdenes a pagar</Typography>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} mb={2} flexWrap="wrap" useFlexGap>
+              <TextField select size="small" label="Obra" value={filtroObra} onChange={(e) => setFiltroObra(e.target.value)} sx={{ minWidth: 200 }}>
+                <MenuItem value="">Todas</MenuItem>
+                {obras.map((o) => <MenuItem key={o.id} value={o.id}>{o.titulo}</MenuItem>)}
+              </TextField>
+              {filtroObra && <Button size="small" onClick={() => setFiltroObra('')}>Limpiar</Button>}
+            </Stack>
+
             {q.isLoading && <LinearProgress sx={{ mb: 1 }} />}
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Obra</TableCell>
-                  <TableCell>#</TableCell>
-                  <TableCell>Contratista</TableCell>
-                  <TableCell align="right">Neto</TableCell>
-                  <TableCell>Estado</TableCell>
-                  <TableCell align="right">Acciones</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {items.map((i) => (
-                  <TableRow key={i.orden_id} hover>
-                    <TableCell>{i.obra_titulo || '(sin título)'}</TableCell>
-                    <TableCell>{i.numero}</TableCell>
-                    <TableCell>{i.contratista_nombre}</TableCell>
-                    <TableCell align="right">{fmt(i.monto_neto)}</TableCell>
-                    <TableCell><Chip size="small" label={i.estado} color={COLOR[i.estado] || 'default'} /></TableCell>
-                    <TableCell align="right">
-                      <Stack direction="row" spacing={1} justifyContent="flex-end">
-                        {i.estado === 'borrador' && (
-                          <Button size="small" onClick={() => accion.mutate({ fn: () => ControlObraService.aprobarOrden(i.orden_id, empresaId) })}>Aprobar</Button>
-                        )}
-                        {i.estado === 'aprobada' && (
-                          <Button size="small" variant="contained" onClick={() => accion.mutate({ fn: () => ControlObraService.pagarOrden(i.orden_id, empresaId) })}>Pagar</Button>
-                        )}
-                        <Button size="small" onClick={() => router.push(`/control-obra/${i.obra_id}`)}>Ver obra</Button>
-                      </Stack>
-                    </TableCell>
+            <Box sx={{ overflowX: 'auto' }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    {COLS.map((c) => (
+                      <TableCell key={c.key} align={c.align || 'left'} sortDirection={orderBy === c.key ? order : false}>
+                        <TableSortLabel active={orderBy === c.key} direction={orderBy === c.key ? order : 'asc'} onClick={() => sortHandler(c.key)}>
+                          {c.label}
+                        </TableSortLabel>
+                      </TableCell>
+                    ))}
+                    <TableCell align="right">Acciones</TableCell>
                   </TableRow>
-                ))}
-                {!q.isLoading && items.length === 0 && (
-                  <TableRow><TableCell colSpan={6}><Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>No hay órdenes de pago pendientes.</Typography></TableCell></TableRow>
-                )}
-              </TableBody>
-            </Table>
+                </TableHead>
+                <TableBody>
+                  {items.map((i) => (
+                    <TableRow key={i.orden_id} hover>
+                      <TableCell>{i.obra_titulo || '(sin título)'}</TableCell>
+                      <TableCell>{i.numero}</TableCell>
+                      <TableCell>{i.contratista_nombre}</TableCell>
+                      <TableCell align="right">{fmt(i.monto_neto)}</TableCell>
+                      <TableCell><Chip size="small" label={i.estado} color={COLOR[i.estado] || 'default'} /></TableCell>
+                      <TableCell align="right">
+                        <Stack direction="row" spacing={1} justifyContent="flex-end">
+                          {i.estado === 'borrador' && (
+                            <Button size="small" onClick={() => accion.mutate({ fn: () => ControlObraService.aprobarOrden(i.orden_id, empresaId) })}>Aprobar</Button>
+                          )}
+                          {i.estado === 'aprobada' && (
+                            <Button size="small" variant="contained" onClick={() => accion.mutate({ fn: () => ControlObraService.pagarOrden(i.orden_id, empresaId) })}>Pagar</Button>
+                          )}
+                          <Button size="small" onClick={() => router.push(`/control-obra/${i.obra_id}`)}>Ver obra</Button>
+                        </Stack>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {!q.isLoading && items.length === 0 && (
+                    <TableRow><TableCell colSpan={6}><Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>No hay órdenes de pago pendientes.</Typography></TableCell></TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </Box>
           </CardContent>
         </Card>
       </Container>

--- a/src/services/controlObra/controlObraService.js
+++ b/src/services/controlObra/controlObraService.js
@@ -74,11 +74,16 @@ const ControlObraService = {
   },
 
   /* ---------- Cartera (cross-obra) ---------- */
-  resumenCartera: async (empresa_id) => {
-    const res = await api.get(`${BASE}/cartera/resumen`, { params: { empresa_id } });
+  resumenCartera: async (empresa_id, { incluir_archivadas = false } = {}) => {
+    const res = await api.get(`${BASE}/cartera/resumen`, { params: { empresa_id, incluir_archivadas: incluir_archivadas ? 'true' : undefined } });
     if (res.status !== 200) throw new Error('Error al obtener la cartera');
     return Array.isArray(res.data?.items) ? res.data.items : [];
   },
+
+  /* ---------- Archivar / eliminar obra ---------- */
+  archivarObra: async (id, empresa_id) => unwrap(await api.patch(`${BASE}/${id}/archivar`, { empresa_id })),
+  desarchivarObra: async (id, empresa_id) => unwrap(await api.patch(`${BASE}/${id}/desarchivar`, { empresa_id })),
+  eliminarObra: async (id, empresa_id) => unwrap(await api.delete(`${BASE}/${id}`, { params: { empresa_id } })),
 
   cobranzas: async (empresa_id) => {
     const res = await api.get(`${BASE}/cartera/cobranzas`, { params: { empresa_id } });

--- a/src/services/controlObra/controlObraService.js
+++ b/src/services/controlObra/controlObraService.js
@@ -170,11 +170,12 @@ const ControlObraService = {
   cobrarCertificado: async (certId, empresa_id, montoParcial = null, fechaCobrado = null) =>
     unwrap(await api.post(`${BASE}/certificados/${certId}/cobrar`, { empresa_id, monto_parcial: montoParcial, fecha_cobrado: fechaCobrado })),
 
-  // Fase F: modo de cobro de la obra + planes adicionales (multi-plan)
-  setModoCobro: async (obraId, empresa_id, modo_cobro) =>
-    unwrap(await api.patch(`${BASE}/${obraId}/modo-cobro`, { empresa_id, modo_cobro })),
-  agregarPlan: async (obraId, empresa_id, { nombre = null, monto_total = 0 } = {}) =>
-    unwrap(await api.post(`${BASE}/${obraId}/planes`, { empresa_id, nombre, monto_total })),
+  // Multi-plan: crear/asociar/desasociar planes de cobro de la obra (0..N).
+  // `plan_cobro_id` presente → asocia uno existente; ausente → crea uno nuevo.
+  agregarPlan: async (obraId, empresa_id, { plan_cobro_id = null, nombre = null, monto_total = 0 } = {}) =>
+    unwrap(await api.post(`${BASE}/${obraId}/planes`, { empresa_id, plan_cobro_id, nombre, monto_total })),
+  desasociarPlan: async (obraId, empresa_id, planId) =>
+    unwrap(await api.delete(`${BASE}/${obraId}/planes/${planId}`, { params: { empresa_id } })),
 };
 
 export default ControlObraService;


### PR DESCRIPTION
Frontend del rediseño del cobro de Control de Obra. Backend: **sorby_bot_wa#261**. Cubre **TAR-548** (multi-plan + curva de ingresos) y **TAR-547** (curva de egresos).

## Qué cambia
- **Curva (`ResumenTab`)**: agrega las series **"Ingresos proyectados"** (Σ cuotas de todos los planes) y **"Egresos reales"** (de caja), con su leyenda.
- **Elimina el toggle `modo_cobro`**: los certificados (cobro directo) y los planes de cobro coexisten, ya no son modos excluyentes.
- **`CobrosObraTab`**: copy actualizado (0..N planes; certificados se cobran directo) + botón **"Nuevo plan"**.
- **Servicio**: `agregarPlan` acepta `plan_cobro_id` (asociar plan existente) y nuevo `desasociarPlan`.

Depende del backend sorby_bot_wa#261 (endpoints de asociar/desasociar plan y las series nuevas de la curva).

🤖 Generated with [Claude Code](https://claude.com/claude-code)