### PR TITLE
TAR-439 — Gestión de sesiones por usuario (UI)

### DIFF
--- a/src/hooks/use-idle-logout.js
+++ b/src/hooks/use-idle-logout.js
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+import { getLastActivityMs, forceSessionLogout } from 'src/services/sessionActivity';
+
+// Espejo del default del backend (SESSION_IDLE_DEFAULT_SECONDS). El backend es la
+// fuente de verdad; esto es solo UX para no esperar al próximo 401.
+const IDLE_DEFAULT_SECONDS = 7 * 24 * 3600;
+const CHECK_INTERVAL_MS = 30 * 1000;
+
+// Logout proactivo por inactividad. Si el usuario no genera actividad (requests
+// no-background) por más de su timeout, lo mandamos a login. Sin aviso/countdown.
+//   idleSeconds: null/undefined → default global; 0 → desactivado.
+export const useIdleLogout = (idleSeconds) => {
+  const idleMsRef = useRef(0);
+  idleMsRef.current = (idleSeconds == null ? IDLE_DEFAULT_SECONDS : idleSeconds) * 1000;
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      const idleMs = idleMsRef.current;
+      if (idleMs <= 0) return; // inactividad desactivada
+      if (Date.now() - getLastActivityMs() > idleMs) {
+        forceSessionLogout();
+      }
+    }, CHECK_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, []);
+};

--- a/src/layouts/dashboard/layout.js
+++ b/src/layouts/dashboard/layout.js
@@ -5,7 +5,9 @@ import { withAuthGuard } from 'src/hocs/with-auth-guard';
 import { SideNav } from './side-nav';
 import { TopNav } from './top-nav';
 import { useVersionCheck } from 'src/hooks/use-version-check';
+import { useIdleLogout } from 'src/hooks/use-idle-logout';
 import { getRemoteVersionFromFirestore } from 'src/services/versionService';
+import { useAuthContext } from 'src/contexts/auth-context';
 
 const NAV_WIDTH_EXPANDED = 280;
 const NAV_WIDTH_COLLAPSED = 72;
@@ -44,6 +46,10 @@ export const Layout = withAuthGuard((props) => {
     pollMs: 5 * 60 * 1000, // 5 minutos
     localVersion: process.env.NEXT_PUBLIC_APP_VERSION || '',
   });
+
+  // Logout proactivo por inactividad (config por usuario; backend enforcea igual).
+  const { user } = useAuthContext();
+  useIdleLogout(user?.session_idle_seconds);
   
   const handlePathnameChange = useCallback(() => {
     if (openNav) setOpenNav(false);

--- a/src/pages/profiles-overview.js
+++ b/src/pages/profiles-overview.js
@@ -133,6 +133,38 @@ const BOOLEAN_FILTER_OPTIONS = [
     return `${Math.round(seconds / 60)} minutos`;
   }
 
+  // Idem para el timeout por inactividad (null = default global 7 días, 0 = sin límite).
+  const SESSION_IDLE_OPTIONS = [
+    { key: 'default', label: 'Default global (7 días)', seconds: null },
+    { key: 'none', label: 'Sin límite', seconds: 0 },
+    { key: '900', label: '15 minutos', seconds: 900 },
+    { key: '1800', label: '30 minutos', seconds: 1800 },
+    { key: '3600', label: '1 hora', seconds: 3600 },
+    { key: '14400', label: '4 horas', seconds: 14400 },
+    { key: '43200', label: '12 horas', seconds: 43200 },
+    { key: '86400', label: '1 día', seconds: 86400 },
+    { key: 'custom', label: 'Personalizado (minutos)', seconds: null },
+  ];
+
+  const SESSION_IDLE_PRESET_SECONDS = new Set([900, 1800, 3600, 14400, 43200, 86400]);
+
+  function idleSecondsToKey(seconds) {
+    if (seconds == null) return 'default';
+    if (seconds === 0) return 'none';
+    if (SESSION_IDLE_PRESET_SECONDS.has(seconds)) return String(seconds);
+    return 'custom';
+  }
+
+  function describeIdleTimeout(seconds) {
+    if (seconds == null) return 'Default global (7 días)';
+    if (seconds === 0) return 'Sin límite';
+    const match = SESSION_IDLE_OPTIONS.find((option) => option.seconds === seconds);
+    if (match) return match.label;
+    if (seconds % 86400 === 0) return `${seconds / 86400} días`;
+    if (seconds % 3600 === 0) return `${seconds / 3600} horas`;
+    return `${Math.round(seconds / 60)} minutos`;
+  }
+
   function normalizeText(value) {
     return String(value ?? '').trim().toLowerCase();
   }
@@ -413,6 +445,9 @@ const BOOLEAN_FILTER_OPTIONS = [
     const [sessionKey, setSessionKey] = useState('default');
     const [sessionCustomMinutes, setSessionCustomMinutes] = useState('');
     const [savingSession, setSavingSession] = useState(false);
+    const [idleKey, setIdleKey] = useState('default');
+    const [idleCustomMinutes, setIdleCustomMinutes] = useState('');
+    const [savingIdle, setSavingIdle] = useState(false);
     const [passwordValue, setPasswordValue] = useState('');
     const [showPassword, setShowPassword] = useState(false);
     const [resetLink, setResetLink] = useState('');
@@ -788,7 +823,7 @@ const BOOLEAN_FILTER_OPTIONS = [
       }
     }, [selectionCloseInfo]);
 
-    // Sincroniza el Select de duración con el perfil abierto en el drawer.
+    // Sincroniza los Select de seguridad con el perfil abierto en el drawer.
     useEffect(() => {
       if (!selectedRow) return;
       const seconds = selectedRow.session_max_seconds;
@@ -796,6 +831,13 @@ const BOOLEAN_FILTER_OPTIONS = [
       setSessionCustomMinutes(
         seconds != null && seconds > 0 && !SESSION_PRESET_SECONDS.has(seconds)
           ? String(Math.round(seconds / 60))
+          : ''
+      );
+      const idle = selectedRow.session_idle_seconds;
+      setIdleKey(idleSecondsToKey(idle));
+      setIdleCustomMinutes(
+        idle != null && idle > 0 && !SESSION_IDLE_PRESET_SECONDS.has(idle)
+          ? String(Math.round(idle / 60))
           : ''
       );
     }, [selectedRow]);
@@ -829,6 +871,36 @@ const BOOLEAN_FILTER_OPTIONS = [
         setSavingSession(false);
       }
     }, [selectedRow, sessionKey, sessionCustomMinutes]);
+
+    const handleIdleKeyChange = useCallback((event) => setIdleKey(event.target.value), []);
+    const handleIdleCustomMinutesChange = useCallback((event) => setIdleCustomMinutes(event.target.value), []);
+
+    const handleSaveIdleTimeout = useCallback(async () => {
+      if (!selectedRow) return;
+      let seconds;
+      if (idleKey === 'custom') {
+        const minutes = Number(idleCustomMinutes);
+        if (!Number.isFinite(minutes) || minutes <= 0) {
+          setError('Ingresá una cantidad de minutos válida para la inactividad.');
+          return;
+        }
+        seconds = Math.floor(minutes) * 60;
+      } else {
+        seconds = SESSION_IDLE_OPTIONS.find((option) => option.key === idleKey)?.seconds ?? null;
+      }
+      setSavingIdle(true);
+      setError(null);
+      try {
+        await profileService.updateIdleTimeout(selectedRow.id, seconds);
+        setRows((current) => current.map((row) => (row.id === selectedRow.id ? { ...row, session_idle_seconds: seconds } : row)));
+        setCopyMessage('Timeout por inactividad actualizado.');
+      } catch (saveError) {
+        console.error('Error al actualizar el timeout por inactividad:', saveError);
+        setError(saveError?.response?.data?.error || 'No se pudo actualizar el timeout por inactividad.');
+      } finally {
+        setSavingIdle(false);
+      }
+    }, [selectedRow, idleKey, idleCustomMinutes]);
 
     const handleExportCsv = useCallback(() => {
       const csvRows = [
@@ -1186,6 +1258,36 @@ const BOOLEAN_FILTER_OPTIONS = [
                         <Box>
                           <Button variant="contained" onClick={handleSaveSessionDuration} disabled={savingSession}>
                             {savingSession ? 'Guardando…' : 'Guardar duración'}
+                          </Button>
+                        </Box>
+
+                        <Divider />
+
+                        <Typography variant="body2" color="text.secondary">
+                          Tras cuánto tiempo <strong>sin actividad</strong> se cierra la sesión (cuenta desde la última acción del usuario en el sistema). Actual: <strong>{describeIdleTimeout(selectedRow.session_idle_seconds)}</strong>.
+                        </Typography>
+                        <FormControl fullWidth size="small">
+                          <InputLabel>Inactividad</InputLabel>
+                          <Select label="Inactividad" value={idleKey} onChange={handleIdleKeyChange}>
+                            {SESSION_IDLE_OPTIONS.map((option) => (
+                              <MenuItem key={option.key} value={option.key}>{option.label}</MenuItem>
+                            ))}
+                          </Select>
+                        </FormControl>
+                        {idleKey === 'custom' ? (
+                          <TextField
+                            fullWidth
+                            size="small"
+                            type="number"
+                            label="Minutos"
+                            value={idleCustomMinutes}
+                            onChange={handleIdleCustomMinutesChange}
+                            inputProps={{ min: 1 }}
+                          />
+                        ) : null}
+                        <Box>
+                          <Button variant="contained" onClick={handleSaveIdleTimeout} disabled={savingIdle}>
+                            {savingIdle ? 'Guardando…' : 'Guardar inactividad'}
                           </Button>
                         </Box>
                       </Stack>

--- a/src/pages/profiles-overview.js
+++ b/src/pages/profiles-overview.js
@@ -8,10 +8,16 @@ import {
   Button,
   Card,
   CardContent,
+  Checkbox,
   Chip,
   CircularProgress,
   Collapse,
   Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   Divider,
   Drawer,
   FormControl,
@@ -47,6 +53,8 @@ import CloseIcon from '@mui/icons-material/Close';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import LogoutIcon from '@mui/icons-material/Logout';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
@@ -54,6 +62,7 @@ import { es } from 'date-fns/locale';
 import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import profileService from 'src/services/profileService';
 import { getAllEmpresas } from 'src/services/empresaService';
+import { useAuthContext } from 'src/contexts/auth-context';
 
 const BOOLEAN_FILTER_OPTIONS = [
     { value: 'all', label: 'Todos' },
@@ -90,6 +99,39 @@ const BOOLEAN_FILTER_OPTIONS = [
     empresaOperator: 'contains',
     empresaValue: '',
   };
+
+  // Opciones de duración de sesión. `key` es el value del Select; `seconds` es lo
+  // que se persiste (null = default global 1 mes, 0 = sin límite).
+  const SESSION_DURATION_OPTIONS = [
+    { key: 'default', label: 'Default global (1 mes)', seconds: null },
+    { key: 'none', label: 'Sin límite', seconds: 0 },
+    { key: '900', label: '15 minutos', seconds: 900 },
+    { key: '1800', label: '30 minutos', seconds: 1800 },
+    { key: '3600', label: '1 hora', seconds: 3600 },
+    { key: '14400', label: '4 horas', seconds: 14400 },
+    { key: '28800', label: '8 horas', seconds: 28800 },
+    { key: '86400', label: '24 horas', seconds: 86400 },
+    { key: 'custom', label: 'Personalizado (minutos)', seconds: null },
+  ];
+
+  const SESSION_PRESET_SECONDS = new Set([900, 1800, 3600, 14400, 28800, 86400]);
+
+  // Traduce el valor persistido (session_max_seconds) al key del Select.
+  function sessionSecondsToKey(seconds) {
+    if (seconds == null) return 'default';
+    if (seconds === 0) return 'none';
+    if (SESSION_PRESET_SECONDS.has(seconds)) return String(seconds);
+    return 'custom';
+  }
+
+  function describeSessionDuration(seconds) {
+    if (seconds == null) return 'Default global (1 mes)';
+    if (seconds === 0) return 'Sin límite';
+    const match = SESSION_DURATION_OPTIONS.find((option) => option.seconds === seconds);
+    if (match) return match.label;
+    if (seconds % 3600 === 0) return `${seconds / 3600} horas`;
+    return `${Math.round(seconds / 60)} minutos`;
+  }
 
   function normalizeText(value) {
     return String(value ?? '').trim().toLowerCase();
@@ -346,6 +388,8 @@ const BOOLEAN_FILTER_OPTIONS = [
   };
 
   function ProfilesOverviewPage() {
+    const { user } = useAuthContext();
+    const isAdmin = Boolean(user?.admin);
     const [rows, setRows] = useState([]);
     const [empresas, setEmpresas] = useState([]);
     const [selectedEmpresa, setSelectedEmpresa] = useState(null);
@@ -363,6 +407,12 @@ const BOOLEAN_FILTER_OPTIONS = [
     const [filtersExpanded, setFiltersExpanded] = useState(false);
     const [sortBy, setSortBy] = useState('created_at');
     const [sortDirection, setSortDirection] = useState('desc');
+    const [selectedIds, setSelectedIds] = useState(() => new Set());
+    const [confirmCloseOpen, setConfirmCloseOpen] = useState(false);
+    const [closingSessions, setClosingSessions] = useState(false);
+    const [sessionKey, setSessionKey] = useState('default');
+    const [sessionCustomMinutes, setSessionCustomMinutes] = useState('');
+    const [savingSession, setSavingSession] = useState(false);
 
     const loadData = useCallback(async () => {
       setLoading(true);
@@ -467,6 +517,26 @@ const BOOLEAN_FILTER_OPTIONS = [
       const start = page * rowsPerPage;
       return sortedRows.slice(start, start + rowsPerPage);
     }, [sortedRows, page, rowsPerPage]);
+
+    // Set de ids visibles según los filtros aplicados. La selección se mantiene
+    // acotada a este set: "seleccionar todos" y el cierre masivo respetan filtros.
+    const filteredIdSet = useMemo(() => new Set(sortedRows.map((row) => row.id)), [sortedRows]);
+
+    useEffect(() => {
+      setSelectedIds((current) => {
+        if (current.size === 0) return current;
+        let changed = false;
+        const next = new Set();
+        current.forEach((id) => {
+          if (filteredIdSet.has(id)) next.add(id);
+          else changed = true;
+        });
+        return changed ? next : current;
+      });
+    }, [filteredIdSet]);
+
+    const allVisibleSelected = sortedRows.length > 0 && selectedIds.size === sortedRows.length;
+    const someVisibleSelected = selectedIds.size > 0 && !allVisibleSelected;
 
     const selectedRow = useMemo(() => {
       if (!selectedRowId) return null;
@@ -604,6 +674,105 @@ const BOOLEAN_FILTER_OPTIONS = [
     const handleClearError = useCallback(() => setError(null), []);
     const handleCloseCopyMessage = useCallback(() => setCopyMessage(null), []);
 
+    const handleToggleRowSelection = useCallback((rowId) => {
+      setSelectedIds((current) => {
+        const next = new Set(current);
+        if (next.has(rowId)) next.delete(rowId);
+        else next.add(rowId);
+        return next;
+      });
+    }, []);
+
+    // Selecciona/deselecciona TODAS las filas filtradas (todas las páginas), no solo
+    // la página visible: respeta los filtros aplicados.
+    const handleToggleSelectAll = useCallback(() => {
+      setSelectedIds((current) => {
+        if (current.size === sortedRows.length) return new Set();
+        return new Set(sortedRows.map((row) => row.id));
+      });
+    }, [sortedRows]);
+
+    const handleOpenConfirmClose = useCallback(() => setConfirmCloseOpen(true), []);
+    const handleCloseConfirmClose = useCallback(() => {
+      if (!closingSessions) setConfirmCloseOpen(false);
+    }, [closingSessions]);
+
+    // Deriva de la selección: perfiles seleccionados con user_id (los únicos a los que
+    // se les puede cerrar sesión web) y cuántos se omiten por no tener user_id.
+    const selectionCloseInfo = useMemo(() => {
+      const selectedRows = rows.filter((row) => selectedIds.has(row.id));
+      const withUserId = selectedRows.filter((row) => row.user_id);
+      return {
+        userIds: withUserId.map((row) => row.user_id),
+        skipped: selectedRows.length - withUserId.length,
+        includesSelf: withUserId.some((row) => row.user_id === user?.user_id || row.user_id === user?.id),
+      };
+    }, [rows, selectedIds, user]);
+
+    const handleConfirmCloseSessions = useCallback(async () => {
+      const { userIds } = selectionCloseInfo;
+      if (!userIds.length) {
+        setConfirmCloseOpen(false);
+        setError('Ninguno de los perfiles seleccionados tiene acceso web (user_id).');
+        return;
+      }
+      setClosingSessions(true);
+      setError(null);
+      try {
+        await profileService.closeSessions(userIds);
+        setCopyMessage(`Se cerró la sesión de ${userIds.length} usuario${userIds.length === 1 ? '' : 's'}.`);
+        setSelectedIds(new Set());
+        setConfirmCloseOpen(false);
+      } catch (closeError) {
+        console.error('Error al cerrar sesiones:', closeError);
+        setError(closeError?.response?.data?.error || 'No se pudieron cerrar las sesiones.');
+      } finally {
+        setClosingSessions(false);
+      }
+    }, [selectionCloseInfo]);
+
+    // Sincroniza el Select de duración con el perfil abierto en el drawer.
+    useEffect(() => {
+      if (!selectedRow) return;
+      const seconds = selectedRow.session_max_seconds;
+      setSessionKey(sessionSecondsToKey(seconds));
+      setSessionCustomMinutes(
+        seconds != null && seconds > 0 && !SESSION_PRESET_SECONDS.has(seconds)
+          ? String(Math.round(seconds / 60))
+          : ''
+      );
+    }, [selectedRow]);
+
+    const handleSessionKeyChange = useCallback((event) => setSessionKey(event.target.value), []);
+    const handleSessionCustomMinutesChange = useCallback((event) => setSessionCustomMinutes(event.target.value), []);
+
+    const handleSaveSessionDuration = useCallback(async () => {
+      if (!selectedRow) return;
+      let seconds;
+      if (sessionKey === 'custom') {
+        const minutes = Number(sessionCustomMinutes);
+        if (!Number.isFinite(minutes) || minutes <= 0) {
+          setError('Ingresá una cantidad de minutos válida.');
+          return;
+        }
+        seconds = Math.floor(minutes) * 60;
+      } else {
+        seconds = SESSION_DURATION_OPTIONS.find((option) => option.key === sessionKey)?.seconds ?? null;
+      }
+      setSavingSession(true);
+      setError(null);
+      try {
+        await profileService.updateSessionDuration(selectedRow.id, seconds);
+        setRows((current) => current.map((row) => (row.id === selectedRow.id ? { ...row, session_max_seconds: seconds } : row)));
+        setCopyMessage('Duración de sesión actualizada.');
+      } catch (saveError) {
+        console.error('Error al actualizar la duración de sesión:', saveError);
+        setError(saveError?.response?.data?.error || 'No se pudo actualizar la duración de sesión.');
+      } finally {
+        setSavingSession(false);
+      }
+    }, [selectedRow, sessionKey, sessionCustomMinutes]);
+
     const handleExportCsv = useCallback(() => {
       const csvRows = [
         ['Nombre', 'Email', 'Telefono', 'Empresa', 'Empresa cliente', 'Confirmado', 'Admin', 'SDR', 'Creado perfil'],
@@ -661,6 +830,10 @@ const BOOLEAN_FILTER_OPTIONS = [
                 {error ? <Alert severity="error" onClose={handleClearError}>{error}</Alert> : null}
                 {copyMessage ? <Alert severity="success" onClose={handleCloseCopyMessage}>{copyMessage}</Alert> : null}
 
+                {!isAdmin ? (
+                  <Alert severity="error">Esta pantalla está disponible solo para administradores.</Alert>
+                ) : (
+                <>
                 <Grid container spacing={2}>
                   <Grid item xs={12} md={3}><StatCard title="Perfiles cargados" value={summary.totalProfiles} subtitle={`${summary.filteredProfiles} visibles`} icon={<PeopleIcon />} /></Grid>
                   <Grid item xs={12} md={3}><StatCard title="Empresas visibles" value={summary.empresasVisibles} subtitle={`${empresas.length} empresas totales`} icon={<BusinessIcon />} /></Grid>
@@ -765,10 +938,30 @@ const BOOLEAN_FILTER_OPTIONS = [
 
                 <Card>
                   <CardContent sx={{ pb: 0 }}>
-                    <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={2} mb={2}>
+                    <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ xs: 'stretch', md: 'center' }} spacing={2} mb={2}>
                       <Typography variant="h6">Resultados</Typography>
                       <Chip color="primary" label={`${sortedRows.length} perfiles`} />
                     </Stack>
+
+                    {selectedIds.size > 0 ? (
+                      <Stack
+                        direction={{ xs: 'column', sm: 'row' }}
+                        alignItems={{ xs: 'stretch', sm: 'center' }}
+                        justifyContent="space-between"
+                        spacing={1.5}
+                        sx={{ mb: 2, p: 1.5, borderRadius: 1, bgcolor: 'action.selected' }}
+                      >
+                        <Typography variant="body2" fontWeight="medium">
+                          {selectedIds.size} seleccionado{selectedIds.size === 1 ? '' : 's'}
+                        </Typography>
+                        <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                          <Button size="small" onClick={() => setSelectedIds(new Set())}>Limpiar selección</Button>
+                          <Button size="small" variant="contained" color="warning" startIcon={<LogoutIcon />} onClick={handleOpenConfirmClose}>
+                            Cerrar sesión ({selectedIds.size})
+                          </Button>
+                        </Stack>
+                      </Stack>
+                    ) : null}
                   </CardContent>
 
                   {loading ? (
@@ -787,6 +980,14 @@ const BOOLEAN_FILTER_OPTIONS = [
                         <Table stickyHeader size="small">
                           <TableHead>
                             <TableRow>
+                              <TableCell padding="checkbox">
+                                <Checkbox
+                                  checked={allVisibleSelected}
+                                  indeterminate={someVisibleSelected}
+                                  onChange={handleToggleSelectAll}
+                                  inputProps={{ 'aria-label': 'Seleccionar todos los perfiles filtrados' }}
+                                />
+                              </TableCell>
                               <TableCell><TableSortLabel active={sortBy === 'fullName'} direction={sortBy === 'fullName' ? sortDirection : 'asc'} onClick={() => handleRequestSort('fullName')}>Perfil</TableSortLabel></TableCell>
                               <TableCell><TableSortLabel active={sortBy === 'empresaNombre'} direction={sortBy === 'empresaNombre' ? sortDirection : 'asc'} onClick={() => handleRequestSort('empresaNombre')}>Empresa</TableSortLabel></TableCell>
                               <TableCell><TableSortLabel active={sortBy === 'confirmed'} direction={sortBy === 'confirmed' ? sortDirection : 'desc'} onClick={() => handleRequestSort('confirmed')}>Flags perfil</TableSortLabel></TableCell>
@@ -797,7 +998,14 @@ const BOOLEAN_FILTER_OPTIONS = [
                           </TableHead>
                           <TableBody>
                             {paginatedRows.map((row) => (
-                              <TableRow key={row.id} hover sx={getRowStatusSx(row)}>
+                              <TableRow key={row.id} hover selected={selectedIds.has(row.id)} sx={getRowStatusSx(row)}>
+                                <TableCell padding="checkbox">
+                                  <Checkbox
+                                    checked={selectedIds.has(row.id)}
+                                    onChange={() => handleToggleRowSelection(row.id)}
+                                    inputProps={{ 'aria-label': `Seleccionar ${row.fullName || row.id}` }}
+                                  />
+                                </TableCell>
                                 <TableCell sx={{ minWidth: 240 }}>
                                   <Typography variant="subtitle2">{row.fullName || 'Sin nombre'}</Typography>
                                   <Stack direction="row" spacing={1} alignItems="center" useFlexGap flexWrap="wrap">
@@ -855,6 +1063,8 @@ const BOOLEAN_FILTER_OPTIONS = [
                     </>
                   )}
                 </Card>
+                </>
+                )}
               </Stack>
             </Container>
           </Box>
@@ -880,6 +1090,50 @@ const BOOLEAN_FILTER_OPTIONS = [
                       <Typography variant="body2">Empresa: {selectedRow.empresaNombre}</Typography>
                     </CardContent>
                   </Card>
+
+                  <Card>
+                    <CardContent>
+                      <Stack direction="row" spacing={1} alignItems="center" mb={1}>
+                        <ShieldOutlinedIcon fontSize="small" color="action" />
+                        <Typography variant="subtitle1" fontWeight="bold">Seguridad · Sesión</Typography>
+                      </Stack>
+                      <Typography variant="body2" color="text.secondary" mb={2}>
+                        Cuánto dura la sesión desde el último login con credenciales. Pasado ese tiempo,
+                        el usuario tiene que volver a iniciar sesión. Actual: <strong>{describeSessionDuration(selectedRow.session_max_seconds)}</strong>.
+                      </Typography>
+                      <Stack spacing={2}>
+                        <FormControl fullWidth size="small">
+                          <InputLabel>Duración máxima de sesión</InputLabel>
+                          <Select label="Duración máxima de sesión" value={sessionKey} onChange={handleSessionKeyChange}>
+                            {SESSION_DURATION_OPTIONS.map((option) => (
+                              <MenuItem key={option.key} value={option.key}>{option.label}</MenuItem>
+                            ))}
+                          </Select>
+                        </FormControl>
+                        {sessionKey === 'custom' ? (
+                          <TextField
+                            fullWidth
+                            size="small"
+                            type="number"
+                            label="Minutos"
+                            value={sessionCustomMinutes}
+                            onChange={handleSessionCustomMinutesChange}
+                            inputProps={{ min: 1 }}
+                          />
+                        ) : null}
+                        {!selectedRow.user_id ? (
+                          <Typography variant="caption" color="text.secondary">
+                            Este perfil no tiene acceso web (sin user_id); la duración se aplicará si en el futuro ingresa a la plataforma.
+                          </Typography>
+                        ) : null}
+                        <Box>
+                          <Button variant="contained" onClick={handleSaveSessionDuration} disabled={savingSession}>
+                            {savingSession ? 'Guardando…' : 'Guardar duración'}
+                          </Button>
+                        </Box>
+                      </Stack>
+                    </CardContent>
+                  </Card>
                   <Card>
                     <CardContent>
                       <Typography variant="subtitle2" gutterBottom>Profile</Typography>
@@ -896,6 +1150,38 @@ const BOOLEAN_FILTER_OPTIONS = [
               ) : null}
             </Box>
           </Drawer>
+
+          <Dialog open={confirmCloseOpen} onClose={handleCloseConfirmClose} maxWidth="xs" fullWidth>
+            <DialogTitle>Cerrar sesión de usuarios</DialogTitle>
+            <DialogContent>
+              <DialogContentText component="div">
+                Se cerrará la sesión de <strong>{selectionCloseInfo.userIds.length}</strong> usuario
+                {selectionCloseInfo.userIds.length === 1 ? '' : 's'}. Tendrán que volver a iniciar sesión en su próxima acción.
+                {selectionCloseInfo.skipped > 0 ? (
+                  <Box component="span" sx={{ display: 'block', mt: 1 }}>
+                    {selectionCloseInfo.skipped} perfil{selectionCloseInfo.skipped === 1 ? '' : 'es'} de la selección no tiene acceso web y se omitirá{selectionCloseInfo.skipped === 1 ? '' : 'n'}.
+                  </Box>
+                ) : null}
+                {selectionCloseInfo.includesSelf ? (
+                  <Box component="span" sx={{ display: 'block', mt: 1, color: 'warning.main' }}>
+                    Atención: tu propio usuario está en la selección; también se cerrará tu sesión.
+                  </Box>
+                ) : null}
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleCloseConfirmClose} disabled={closingSessions}>Cancelar</Button>
+              <Button
+                variant="contained"
+                color="warning"
+                startIcon={<LogoutIcon />}
+                onClick={handleConfirmCloseSessions}
+                disabled={closingSessions || selectionCloseInfo.userIds.length === 0}
+              >
+                {closingSessions ? 'Cerrando…' : 'Cerrar sesión'}
+              </Button>
+            </DialogActions>
+          </Dialog>
         </>
       </LocalizationProvider>
     );

--- a/src/pages/profiles-overview.js
+++ b/src/pages/profiles-overview.js
@@ -100,40 +100,22 @@ const BOOLEAN_FILTER_OPTIONS = [
     empresaValue: '',
   };
 
-  // Opciones de duración de sesión. `key` es el value del Select; `seconds` es lo
-  // que se persiste (null = default global 1 mes, 0 = sin límite).
+  // Opciones de duración ABSOLUTA (tope desde el login, use o no la app).
+  // Escala de horas/días: un tope corto acá cortaría aunque el usuario esté trabajando.
   const SESSION_DURATION_OPTIONS = [
     { key: 'default', label: 'Default global (1 mes)', seconds: null },
     { key: 'none', label: 'Sin límite', seconds: 0 },
-    { key: '900', label: '15 minutos', seconds: 900 },
-    { key: '1800', label: '30 minutos', seconds: 1800 },
     { key: '3600', label: '1 hora', seconds: 3600 },
-    { key: '14400', label: '4 horas', seconds: 14400 },
     { key: '28800', label: '8 horas', seconds: 28800 },
-    { key: '86400', label: '24 horas', seconds: 86400 },
-    { key: 'custom', label: 'Personalizado (minutos)', seconds: null },
+    { key: '86400', label: '1 día', seconds: 86400 },
+    { key: '604800', label: '7 días', seconds: 604800 },
+    { key: '2592000', label: '30 días', seconds: 2592000 },
+    { key: 'custom', label: 'Personalizado', seconds: null },
   ];
 
-  const SESSION_PRESET_SECONDS = new Set([900, 1800, 3600, 14400, 28800, 86400]);
+  const SESSION_PRESET_SECONDS = new Set([3600, 28800, 86400, 604800, 2592000]);
 
-  // Traduce el valor persistido (session_max_seconds) al key del Select.
-  function sessionSecondsToKey(seconds) {
-    if (seconds == null) return 'default';
-    if (seconds === 0) return 'none';
-    if (SESSION_PRESET_SECONDS.has(seconds)) return String(seconds);
-    return 'custom';
-  }
-
-  function describeSessionDuration(seconds) {
-    if (seconds == null) return 'Default global (1 mes)';
-    if (seconds === 0) return 'Sin límite';
-    const match = SESSION_DURATION_OPTIONS.find((option) => option.seconds === seconds);
-    if (match) return match.label;
-    if (seconds % 3600 === 0) return `${seconds / 3600} horas`;
-    return `${Math.round(seconds / 60)} minutos`;
-  }
-
-  // Idem para el timeout por inactividad (null = default global 7 días, 0 = sin límite).
+  // Opciones de INACTIVIDAD. Acá sí tienen sentido los valores cortos.
   const SESSION_IDLE_OPTIONS = [
     { key: 'default', label: 'Default global (7 días)', seconds: null },
     { key: 'none', label: 'Sin límite', seconds: 0 },
@@ -143,26 +125,138 @@ const BOOLEAN_FILTER_OPTIONS = [
     { key: '14400', label: '4 horas', seconds: 14400 },
     { key: '43200', label: '12 horas', seconds: 43200 },
     { key: '86400', label: '1 día', seconds: 86400 },
-    { key: 'custom', label: 'Personalizado (minutos)', seconds: null },
+    { key: '604800', label: '7 días', seconds: 604800 },
+    { key: 'custom', label: 'Personalizado', seconds: null },
   ];
 
-  const SESSION_IDLE_PRESET_SECONDS = new Set([900, 1800, 3600, 14400, 43200, 86400]);
+  const SESSION_IDLE_PRESET_SECONDS = new Set([900, 1800, 3600, 14400, 43200, 86400, 604800]);
 
-  function idleSecondsToKey(seconds) {
-    if (seconds == null) return 'default';
-    if (seconds === 0) return 'none';
-    if (SESSION_IDLE_PRESET_SECONDS.has(seconds)) return String(seconds);
-    return 'custom';
+  // Unidades del input "Personalizado". Todo se persiste en SEGUNDOS.
+  const CUSTOM_UNITS = [
+    { key: 'minutos', label: 'minutos', seconds: 60 },
+    { key: 'horas', label: 'horas', seconds: 3600 },
+    { key: 'dias', label: 'días', seconds: 86400 },
+  ];
+
+  // seconds (custom, >0) → { value, unit } eligiendo la unidad más redonda.
+  function secondsToCustom(seconds) {
+    if (!seconds || seconds <= 0) return { value: '', unit: 'horas' };
+    if (seconds % 86400 === 0) return { value: String(seconds / 86400), unit: 'dias' };
+    if (seconds % 3600 === 0) return { value: String(seconds / 3600), unit: 'horas' };
+    return { value: String(Math.round(seconds / 60)), unit: 'minutos' };
   }
 
-  function describeIdleTimeout(seconds) {
-    if (seconds == null) return 'Default global (7 días)';
+  // { value, unit } → seconds (o null si es inválido).
+  function customToSeconds(value, unit) {
+    const n = Number(value);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    const factor = CUSTOM_UNITS.find((u) => u.key === unit)?.seconds ?? 60;
+    return Math.floor(n) * factor;
+  }
+
+  function describeDuration(seconds, defaultLabel) {
+    if (seconds == null) return defaultLabel;
     if (seconds === 0) return 'Sin límite';
-    const match = SESSION_IDLE_OPTIONS.find((option) => option.seconds === seconds);
-    if (match) return match.label;
     if (seconds % 86400 === 0) return `${seconds / 86400} días`;
     if (seconds % 3600 === 0) return `${seconds / 3600} horas`;
     return `${Math.round(seconds / 60)} minutos`;
+  }
+  const describeSessionDuration = (s) => describeDuration(s, 'Default global (1 mes)');
+  const describeIdleTimeout = (s) => describeDuration(s, 'Default global (7 días)');
+
+  function formatRelativeTime(value) {
+    const date = toValidDate(value);
+    if (!date) return 'Sin actividad';
+    const diffMs = Date.now() - date.getTime();
+    if (diffMs < 60000) return 'hace instantes';
+    const min = Math.floor(diffMs / 60000);
+    if (min < 60) return `hace ${min} min`;
+    const h = Math.floor(min / 60);
+    if (h < 24) return `hace ${h} h`;
+    const d = Math.floor(h / 24);
+    if (d < 30) return `hace ${d} día${d === 1 ? '' : 's'}`;
+    const mo = Math.floor(d / 30);
+    return `hace ${mo} mes${mo === 1 ? '' : 'es'}`;
+  }
+
+  // Control reutilizable: Select de presets + (si "Personalizado") número + unidad.
+  // Se auto-sincroniza cuando cambia valueSeconds; guarda SEGUNDOS vía onSave.
+  function SessionDurationField({ label, options, presetSeconds, valueSeconds, saving, onSave, buttonAdornment }) {
+    const secondsToKey = (seconds) => {
+      if (seconds == null) return 'default';
+      if (seconds === 0) return 'none';
+      if (presetSeconds.has(seconds)) return String(seconds);
+      return 'custom';
+    };
+
+    const [key, setKey] = useState(() => secondsToKey(valueSeconds));
+    const [customValue, setCustomValue] = useState(() => secondsToCustom(valueSeconds).value);
+    const [customUnit, setCustomUnit] = useState(() => secondsToCustom(valueSeconds).unit);
+    const [localError, setLocalError] = useState(null);
+
+    useEffect(() => {
+      setKey(secondsToKey(valueSeconds));
+      const c = secondsToCustom(valueSeconds);
+      setCustomValue(c.value);
+      setCustomUnit(c.unit);
+      setLocalError(null);
+    }, [valueSeconds]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const handleSave = () => {
+      let seconds;
+      if (key === 'custom') {
+        seconds = customToSeconds(customValue, customUnit);
+        if (seconds == null) { setLocalError('Ingresá un valor válido.'); return; }
+      } else {
+        seconds = options.find((o) => o.key === key)?.seconds ?? null;
+      }
+      setLocalError(null);
+      onSave(seconds);
+    };
+
+    return (
+      <Stack spacing={2}>
+        <FormControl fullWidth size="small">
+          <InputLabel>{label}</InputLabel>
+          <Select label={label} value={key} onChange={(e) => setKey(e.target.value)}>
+            {options.map((option) => (
+              <MenuItem key={option.key} value={option.key}>{option.label}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {key === 'custom' ? (
+          <Stack direction="row" spacing={1}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Cantidad"
+              value={customValue}
+              onChange={(e) => setCustomValue(e.target.value)}
+              error={Boolean(localError)}
+              helperText={localError || ''}
+              inputProps={{ min: 1 }}
+            />
+            <FormControl size="small" sx={{ minWidth: 130 }}>
+              <InputLabel>Unidad</InputLabel>
+              <Select label="Unidad" value={customUnit} onChange={(e) => setCustomUnit(e.target.value)}>
+                {CUSTOM_UNITS.map((u) => (
+                  <MenuItem key={u.key} value={u.key}>{u.label}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Stack>
+        ) : null}
+        <Box>
+          <Stack direction="row" spacing={2} alignItems="center" useFlexGap flexWrap="wrap">
+            <Button variant="contained" onClick={handleSave} disabled={saving}>
+              {saving ? 'Guardando…' : 'Guardar'}
+            </Button>
+            {buttonAdornment || null}
+          </Stack>
+        </Box>
+      </Stack>
+    );
   }
 
   function normalizeText(value) {
@@ -442,11 +536,7 @@ const BOOLEAN_FILTER_OPTIONS = [
     const [selectedIds, setSelectedIds] = useState(() => new Set());
     const [confirmCloseOpen, setConfirmCloseOpen] = useState(false);
     const [closingSessions, setClosingSessions] = useState(false);
-    const [sessionKey, setSessionKey] = useState('default');
-    const [sessionCustomMinutes, setSessionCustomMinutes] = useState('');
     const [savingSession, setSavingSession] = useState(false);
-    const [idleKey, setIdleKey] = useState('default');
-    const [idleCustomMinutes, setIdleCustomMinutes] = useState('');
     const [savingIdle, setSavingIdle] = useState(false);
     const [passwordValue, setPasswordValue] = useState('');
     const [showPassword, setShowPassword] = useState(false);
@@ -823,41 +913,8 @@ const BOOLEAN_FILTER_OPTIONS = [
       }
     }, [selectionCloseInfo]);
 
-    // Sincroniza los Select de seguridad con el perfil abierto en el drawer.
-    useEffect(() => {
+    const handleSaveSessionDuration = useCallback(async (seconds) => {
       if (!selectedRow) return;
-      const seconds = selectedRow.session_max_seconds;
-      setSessionKey(sessionSecondsToKey(seconds));
-      setSessionCustomMinutes(
-        seconds != null && seconds > 0 && !SESSION_PRESET_SECONDS.has(seconds)
-          ? String(Math.round(seconds / 60))
-          : ''
-      );
-      const idle = selectedRow.session_idle_seconds;
-      setIdleKey(idleSecondsToKey(idle));
-      setIdleCustomMinutes(
-        idle != null && idle > 0 && !SESSION_IDLE_PRESET_SECONDS.has(idle)
-          ? String(Math.round(idle / 60))
-          : ''
-      );
-    }, [selectedRow]);
-
-    const handleSessionKeyChange = useCallback((event) => setSessionKey(event.target.value), []);
-    const handleSessionCustomMinutesChange = useCallback((event) => setSessionCustomMinutes(event.target.value), []);
-
-    const handleSaveSessionDuration = useCallback(async () => {
-      if (!selectedRow) return;
-      let seconds;
-      if (sessionKey === 'custom') {
-        const minutes = Number(sessionCustomMinutes);
-        if (!Number.isFinite(minutes) || minutes <= 0) {
-          setError('Ingresá una cantidad de minutos válida.');
-          return;
-        }
-        seconds = Math.floor(minutes) * 60;
-      } else {
-        seconds = SESSION_DURATION_OPTIONS.find((option) => option.key === sessionKey)?.seconds ?? null;
-      }
       setSavingSession(true);
       setError(null);
       try {
@@ -870,24 +927,10 @@ const BOOLEAN_FILTER_OPTIONS = [
       } finally {
         setSavingSession(false);
       }
-    }, [selectedRow, sessionKey, sessionCustomMinutes]);
+    }, [selectedRow]);
 
-    const handleIdleKeyChange = useCallback((event) => setIdleKey(event.target.value), []);
-    const handleIdleCustomMinutesChange = useCallback((event) => setIdleCustomMinutes(event.target.value), []);
-
-    const handleSaveIdleTimeout = useCallback(async () => {
+    const handleSaveIdleTimeout = useCallback(async (seconds) => {
       if (!selectedRow) return;
-      let seconds;
-      if (idleKey === 'custom') {
-        const minutes = Number(idleCustomMinutes);
-        if (!Number.isFinite(minutes) || minutes <= 0) {
-          setError('Ingresá una cantidad de minutos válida para la inactividad.');
-          return;
-        }
-        seconds = Math.floor(minutes) * 60;
-      } else {
-        seconds = SESSION_IDLE_OPTIONS.find((option) => option.key === idleKey)?.seconds ?? null;
-      }
       setSavingIdle(true);
       setError(null);
       try {
@@ -900,7 +943,7 @@ const BOOLEAN_FILTER_OPTIONS = [
       } finally {
         setSavingIdle(false);
       }
-    }, [selectedRow, idleKey, idleCustomMinutes]);
+    }, [selectedRow]);
 
     const handleExportCsv = useCallback(() => {
       const csvRows = [
@@ -1180,6 +1223,7 @@ const BOOLEAN_FILTER_OPTIONS = [
                                   <Typography variant="caption" display="block">Perfil: {formatDateTime(row.created_at)}</Typography>
                                   <Typography variant="caption" display="block">Empresa: {formatDateTime(row.empresa?.createdAt)}</Typography>
                                   <Typography variant="caption" display="block">Última interacción: {formatDateTime(row.last_interaction_timestamp)}</Typography>
+                                  <Typography variant="caption" display="block" color={row.last_activity_at ? 'text.secondary' : 'text.disabled'}>Última actividad web: {row.last_activity_at ? `${formatDateTime(row.last_activity_at)} (${formatRelativeTime(row.last_activity_at)})` : 'Sin actividad'}</Typography>
                                 </TableCell>
                                 <TableCell align="right"><Button size="small" data-rowid={row.id} onClick={handleOpenDetail}>Ver detalle</Button></TableCell>
                               </TableRow>
@@ -1227,70 +1271,48 @@ const BOOLEAN_FILTER_OPTIONS = [
                         <Typography variant="subtitle1" fontWeight="bold">Seguridad · Sesión</Typography>
                       </Stack>
                       <Typography variant="body2" color="text.secondary" mb={2}>
-                        Cuánto dura la sesión desde el último login con credenciales. Pasado ese tiempo,
-                        el usuario tiene que volver a iniciar sesión. Actual: <strong>{describeSessionDuration(selectedRow.session_max_seconds)}</strong>.
+                        Cuánto dura la sesión desde el último login con credenciales, use o no la app.
+                        Pasado ese tiempo, el usuario tiene que volver a iniciar sesión.
+                        Actual: <strong>{describeSessionDuration(selectedRow.session_max_seconds)}</strong>.
                       </Typography>
-                      <Stack spacing={2}>
-                        <FormControl fullWidth size="small">
-                          <InputLabel>Duración máxima de sesión</InputLabel>
-                          <Select label="Duración máxima de sesión" value={sessionKey} onChange={handleSessionKeyChange}>
-                            {SESSION_DURATION_OPTIONS.map((option) => (
-                              <MenuItem key={option.key} value={option.key}>{option.label}</MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                        {sessionKey === 'custom' ? (
-                          <TextField
-                            fullWidth
-                            size="small"
-                            type="number"
-                            label="Minutos"
-                            value={sessionCustomMinutes}
-                            onChange={handleSessionCustomMinutesChange}
-                            inputProps={{ min: 1 }}
-                          />
-                        ) : null}
-                        {!selectedRow.user_id ? (
-                          <Typography variant="caption" color="text.secondary">
-                            Este perfil no tiene acceso web (sin user_id); la duración se aplicará si en el futuro ingresa a la plataforma.
-                          </Typography>
-                        ) : null}
-                        <Box>
-                          <Button variant="contained" onClick={handleSaveSessionDuration} disabled={savingSession}>
-                            {savingSession ? 'Guardando…' : 'Guardar duración'}
-                          </Button>
-                        </Box>
-
-                        <Divider />
-
-                        <Typography variant="body2" color="text.secondary">
-                          Tras cuánto tiempo <strong>sin actividad</strong> se cierra la sesión (cuenta desde la última acción del usuario en el sistema). Actual: <strong>{describeIdleTimeout(selectedRow.session_idle_seconds)}</strong>.
+                      <SessionDurationField
+                        label="Duración máxima de sesión"
+                        options={SESSION_DURATION_OPTIONS}
+                        presetSeconds={SESSION_PRESET_SECONDS}
+                        valueSeconds={selectedRow.session_max_seconds}
+                        saving={savingSession}
+                        onSave={handleSaveSessionDuration}
+                      />
+                      {!selectedRow.user_id ? (
+                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+                          Este perfil no tiene acceso web (sin user_id); se aplicará si en el futuro ingresa a la plataforma.
                         </Typography>
-                        <FormControl fullWidth size="small">
-                          <InputLabel>Inactividad</InputLabel>
-                          <Select label="Inactividad" value={idleKey} onChange={handleIdleKeyChange}>
-                            {SESSION_IDLE_OPTIONS.map((option) => (
-                              <MenuItem key={option.key} value={option.key}>{option.label}</MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                        {idleKey === 'custom' ? (
-                          <TextField
-                            fullWidth
-                            size="small"
-                            type="number"
-                            label="Minutos"
-                            value={idleCustomMinutes}
-                            onChange={handleIdleCustomMinutesChange}
-                            inputProps={{ min: 1 }}
-                          />
-                        ) : null}
-                        <Box>
-                          <Button variant="contained" onClick={handleSaveIdleTimeout} disabled={savingIdle}>
-                            {savingIdle ? 'Guardando…' : 'Guardar inactividad'}
-                          </Button>
-                        </Box>
-                      </Stack>
+                      ) : null}
+
+                      <Divider sx={{ my: 2 }} />
+
+                      <Typography variant="body2" color="text.secondary" mb={2}>
+                        Tras cuánto tiempo <strong>sin actividad</strong> se cierra la sesión (el reloj se
+                        reinicia con cada acción del usuario). Actual: <strong>{describeIdleTimeout(selectedRow.session_idle_seconds)}</strong>.
+                      </Typography>
+                      <SessionDurationField
+                        label="Inactividad"
+                        options={SESSION_IDLE_OPTIONS}
+                        presetSeconds={SESSION_IDLE_PRESET_SECONDS}
+                        valueSeconds={selectedRow.session_idle_seconds}
+                        saving={savingIdle}
+                        onSave={handleSaveIdleTimeout}
+                        buttonAdornment={
+                          <Tooltip title={selectedRow.last_activity_at ? `Actividad web: ${formatDateTime(selectedRow.last_activity_at)}` : 'Sin actividad web registrada'}>
+                            <Chip
+                              size="small"
+                              variant="outlined"
+                              color={selectedRow.last_activity_at ? 'default' : 'warning'}
+                              label={`Última actividad: ${formatRelativeTime(selectedRow.last_activity_at)}`}
+                            />
+                          </Tooltip>
+                        }
+                      />
                     </CardContent>
                   </Card>
                   <Card>

--- a/src/services/_authInterceptor.js
+++ b/src/services/_authInterceptor.js
@@ -1,5 +1,17 @@
-import { signOut as firebaseSignOut } from 'firebase/auth';
 import { auth } from 'src/config/firebase';
+import { markActivity, forceSessionLogout } from './sessionActivity';
+
+// Pollers de fondo que NO deben contar como actividad del usuario (para el idle
+// timeout): el refresh de usuario cada 30 min y el sync de conversaciones cada 30s.
+// Se detectan por URL; si matchean, se marcan con el header X-Background para que
+// el backend tampoco los cuente. (Créditos y version-check van por Firestore, no
+// por esta API, así que no hace falta listarlos.)
+const BACKGROUND_URL_PATTERNS = ['/profile/user/', '/conversaciones/sync'];
+const isBackgroundRequest = config => {
+  if (config?.headers?.['X-Background'] === '1' || config?.headers?.['x-background'] === '1') return true;
+  const url = config?.url || '';
+  return BACKGROUND_URL_PATTERNS.some(pattern => url.includes(pattern));
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Interceptores de auth compartidos por TODAS las instancias de axios.
@@ -85,6 +97,14 @@ export const attachAuthInterceptors = api => {
         if (token) {
           config.headers['Authorization'] = `Bearer ${token}`;
         }
+
+        // Actividad = request de usuario que pega a la API. Los de fondo se marcan
+        // con X-Background (para que el backend tampoco los cuente) y no resetean el idle.
+        if (isBackgroundRequest(config)) {
+          config.headers['X-Background'] = '1';
+        } else {
+          markActivity();
+        }
       } catch (error) {
         const fallbackToken = window.localStorage.getItem('authToken');
         if (fallbackToken) {
@@ -103,19 +123,12 @@ export const attachAuthInterceptors = api => {
     async error => {
       const originalRequest = error.config;
 
-      // Sesión invalidada app-level (duración vencida o cierre por admin). Refrescar
-      // el token NO ayuda: el token nuevo mantiene el mismo auth_time y seguiría 401.
-      // Cortamos antes del retry y deslogueamos de verdad.
+      // Sesión invalidada app-level (duración vencida, cierre por admin o inactividad).
+      // Refrescar el token NO ayuda: el token nuevo mantiene el mismo auth_time y
+      // seguiría 401. Cortamos antes del retry y deslogueamos de verdad.
       const sessionCode = error?.response?.data?.code;
-      if (sessionCode === 'SESSION_REVOKED' || sessionCode === 'SESSION_EXPIRED') {
-        await firebaseSignOut(auth).catch(() => {});
-        if (typeof window !== 'undefined') {
-          window.localStorage.removeItem('authToken');
-          window.localStorage.removeItem('MY_APP_STATE');
-          if (!window.location.pathname.startsWith('/auth')) {
-            window.location.href = '/auth/login';
-          }
-        }
+      if (sessionCode === 'SESSION_REVOKED' || sessionCode === 'SESSION_EXPIRED' || sessionCode === 'SESSION_IDLE') {
+        await forceSessionLogout();
         return Promise.reject(error);
       }
 

--- a/src/services/_authInterceptor.js
+++ b/src/services/_authInterceptor.js
@@ -1,3 +1,4 @@
+import { signOut as firebaseSignOut } from 'firebase/auth';
 import { auth } from 'src/config/firebase';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -101,6 +102,22 @@ export const attachAuthInterceptors = api => {
     response => response,
     async error => {
       const originalRequest = error.config;
+
+      // Sesión invalidada app-level (duración vencida o cierre por admin). Refrescar
+      // el token NO ayuda: el token nuevo mantiene el mismo auth_time y seguiría 401.
+      // Cortamos antes del retry y deslogueamos de verdad.
+      const sessionCode = error?.response?.data?.code;
+      if (sessionCode === 'SESSION_REVOKED' || sessionCode === 'SESSION_EXPIRED') {
+        await firebaseSignOut(auth).catch(() => {});
+        if (typeof window !== 'undefined') {
+          window.localStorage.removeItem('authToken');
+          window.localStorage.removeItem('MY_APP_STATE');
+          if (!window.location.pathname.startsWith('/auth')) {
+            window.location.href = '/auth/login';
+          }
+        }
+        return Promise.reject(error);
+      }
 
       if ([401, 403].includes(error?.response?.status) && originalRequest && !originalRequest._retry) {
         originalRequest._retry = true;

--- a/src/services/profileService.js
+++ b/src/services/profileService.js
@@ -107,6 +107,21 @@ const profileService = {
       throw err; // propaga para que el caller pueda reintentar
     }
   },
+
+  // Acciones destructivas de gestión de sesión: re-lanzan el error para que la UI
+  // muestre fallos reales (a diferencia de las lecturas que devuelven valor neutro).
+  closeSessions: async (userIds) => {
+    const response = await api.post('/profile/sessions/close', { userIds });
+    return response.data;
+  },
+
+  updateSessionDuration: async (profileId, sessionMaxSeconds) => {
+    const response = await api.put(
+      `/profile/${encodeURIComponent(profileId)}/session-duration`,
+      { session_max_seconds: sessionMaxSeconds }
+    );
+    return response.data;
+  },
 };
 
 export default profileService;

--- a/src/services/profileService.js
+++ b/src/services/profileService.js
@@ -134,6 +134,14 @@ const profileService = {
     );
     return response.data;
   },
+
+  updateIdleTimeout: async (profileId, sessionIdleSeconds) => {
+    const response = await api.put(
+      `/profile/${encodeURIComponent(profileId)}/idle-timeout`,
+      { session_idle_seconds: sessionIdleSeconds }
+    );
+    return response.data;
+  },
 };
 
 export default profileService;

--- a/src/services/sessionActivity.js
+++ b/src/services/sessionActivity.js
@@ -1,0 +1,30 @@
+import { signOut as firebaseSignOut } from 'firebase/auth';
+import { auth } from 'src/config/firebase';
+
+// Timestamp de la última actividad real del usuario (request no-background).
+// Lo actualiza el request-interceptor de axios y lo lee el IdleWatcher para el
+// logout proactivo por inactividad. Fuente de verdad final: el backend.
+let lastActivityMs = Date.now();
+
+export const markActivity = () => {
+  lastActivityMs = Date.now();
+};
+
+export const getLastActivityMs = () => lastActivityMs;
+
+// Logout "de verdad": corta la sesión de Firebase, limpia el estado local y
+// manda a login. Idempotente: varios disparos concurrentes (interceptor +
+// IdleWatcher) hacen una sola cosa.
+let loggingOut = false;
+export const forceSessionLogout = async () => {
+  if (loggingOut) return;
+  loggingOut = true;
+  await firebaseSignOut(auth).catch(() => {});
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem('authToken');
+    window.localStorage.removeItem('MY_APP_STATE');
+    if (!window.location.pathname.startsWith('/auth')) {
+      window.location.href = '/auth/login';
+    }
+  }
+};


### PR DESCRIPTION
Ticket: [TAR-439 — Onboarding: cambios de manejo de tokens](https://app.notion.com/p/38350a1e534180f2880ffd1933b6b20b) · PR hermano (backend): https://github.com/fedemaidan/sorby_bot_wa/pull/262

UI de la gestión de sesiones por usuario (2ª parte del ticket, variante app-level). La lógica de enforcement vive en el PR hermano del backend.

---

## TAR-439 — Gestión de sesiones (UI en Perfiles Globales)

**Causa raíz / Problema:** no había forma, desde el panel de administración, de controlar cuánto dura la sesión de un usuario ni de cerrarle la sesión. Requerimiento de seguridad del cliente en el onboarding.

**Cómo lo hicimos (funcional):** en *Perfiles Globales* (`profiles-overview.js`), un administrador ahora puede:
- **Configurar la duración de sesión** de cada usuario desde el detalle (presets: 15 min, 1 h, 4 h, 24 h, 1 mes, sin límite, o personalizado). Pasada esa duración, el usuario debe volver a iniciar sesión.
- **Cerrar la sesión** de uno o varios usuarios: marca usuarios con un checkbox por fila (o "seleccionar todos", que respeta los filtros aplicados) y confirma. Los usuarios afectados caen a la pantalla de login en su próxima acción.

**Decisiones y por qué:**
- **"Seleccionar todos" opera sobre las filas filtradas, no sobre la página visible** → si el admin filtra por empresa y marca todos, cierra la sesión de **todos los usuarios de esa empresa**, no sólo los 25 de la página. Como la tabla ya filtra client-side, se resuelve sobre `sortedRows`.
- **Gate de admin en la página** → la pantalla no estaba protegida por rol; se agrega el chequeo `user.admin` (patrón de `movimientos-globales.js`). El backend igual gatea (defensa en profundidad).
- **Forzar logout real en el interceptor** → ante 401 con `code` `SESSION_REVOKED`/`SESSION_EXPIRED`, el interceptor hace `signOut` de Firebase + redirect a login **antes** de reintentar (refrescar no ayuda: el token nuevo mantiene el mismo `auth_time`). Sin esto, el usuario invalidado se quedaba con 401s sin ser deslogueado.
- **Diálogo de confirmación con avisos** → informa cuántos se cierran, omite los perfiles sin `user_id` (nunca entraron a la web) y advierte si el propio admin está en la selección.
- **Métodos de servicio que re-lanzan el error** → a diferencia de las lecturas (que devuelven valor neutro), las acciones destructivas propagan el error para que la UI lo muestre.

**Cómo lo implementamos (técnico):**
- `profiles-overview.js`: gate de admin; selección con `Set` (functional setState) + poda al cambiar filtros; header checkbox con estado indeterminado; barra bulk "Cerrar sesión (N)"; `Dialog` de confirmación; card "Seguridad · Sesión" en el `Drawer` con `Select` de presets + input custom (minutos).
- `profileService.js`: `closeSessions(userIds)` → `POST /profile/sessions/close`; `updateSessionDuration(profileId, seconds)` → `PUT /profile/:id/session-duration`.
- `_authInterceptor.js`: manejo de `SESSION_REVOKED`/`SESSION_EXPIRED` al inicio del response-interceptor de error.

**Producción / compatibilidad:** aditivo. Un perfil sin `session_max_seconds` muestra "Default global (1 mes)". Sin migración. Depende del backend del PR hermano (el `code` de los 401 y los endpoints).

**Verificación:** ESLint limpio + validado en browser (ver iteración 2).

**Notas al código:**
- La poda de `selectedIds` al cambiar `filteredIdSet` evita cerrar sesión a usuarios que salieron del filtro después de haberlos seleccionado.
- `sessionSecondsToKey(undefined)` y `describeSessionDuration(undefined)` caen en la rama `== null` → los perfiles sin el campo se muestran como "Default global (1 mes)" sin lógica extra.

---

## TAR-439 (iteración 2) — UI y logout por inactividad

**Cómo lo hicimos (funcional):** en el mismo detalle del perfil, el admin ahora también configura un **timeout por inactividad** (presets 15 min … 1 día + personalizado, default 7 días). Si el usuario deja de operar el sistema por ese tiempo, se lo manda a la pantalla de login.

**Decisiones y por qué:**
- **Actividad = request de usuario que pega a la API** (no mousemove) → los pollers de fondo (refresh de usuario cada 30 min, sync de conversaciones) se detectan por URL en el interceptor y se marcan `X-Background` para no contar ni resetear el idle.
- **Logout proactivo sin aviso** → un `<IdleWatcher/>` en el layout del dashboard (solo logueado) desloguea al vencer, sin esperar el próximo 401. El backend es la fuente de verdad igual.
- **Reusar el camino de logout** → `SESSION_IDLE` se suma al mismo forzado de `signOut` + limpieza + redirect del interceptor.

**Cómo lo implementamos (técnico):**
- `sessionActivity.js` (nuevo): `markActivity()` + `forceSessionLogout()` idempotente.
- `_authInterceptor.js`: marca actividad en requests de usuario; detecta los de fondo por URL (`/profile/user/`, `/conversaciones/sync`) y les pone `X-Background`; agrega `SESSION_IDLE` al logout.
- `use-idle-logout.js` (nuevo) montado en `dashboard/layout.js`: `setInterval` que compara `now - lastActivity` con el `session_idle_seconds` del usuario.
- `profiles-overview.js`: segundo control "Inactividad" en la card del drawer; `profileService.updateIdleTimeout`.

**Producción / compatibilidad:** aditivo. Perfil sin `session_idle_seconds` → "Default global (7 días)". Depende del backend (código `SESSION_IDLE` + endpoint + header `X-Background` en CORS).

**Verificación (browser, end-to-end):** login → drawer muestra Duración + Inactividad → guardar "1 min" (`PUT idle-timeout` **200**) → tras 66s sin actividad, request → **401 `SESSION_IDLE`** → interceptor → redirect a `/auth/login` + limpia `authToken`/`MY_APP_STATE`. También se validó el fix del deadlock de re-login (backend).

---

## TL;DR
- **Usuario (admin):** en Perfiles Globales configura por usuario la **duración** de sesión y el **timeout por inactividad** (drawer), y **cierra sesiones** con checkbox por fila + "seleccionar todos" respetando filtros.
- **Inactividad:** actividad = request de usuario a la API; los pollers de fondo se marcan `X-Background`. `<IdleWatcher/>` en el layout desloguea proactivo; `SESSION_IDLE` en el interceptor.
- **Archivos:** `profiles-overview.js` (gate + selección + bulk + drawer con 2 controles), `profileService.js` (`closeSessions`, `updateSessionDuration`, `updateIdleTimeout`), `_authInterceptor.js`, `sessionActivity.js` (nuevo), `use-idle-logout.js` (nuevo), `dashboard/layout.js`.
- **Compatibilidad:** aditivo, sin migración; perfiles viejos = defaults (1 mes / 7 días).
- **Verificación:** ESLint + validación end-to-end en browser (idle → `SESSION_IDLE` → logout).
- **Depende del** PR hermano de backend (enforcement + endpoints + CORS).

