### PR TITLE
Control de Obra — Lado costo (simetría cliente/proveedor) [frontend]

### DIFF
--- a/src/components/controlObra/EditarTareaDrawer.js
+++ b/src/components/controlObra/EditarTareaDrawer.js
@@ -36,6 +36,7 @@ export default function EditarTareaDrawer({ obra, subrubro, empresaId, onClose, 
     nombre: subrubro.nombre || '',
     monto: String(subrubro.contrato ?? subrubro.monto ?? 0),
     costo_estimado: subrubro.costo_estimado ?? '',
+    costo_directo: subrubro.costo_directo ?? '',
     unidad: subrubro.unidad || '',
     cantidad: subrubro.cantidad ?? '',
     fecha_inicio: inicioInicial,
@@ -66,6 +67,7 @@ export default function EditarTareaDrawer({ obra, subrubro, empresaId, onClose, 
       nombre: form.nombre,
       monto: Number(form.monto),
       costo_estimado: form.costo_estimado === '' ? null : Number(form.costo_estimado),
+      costo_directo: form.costo_directo === '' ? null : Number(form.costo_directo),
       unidad: form.unidad || null,
       cantidad: form.cantidad === '' ? null : Number(form.cantidad),
       duracion_dias: tieneDuracion ? Number(form.duracion_dias) : null,
@@ -94,7 +96,8 @@ export default function EditarTareaDrawer({ obra, subrubro, empresaId, onClose, 
       <Stack spacing={2}>
         <TextField label="Nombre" value={form.nombre} onChange={(e) => set('nombre', e.target.value)} size="small" fullWidth />
         <TextField label="Monto de contrato (cliente)" type="number" value={form.monto} onChange={(e) => set('monto', e.target.value)} size="small" fullWidth helperText="Lo que vas a cobrar por este sub-rubro" />
-        <TextField label="Costo estimado (proveedor)" type="number" value={form.costo_estimado} onChange={(e) => set('costo_estimado', e.target.value)} size="small" fullWidth helperText="Lo que pensás gastar; lo refina el contrato del proveedor. Vacío = sin estimar" />
+        <TextField label="Costo estimado (proveedor)" type="number" value={form.costo_estimado} onChange={(e) => set('costo_estimado', e.target.value)} size="small" fullWidth helperText="Parte del costo que es del proveedor; lo refina el contrato. Vacío = sin estimar" />
+        <TextField label="Costo directo (materiales/otros)" type="number" value={form.costo_directo} onChange={(e) => set('costo_directo', e.target.value)} size="small" fullWidth helperText="Parte que NO es del proveedor: materiales/gastos que vas imputando sueltos. Se suma al costo esperado" />
         <Stack direction="row" spacing={1}>
           <TextField label="Unidad" value={form.unidad} onChange={(e) => set('unidad', e.target.value)} size="small" sx={{ flex: 1 }} />
           <TextField label="Cantidad" type="number" value={form.cantidad} onChange={(e) => set('cantidad', e.target.value)} size="small" sx={{ flex: 1 }} />

--- a/src/components/controlObra/EditarTareaDrawer.js
+++ b/src/components/controlObra/EditarTareaDrawer.js
@@ -35,6 +35,7 @@ export default function EditarTareaDrawer({ obra, subrubro, empresaId, onClose, 
   const [form, setForm] = useState({
     nombre: subrubro.nombre || '',
     monto: String(subrubro.contrato ?? subrubro.monto ?? 0),
+    costo_estimado: subrubro.costo_estimado ?? '',
     unidad: subrubro.unidad || '',
     cantidad: subrubro.cantidad ?? '',
     fecha_inicio: inicioInicial,
@@ -64,6 +65,7 @@ export default function EditarTareaDrawer({ obra, subrubro, empresaId, onClose, 
     mutationFn: () => ControlObraService.editarSubrubro(obra._id, subrubro.uid, empresaId, {
       nombre: form.nombre,
       monto: Number(form.monto),
+      costo_estimado: form.costo_estimado === '' ? null : Number(form.costo_estimado),
       unidad: form.unidad || null,
       cantidad: form.cantidad === '' ? null : Number(form.cantidad),
       duracion_dias: tieneDuracion ? Number(form.duracion_dias) : null,
@@ -91,7 +93,8 @@ export default function EditarTareaDrawer({ obra, subrubro, empresaId, onClose, 
     >
       <Stack spacing={2}>
         <TextField label="Nombre" value={form.nombre} onChange={(e) => set('nombre', e.target.value)} size="small" fullWidth />
-        <TextField label="Monto de contrato" type="number" value={form.monto} onChange={(e) => set('monto', e.target.value)} size="small" fullWidth />
+        <TextField label="Monto de contrato (cliente)" type="number" value={form.monto} onChange={(e) => set('monto', e.target.value)} size="small" fullWidth helperText="Lo que vas a cobrar por este sub-rubro" />
+        <TextField label="Costo estimado (proveedor)" type="number" value={form.costo_estimado} onChange={(e) => set('costo_estimado', e.target.value)} size="small" fullWidth helperText="Lo que pensás gastar; lo refina el contrato del proveedor. Vacío = sin estimar" />
         <Stack direction="row" spacing={1}>
           <TextField label="Unidad" value={form.unidad} onChange={(e) => set('unidad', e.target.value)} size="small" sx={{ flex: 1 }} />
           <TextField label="Cantidad" type="number" value={form.cantidad} onChange={(e) => set('cantidad', e.target.value)} size="small" sx={{ flex: 1 }} />

--- a/src/components/controlObra/EjecucionTab.js
+++ b/src/components/controlObra/EjecucionTab.js
@@ -25,6 +25,7 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
   const qc = useQueryClient();
   const [dialog, setDialog] = useState(false);
   const [masiva, setMasiva] = useState(false);
+  const [estimar, setEstimar] = useState(false);
   const [armado, setArmado] = useState(false);
   const [audit, setAudit] = useState(false);
   const [nuevoRubro, setNuevoRubro] = useState(false);
@@ -47,6 +48,7 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
             </Button>
             <Button size="small" variant="outlined" onClick={() => setDialog(true)}>Imputar gasto</Button>
             <Button size="small" variant="outlined" onClick={() => setMasiva(true)}>Re-imputar masiva</Button>
+            <Button size="small" variant="outlined" onClick={() => setEstimar(true)}>Estimar costos</Button>
             <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={() => setNuevoRubro(true)}>Rubro</Button>
             <IconButton size="small" title="Historial de cambios" onClick={() => setAudit(true)}><HistoryIcon fontSize="small" /></IconButton>
           </Stack>
@@ -58,8 +60,7 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
               <TableCell align="right">Contrato</TableCell>
               <TableCell sx={{ width: 160 }}>Avance</TableCell>
               <TableCell align="right">Certificado</TableCell>
-              <TableCell align="right">Costo estimado</TableCell>
-              <TableCell align="right">Contratado</TableCell>
+              <TableCell align="right" title="Costo estimado → contratado del proveedor (el firme manda)">Costo est/contr</TableCell>
               <TableCell align="right">Gastado</TableCell>
               <TableCell align="right">Margen esperado</TableCell>
               <TableCell align="right">Margen</TableCell>
@@ -73,7 +74,6 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
                 <TableRow key={r.uid} sx={{ '& td': { bgcolor: 'action.hover', fontWeight: 600, borderBottom: 'none' } }}>
                   <TableCell>{r.nombre}</TableCell>
                   <TableCell align="right">{fmt(rContrato)}</TableCell>
-                  <TableCell />
                   <TableCell />
                   <TableCell />
                   <TableCell />
@@ -111,8 +111,7 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
                       </Stack>
                     </TableCell>
                     <TableCell align="right">{fmt(s.certificado)}</TableCell>
-                    <TableCell align="right">{s.costo_estimado != null ? fmt(s.costo_estimado) : '—'}</TableCell>
-                    <TableCell align="right">{s.contrato_proveedor ? fmt(s.contrato_proveedor.monto) : '—'}</TableCell>
+                    <CostoCell s={s} />
                     <TableCell align="right" sx={s.sobrecosto ? { color: 'error.main', fontWeight: 600 } : undefined}>{fmt(s.gastado)}</TableCell>
                     <TableCell align="right" sx={{ color: s.margen_esperado != null ? margenColor(s.margen_esperado) : undefined, fontWeight: 500 }}>
                       {s.margen_esperado != null ? fmt(s.margen_esperado) : '—'}
@@ -129,7 +128,6 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
               <TableCell align="right">{fmt(t.contrato)}</TableCell>
               <TableCell />
               <TableCell align="right">{fmt(t.certificado)}</TableCell>
-              <TableCell />
               <TableCell align="right" title="Costo de referencia (contratado o estimado)">{t.costo_ref != null ? fmt(t.costo_ref) : '—'}</TableCell>
               <TableCell align="right">{fmt(t.gastado)}</TableCell>
               <TableCell align="right" sx={{ color: t.margen_esperado != null ? margenColor(t.margen_esperado) : undefined }}>{t.margen_esperado != null ? fmt(t.margen_esperado) : '—'}</TableCell>
@@ -185,7 +183,89 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
       <AuditoriaDrawer open={audit} onClose={() => setAudit(false)} obra={obra} empresaId={empresaId} />
 
       <NuevoRubroDialog open={nuevoRubro} onClose={() => setNuevoRubro(false)} obra={obra} empresaId={empresaId} onDone={() => { setNuevoRubro(false); qc.invalidateQueries({ queryKey: ['control-obra'] }); }} />
+
+      <EstimarCostosDialog open={estimar} onClose={() => setEstimar(false)} obra={obra} empresaId={empresaId} onDone={() => { setEstimar(false); qc.invalidateQueries({ queryKey: ['control-obra'] }); }} />
     </Card>
+  );
+}
+
+// Celda fusionada costo estimado / contratado (feedback #1). Muestra el valor de
+// referencia (contratado si hay, si no el estimado) y, cuando conviven, la
+// diferencia entre lo estimado y lo firme.
+function CostoCell({ s }) {
+  const estimado = s.costo_estimado;
+  const contratado = s.contrato_proveedor ? s.contrato_proveedor.monto : null;
+  const ref = contratado != null ? contratado : estimado;
+  if (ref == null) return <TableCell align="right">—</TableCell>;
+  const ambos = contratado != null && estimado != null;
+  const delta = ambos ? contratado - estimado : 0;
+  return (
+    <TableCell align="right">
+      <Typography variant="body2" component="span" sx={{ fontStyle: contratado == null ? 'italic' : 'normal' }}>
+        {fmt(ref)}
+      </Typography>
+      {ambos && delta !== 0 && (
+        <Typography variant="caption" display="block" sx={{ color: delta > 0 ? 'error.main' : 'success.main' }}>
+          est. {fmt(estimado)} · {delta > 0 ? '+' : ''}{fmt(delta)}
+        </Typography>
+      )}
+      {!ambos && (
+        <Typography variant="caption" display="block" color="text.secondary">
+          {contratado != null ? 'contratado' : 'estimado'}
+        </Typography>
+      )}
+    </TableCell>
+  );
+}
+
+// Carga masiva de costos estimados desde el contrato (feedback #2), o al revés.
+function EstimarCostosDialog({ open, onClose, obra, empresaId, onDone }) {
+  const [direccion, setDireccion] = useState('costo_desde_contrato');
+  const [pct, setPct] = useState('20');
+  const [soloVacios, setSoloVacios] = useState(true);
+  const [error, setError] = useState(null);
+  const m = useMutation({
+    mutationFn: () => ControlObraService.estimarCostos(obra._id, empresaId, { direccion, pct: Number(pct), solo_vacios: soloVacios }),
+    onSuccess: onDone,
+    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
+  });
+  const desdeContrato = direccion === 'costo_desde_contrato';
+  return (
+    <FormDrawer
+      open={open} onClose={onClose} title="Estimar costos en masa" width={440}
+      actions={(
+        <>
+          <Button onClick={onClose}>Cancelar</Button>
+          <Button variant="contained" disabled={m.isPending || pct === '' || Number.isNaN(Number(pct))} onClick={() => { setError(null); m.mutate(); }}>Aplicar</Button>
+        </>
+      )}
+    >
+      <Stack spacing={2}>
+        <TextField
+          select SelectProps={{ native: true }} size="small" label="Dirección"
+          value={direccion} onChange={(e) => setDireccion(e.target.value)}
+        >
+          <option value="costo_desde_contrato">Costo estimado = contrato − %</option>
+          <option value="contrato_desde_costo">Contrato = costo estimado + %</option>
+        </TextField>
+        <TextField
+          label={desdeContrato ? 'Margen a descontar del contrato (%)' : 'Markup sobre el costo (%)'}
+          type="number" value={pct} onChange={(e) => setPct(e.target.value)} size="small" fullWidth
+          inputProps={{ min: 0, step: 1 }}
+          helperText={desdeContrato
+            ? 'Costo estimado = monto de contrato × (1 − %). Ej: 20% → costo = 80% del contrato.'
+            : 'Contrato = costo estimado × (1 + %). Fija el precio al cliente a partir del costo.'}
+        />
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ cursor: 'pointer' }} onClick={() => setSoloVacios((v) => !v)}>
+          <input type="checkbox" checked={soloVacios} onChange={(e) => setSoloVacios(e.target.checked)} />
+          <Typography variant="body2">Solo los que están sin {desdeContrato ? 'costo estimado' : 'contrato'} (no pisar los cargados)</Typography>
+        </Stack>
+        <Typography variant="caption" color="text.secondary">
+          Se aplica a todos los sub-rubros de la obra. {desdeContrato ? 'No toca los contratos de proveedor ya asignados.' : 'Ajusta el monto de contrato con el cliente y el plan de cobro asociado.'}
+        </Typography>
+        {error && <Typography color="error" variant="body2">{error}</Typography>}
+      </Stack>
+    </FormDrawer>
   );
 }
 

--- a/src/components/controlObra/EjecucionTab.js
+++ b/src/components/controlObra/EjecucionTab.js
@@ -10,7 +10,7 @@ import HistoryIcon from '@mui/icons-material/History';
 import AddIcon from '@mui/icons-material/Add';
 import ImputarGastoDialog from 'src/components/controlObra/ImputarGastoDialog';
 import ReimputarMasivaDialog from 'src/components/controlObra/ReimputarMasivaDialog';
-import SubrubroAccionesMenu from 'src/components/controlObra/SubrubroAccionesMenu';
+import SubrubroDetalleDrawer from 'src/components/controlObra/SubrubroDetalleDrawer';
 import RubroAccionesMenu from 'src/components/controlObra/RubroAccionesMenu';
 import ArmadoCertificadoDrawer from 'src/components/controlObra/ArmadoCertificadoDrawer';
 import AuditoriaDrawer from 'src/components/controlObra/AuditoriaDrawer';
@@ -29,8 +29,12 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
   const [armado, setArmado] = useState(false);
   const [audit, setAudit] = useState(false);
   const [nuevoRubro, setNuevoRubro] = useState(false);
-  const [menu, setMenu] = useState({ anchorEl: null, sub: null });
+  const [detalleUid, setDetalleUid] = useState(null);
   const [rubroMenu, setRubroMenu] = useState({ anchorEl: null, rubro: null });
+  // El detalle se re-deriva de la ejecución en cada render para reflejar ediciones.
+  const detalleSub = detalleUid
+    ? (ejec?.rubros || []).flatMap((r) => r.subrubros || []).find((x) => x.uid === detalleUid)
+    : null;
   const t = ejec?.totales || {};
   const pendientesCert = (ejec?.rubros || []).flatMap((r) => r.subrubros || []).filter((s) => (s.avance_pct || 0) > (s.cert_pct || 0)).length;
 
@@ -84,7 +88,7 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
                   </TableCell>
                 </TableRow>,
                 ...(r.subrubros || []).map((s) => (
-                  <TableRow key={s.uid} hover sx={{ cursor: 'pointer' }} onClick={(e) => setMenu({ anchorEl: e.currentTarget, sub: s })}>
+                  <TableRow key={s.uid} hover sx={{ cursor: 'pointer' }} onClick={() => setDetalleUid(s.uid)}>
                     <TableCell sx={{ pl: 4 }}>
                       <Stack direction="row" spacing={0.75} alignItems="center">
                         <span>{s.nombre}</span>
@@ -156,13 +160,14 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
         onDone={() => { setMasiva(false); qc.invalidateQueries({ queryKey: ['control-obra'] }); }}
       />
 
-      <SubrubroAccionesMenu
-        obra={obra}
-        subrubro={menu.sub}
-        empresaId={empresaId}
-        anchorEl={menu.anchorEl}
-        onClose={() => setMenu({ anchorEl: null, sub: null })}
-      />
+      {detalleSub && (
+        <SubrubroDetalleDrawer
+          obra={obra}
+          subrubro={detalleSub}
+          empresaId={empresaId}
+          onClose={() => setDetalleUid(null)}
+        />
+      )}
 
       <RubroAccionesMenu
         obra={obra}

--- a/src/components/controlObra/EjecucionTab.js
+++ b/src/components/controlObra/EjecucionTab.js
@@ -58,7 +58,10 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
               <TableCell align="right">Contrato</TableCell>
               <TableCell sx={{ width: 160 }}>Avance</TableCell>
               <TableCell align="right">Certificado</TableCell>
+              <TableCell align="right">Costo estimado</TableCell>
+              <TableCell align="right">Contratado</TableCell>
               <TableCell align="right">Gastado</TableCell>
+              <TableCell align="right">Margen esperado</TableCell>
               <TableCell align="right">Margen</TableCell>
             </TableRow>
           </TableHead>
@@ -72,7 +75,10 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
                   <TableCell align="right">{fmt(rContrato)}</TableCell>
                   <TableCell />
                   <TableCell />
+                  <TableCell />
+                  <TableCell />
                   <TableCell align="right">{fmt(rGastado)}</TableCell>
+                  <TableCell />
                   <TableCell align="right" sx={{ py: 0 }}>
                     <IconButton size="small" onClick={(e) => setRubroMenu({ anchorEl: e.currentTarget, rubro: r })}><MoreVertIcon fontSize="small" /></IconButton>
                   </TableCell>
@@ -105,7 +111,12 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
                       </Stack>
                     </TableCell>
                     <TableCell align="right">{fmt(s.certificado)}</TableCell>
-                    <TableCell align="right">{fmt(s.gastado)}</TableCell>
+                    <TableCell align="right">{s.costo_estimado != null ? fmt(s.costo_estimado) : '—'}</TableCell>
+                    <TableCell align="right">{s.contrato_proveedor ? fmt(s.contrato_proveedor.monto) : '—'}</TableCell>
+                    <TableCell align="right" sx={s.sobrecosto ? { color: 'error.main', fontWeight: 600 } : undefined}>{fmt(s.gastado)}</TableCell>
+                    <TableCell align="right" sx={{ color: s.margen_esperado != null ? margenColor(s.margen_esperado) : undefined, fontWeight: 500 }}>
+                      {s.margen_esperado != null ? fmt(s.margen_esperado) : '—'}
+                    </TableCell>
                     <TableCell align="right" sx={{ color: margenColor(s.margen), fontWeight: 500 }}>{fmt(s.margen)}</TableCell>
                   </TableRow>
                 )),
@@ -118,7 +129,10 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
               <TableCell align="right">{fmt(t.contrato)}</TableCell>
               <TableCell />
               <TableCell align="right">{fmt(t.certificado)}</TableCell>
+              <TableCell />
+              <TableCell align="right" title="Costo de referencia (contratado o estimado)">{t.costo_ref != null ? fmt(t.costo_ref) : '—'}</TableCell>
               <TableCell align="right">{fmt(t.gastado)}</TableCell>
+              <TableCell align="right" sx={{ color: t.margen_esperado != null ? margenColor(t.margen_esperado) : undefined }}>{t.margen_esperado != null ? fmt(t.margen_esperado) : '—'}</TableCell>
               <TableCell align="right" sx={{ color: margenColor(t.margen || 0) }}>{fmt(t.margen)}</TableCell>
             </TableRow>
           </TableBody>

--- a/src/components/controlObra/EjecucionTab.js
+++ b/src/components/controlObra/EjecucionTab.js
@@ -189,31 +189,34 @@ export default function EjecucionTab({ obra, ejec, empresaId }) {
   );
 }
 
-// Celda fusionada costo estimado / contratado (feedback #1). Muestra el valor de
-// referencia (contratado si hay, si no el estimado) y, cuando conviven, la
-// diferencia entre lo estimado y lo firme.
+// Celda de costo de la tarea. Muestra el costo de referencia total (parte proveedor
+// + parte directa/materiales) y, debajo, la composición: si hay costo directo lo
+// desglosa "prov X + dir Y"; si no, cae al detalle estimado/contratado (feedback #1).
 function CostoCell({ s }) {
+  const total = s.costo_ref;
+  if (total == null) return <TableCell align="right">—</TableCell>;
   const estimado = s.costo_estimado;
   const contratado = s.contrato_proveedor ? s.contrato_proveedor.monto : null;
-  const ref = contratado != null ? contratado : estimado;
-  if (ref == null) return <TableCell align="right">—</TableCell>;
-  const ambos = contratado != null && estimado != null;
+  const directo = s.costo_directo;
+  const soloEstimado = contratado == null && directo == null; // todo estimado (blando)
+  const ambos = contratado != null && estimado != null && contratado !== estimado;
   const delta = ambos ? contratado - estimado : 0;
+  let caption = null;
+  let captionColor = 'text.secondary';
+  if (directo != null) {
+    caption = `prov ${fmt(s.costo_proveedor || 0)} + dir ${fmt(directo)}`;
+  } else if (ambos) {
+    caption = `est. ${fmt(estimado)} · ${delta > 0 ? '+' : ''}${fmt(delta)}`;
+    captionColor = delta > 0 ? 'error.main' : 'success.main';
+  } else {
+    caption = contratado != null ? 'contratado' : 'estimado';
+  }
   return (
     <TableCell align="right">
-      <Typography variant="body2" component="span" sx={{ fontStyle: contratado == null ? 'italic' : 'normal' }}>
-        {fmt(ref)}
+      <Typography variant="body2" component="span" sx={{ fontStyle: soloEstimado ? 'italic' : 'normal' }}>
+        {fmt(total)}
       </Typography>
-      {ambos && delta !== 0 && (
-        <Typography variant="caption" display="block" sx={{ color: delta > 0 ? 'error.main' : 'success.main' }}>
-          est. {fmt(estimado)} · {delta > 0 ? '+' : ''}{fmt(delta)}
-        </Typography>
-      )}
-      {!ambos && (
-        <Typography variant="caption" display="block" color="text.secondary">
-          {contratado != null ? 'contratado' : 'estimado'}
-        </Typography>
-      )}
+      <Typography variant="caption" display="block" sx={{ color: captionColor }}>{caption}</Typography>
     </TableCell>
   );
 }

--- a/src/components/controlObra/ManoObraTab.js
+++ b/src/components/controlObra/ManoObraTab.js
@@ -1,15 +1,31 @@
 import { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
-  Box, Button, Card, CardContent, Chip, Stack, Table, TableBody, TableCell,
-  TableHead, TableRow, TextField, Typography,
+  Alert, Box, Button, Card, CardContent, Chip, LinearProgress, MenuItem, Paper,
+  Stack, Table, TableBody, TableCell, TableHead, TableRow, TextField, Typography,
 } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
 import FormDrawer from 'src/components/controlObra/FormDrawer';
 import ControlObraService from 'src/services/controlObra/controlObraService';
 
 const fmt = (n) => (Number(n) || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 });
+const money = (n, moneda) => (Number(n) || 0).toLocaleString('es-AR', { style: 'currency', currency: moneda === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
 const COLOR = { borrador: 'default', aprobada: 'info', pagada: 'success', anulada: 'error' };
 const MODALIDAD_LBL = { avance_fisico: 'avance físico', certificado: 'certificado' };
+
+// Proveedores con contrato asignado a alguna tarea de la obra (candidatos a plan de pago).
+function proveedoresConContrato(obra) {
+  const map = new Map();
+  for (const r of obra.rubros || []) {
+    for (const s of r.subrubros || []) {
+      const c = s.contrato_proveedor;
+      if (!c || !c.proveedor_nombre) continue;
+      const key = c.proveedor_id || c.proveedor_nombre;
+      if (!map.has(key)) map.set(key, { proveedor_id: c.proveedor_id || null, proveedor_nombre: c.proveedor_nombre });
+    }
+  }
+  return Array.from(map.values());
+}
 
 export default function ManoObraTab({ obra, empresaId }) {
   const qc = useQueryClient();
@@ -105,7 +121,204 @@ export default function ManoObraTab({ obra, empresaId }) {
       </CardContent>
       <NuevaOrdenDialog open={dialog} onClose={() => setDialog(false)} obra={obra} empresaId={empresaId} onDone={() => { setDialog(false); refresh(); }} />
     </Card>
+
+    <PlanesPagoSection obra={obra} empresaId={empresaId} />
     </Stack>
+  );
+}
+
+// Sección "Planes de pago a proveedores" (T3): espejo outbound de CobrosObraTab.
+// Lista 0..N planes de la obra con resumen/cuotas; permite crear uno nuevo y
+// generar cuotas por avance devengado del proveedor.
+function PlanesPagoSection({ obra, empresaId }) {
+  const qc = useQueryClient();
+  const [dialog, setDialog] = useState(false);
+
+  const planesQ = useQuery({
+    queryKey: ['control-obra', 'planes-pago', obra._id, empresaId],
+    queryFn: () => ControlObraService.listarPlanesPago(obra._id, empresaId),
+    enabled: !!empresaId,
+  });
+  const refresh = () => qc.invalidateQueries({ queryKey: ['control-obra', 'planes-pago', obra._id, empresaId] });
+
+  const generarAvance = useMutation({
+    mutationFn: (planId) => ControlObraService.generarCuotasPorAvance(planId, empresaId),
+    onSuccess: refresh,
+  });
+
+  const planes = planesQ.data || [];
+
+  return (
+    <Card>
+      <CardContent>
+        <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ sm: 'center' }} spacing={1} mb={1}>
+          <Box>
+            <Typography variant="subtitle1" fontWeight={600}>Planes de pago a proveedores</Typography>
+            <Typography variant="caption" color="text.secondary">
+              0..N planes por obra. Cada plan agrupa las cuotas a desembolsar a un proveedor (por avance devengado, fijas o por hito).
+            </Typography>
+          </Box>
+          <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={() => setDialog(true)}>Nuevo plan de pago</Button>
+        </Stack>
+
+        {planesQ.isLoading && <LinearProgress sx={{ mb: 2 }} />}
+
+        {!planesQ.isLoading && planes.length === 0 && (
+          <Typography variant="body2" color="text.secondary">La obra no tiene planes de pago.</Typography>
+        )}
+
+        {generarAvance.isError && (
+          <Alert severity="warning" sx={{ mb: 1.5 }}>
+            {generarAvance.error?.response?.data?.error?.message || 'No se pudieron generar cuotas por avance.'}
+          </Alert>
+        )}
+
+        <Stack spacing={1.5}>
+          {planes.map((plan) => {
+            const r = plan.resumen || {};
+            const pct = r.total ? Math.round((r.pagado || 0) / r.total * 100) : 0;
+            return (
+              <Paper key={plan._id} variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+                <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" spacing={1.5} alignItems={{ sm: 'center' }}>
+                  <Box sx={{ minWidth: 0 }}>
+                    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                      <Typography variant="subtitle2" fontWeight={700}>{plan.nombre}</Typography>
+                      <Chip size="small" label={plan.estado} color={plan.estado === 'completado' ? 'success' : plan.estado === 'activo' ? 'primary' : 'default'} />
+                      {plan.indexacion && <Chip size="small" variant="outlined" label={plan.indexacion} />}
+                    </Stack>
+                    <Typography variant="caption" color="text.secondary">
+                      {r.cuotas_total || 0} cuota(s) · Proveedor: {plan.proveedor_nombre || 's/d'}
+                    </Typography>
+                  </Box>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    disabled={generarAvance.isPending}
+                    onClick={() => generarAvance.mutate(plan._id)}
+                  >
+                    Generar por avance
+                  </Button>
+                </Stack>
+
+                <Stack direction="row" spacing={3} mt={1.5} flexWrap="wrap">
+                  <Metric label="Total" value={money(r.total, plan.moneda)} />
+                  <Metric label="Pagado" value={money(r.pagado, plan.moneda)} color="success.main" />
+                  <Metric label="Pendiente" value={money(r.pendiente, plan.moneda)} color="error.main" />
+                  {r.vencido > 0 && <Metric label="Vencido" value={money(r.vencido, plan.moneda)} color="warning.main" />}
+                </Stack>
+
+                <Box mt={1}>
+                  <Stack direction="row" justifyContent="space-between" mb={0.5}>
+                    <Typography variant="caption" color="text.secondary">Avance de pago</Typography>
+                    <Typography variant="caption" fontWeight={600}>{pct}%</Typography>
+                  </Stack>
+                  <LinearProgress variant="determinate" value={pct} color={plan.estado === 'completado' ? 'success' : 'primary'} sx={{ height: 6, borderRadius: 3 }} />
+                </Box>
+
+                {(plan.cuotas || []).length > 0 && (
+                  <Table size="small" sx={{ mt: 1.5 }}>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Descripción</TableCell>
+                        <TableCell>Vencimiento</TableCell>
+                        <TableCell align="right">Monto</TableCell>
+                        <TableCell>Estado</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {plan.cuotas.map((c) => (
+                        <TableRow key={c._id}>
+                          <TableCell>{c.descripcion || c.tipo}</TableCell>
+                          <TableCell>{c.fecha_vencimiento ? new Date(c.fecha_vencimiento).toLocaleDateString('es-AR') : '—'}</TableCell>
+                          <TableCell align="right">{money(c.monto, plan.moneda)}</TableCell>
+                          <TableCell><Chip size="small" label={c.estado_ui || c.estado} color={COLOR[c.estado] || 'default'} /></TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </Paper>
+            );
+          })}
+        </Stack>
+      </CardContent>
+
+      <NuevoPlanPagoDialog
+        open={dialog}
+        onClose={() => setDialog(false)}
+        obra={obra}
+        empresaId={empresaId}
+        onDone={() => { setDialog(false); refresh(); }}
+      />
+    </Card>
+  );
+}
+
+function NuevoPlanPagoDialog({ open, onClose, obra, empresaId, onDone }) {
+  const proveedores = useMemo(() => proveedoresConContrato(obra), [obra]);
+  const [sel, setSel] = useState('');
+  const [proveedorLibre, setProveedorLibre] = useState('');
+  const [nombre, setNombre] = useState('');
+  const [error, setError] = useState(null);
+
+  const seleccionado = proveedores.find((p) => (p.proveedor_id || p.proveedor_nombre) === sel);
+
+  const crear = useMutation({
+    mutationFn: () => {
+      const proveedor_nombre = seleccionado ? seleccionado.proveedor_nombre : proveedorLibre.trim();
+      if (!proveedor_nombre) throw new Error('Elegí o escribí un proveedor');
+      return ControlObraService.crearPlanPago(obra._id, {
+        empresa_id: empresaId,
+        proveedor_id: seleccionado ? seleccionado.proveedor_id : null,
+        proveedor_nombre,
+        nombre: nombre.trim() || null,
+      });
+    },
+    onSuccess: () => { setSel(''); setProveedorLibre(''); setNombre(''); onDone(); },
+    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
+  });
+
+  return (
+    <FormDrawer
+      open={open} onClose={onClose} title="Nuevo plan de pago" width={480}
+      actions={(
+        <>
+          <Button onClick={onClose}>Cancelar</Button>
+          <Button variant="contained" disabled={crear.isPending} onClick={() => { setError(null); crear.mutate(); }}>Crear</Button>
+        </>
+      )}
+    >
+      <Typography variant="caption" color="text.secondary">Proveedor</Typography>
+      {proveedores.length > 0 ? (
+        <TextField select fullWidth size="small" label="Proveedor (con contrato)" value={sel} onChange={(e) => setSel(e.target.value)} sx={{ mt: 1, mb: 2 }}>
+          <MenuItem value="">Otro (escribir)</MenuItem>
+          {proveedores.map((p) => (
+            <MenuItem key={p.proveedor_id || p.proveedor_nombre} value={p.proveedor_id || p.proveedor_nombre}>{p.proveedor_nombre}</MenuItem>
+          ))}
+        </TextField>
+      ) : (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 1 }}>
+          No hay proveedores con contrato asignado en la obra. Escribí el nombre a mano.
+        </Typography>
+      )}
+
+      {!seleccionado && (
+        <TextField label="Nombre del proveedor" fullWidth size="small" value={proveedorLibre} onChange={(e) => setProveedorLibre(e.target.value)} sx={{ mb: 2 }} />
+      )}
+
+      <TextField label="Nombre del plan (opcional)" fullWidth size="small" value={nombre} onChange={(e) => setNombre(e.target.value)} placeholder="Pagos: <proveedor>" />
+
+      {error && <Typography color="error" variant="body2" mt={1}>{error}</Typography>}
+    </FormDrawer>
+  );
+}
+
+function Metric({ label, value, color }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" display="block">{label}</Typography>
+      <Typography variant="body2" fontWeight={700} color={color}>{value}</Typography>
+    </Box>
   );
 }
 

--- a/src/components/controlObra/ManoObraTab.js
+++ b/src/components/controlObra/ManoObraTab.js
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
-  Alert, Box, Button, Card, CardContent, Chip, LinearProgress, MenuItem, Paper,
+  Alert, Box, Button, Card, CardContent, Chip, LinearProgress, Paper,
   Stack, Table, TableBody, TableCell, TableHead, TableRow, TextField, Typography,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
@@ -12,20 +13,6 @@ const fmt = (n) => (Number(n) || 0).toLocaleString('es-AR', { style: 'currency',
 const money = (n, moneda) => (Number(n) || 0).toLocaleString('es-AR', { style: 'currency', currency: moneda === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
 const COLOR = { borrador: 'default', aprobada: 'info', pagada: 'success', anulada: 'error' };
 const MODALIDAD_LBL = { avance_fisico: 'avance físico', certificado: 'certificado' };
-
-// Proveedores con contrato asignado a alguna tarea de la obra (candidatos a plan de pago).
-function proveedoresConContrato(obra) {
-  const map = new Map();
-  for (const r of obra.rubros || []) {
-    for (const s of r.subrubros || []) {
-      const c = s.contrato_proveedor;
-      if (!c || !c.proveedor_nombre) continue;
-      const key = c.proveedor_id || c.proveedor_nombre;
-      if (!map.has(key)) map.set(key, { proveedor_id: c.proveedor_id || null, proveedor_nombre: c.proveedor_nombre });
-    }
-  }
-  return Array.from(map.values());
-}
 
 export default function ManoObraTab({ obra, empresaId }) {
   const qc = useQueryClient();
@@ -132,7 +119,7 @@ export default function ManoObraTab({ obra, empresaId }) {
 // generar cuotas por avance devengado del proveedor.
 function PlanesPagoSection({ obra, empresaId }) {
   const qc = useQueryClient();
-  const [dialog, setDialog] = useState(false);
+  const router = useRouter();
 
   const planesQ = useQuery({
     queryKey: ['control-obra', 'planes-pago', obra._id, empresaId],
@@ -140,6 +127,12 @@ function PlanesPagoSection({ obra, empresaId }) {
     enabled: !!empresaId,
   });
   const refresh = () => qc.invalidateQueries({ queryKey: ['control-obra', 'planes-pago', obra._id, empresaId] });
+
+  // Abre el asistente de plan de pago con la obra precargada (espejo de "Nuevo plan" de cobros).
+  const nuevoPlan = () => router.push({
+    pathname: '/pagos-proveedores/nuevo',
+    query: { obra: obra._id, ...(obra.proyecto_id ? { proyecto: obra.proyecto_id } : {}) },
+  });
 
   const generarAvance = useMutation({
     mutationFn: (planId) => ControlObraService.generarCuotasPorAvance(planId, empresaId),
@@ -158,7 +151,7 @@ function PlanesPagoSection({ obra, empresaId }) {
               0..N planes por obra. Cada plan agrupa las cuotas a desembolsar a un proveedor (por avance devengado, fijas o por hito).
             </Typography>
           </Box>
-          <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={() => setDialog(true)}>Nuevo plan de pago</Button>
+          <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={nuevoPlan}>Nuevo plan de pago</Button>
         </Stack>
 
         {planesQ.isLoading && <LinearProgress sx={{ mb: 2 }} />}
@@ -178,7 +171,12 @@ function PlanesPagoSection({ obra, empresaId }) {
             const r = plan.resumen || {};
             const pct = r.total ? Math.round((r.pagado || 0) / r.total * 100) : 0;
             return (
-              <Paper key={plan._id} variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+              <Paper
+                key={plan._id}
+                variant="outlined"
+                sx={{ p: 2, borderRadius: 2, cursor: 'pointer', '&:hover': { borderColor: 'primary.main' } }}
+                onClick={() => router.push(`/pagos-proveedores/${plan._id}`)}
+              >
                 <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" spacing={1.5} alignItems={{ sm: 'center' }}>
                   <Box sx={{ minWidth: 0 }}>
                     <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
@@ -190,14 +188,19 @@ function PlanesPagoSection({ obra, empresaId }) {
                       {r.cuotas_total || 0} cuota(s) · Proveedor: {plan.proveedor_nombre || 's/d'}
                     </Typography>
                   </Box>
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    disabled={generarAvance.isPending}
-                    onClick={() => generarAvance.mutate(plan._id)}
-                  >
-                    Generar por avance
-                  </Button>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      disabled={generarAvance.isPending}
+                      onClick={(e) => { e.stopPropagation(); generarAvance.mutate(plan._id); }}
+                    >
+                      Generar por avance
+                    </Button>
+                    <Button size="small" onClick={(e) => { e.stopPropagation(); router.push(`/pagos-proveedores/${plan._id}`); }}>
+                      Ver detalle
+                    </Button>
+                  </Stack>
                 </Stack>
 
                 <Stack direction="row" spacing={3} mt={1.5} flexWrap="wrap">
@@ -242,74 +245,7 @@ function PlanesPagoSection({ obra, empresaId }) {
           })}
         </Stack>
       </CardContent>
-
-      <NuevoPlanPagoDialog
-        open={dialog}
-        onClose={() => setDialog(false)}
-        obra={obra}
-        empresaId={empresaId}
-        onDone={() => { setDialog(false); refresh(); }}
-      />
     </Card>
-  );
-}
-
-function NuevoPlanPagoDialog({ open, onClose, obra, empresaId, onDone }) {
-  const proveedores = useMemo(() => proveedoresConContrato(obra), [obra]);
-  const [sel, setSel] = useState('');
-  const [proveedorLibre, setProveedorLibre] = useState('');
-  const [nombre, setNombre] = useState('');
-  const [error, setError] = useState(null);
-
-  const seleccionado = proveedores.find((p) => (p.proveedor_id || p.proveedor_nombre) === sel);
-
-  const crear = useMutation({
-    mutationFn: () => {
-      const proveedor_nombre = seleccionado ? seleccionado.proveedor_nombre : proveedorLibre.trim();
-      if (!proveedor_nombre) throw new Error('Elegí o escribí un proveedor');
-      return ControlObraService.crearPlanPago(obra._id, {
-        empresa_id: empresaId,
-        proveedor_id: seleccionado ? seleccionado.proveedor_id : null,
-        proveedor_nombre,
-        nombre: nombre.trim() || null,
-      });
-    },
-    onSuccess: () => { setSel(''); setProveedorLibre(''); setNombre(''); onDone(); },
-    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
-  });
-
-  return (
-    <FormDrawer
-      open={open} onClose={onClose} title="Nuevo plan de pago" width={480}
-      actions={(
-        <>
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button variant="contained" disabled={crear.isPending} onClick={() => { setError(null); crear.mutate(); }}>Crear</Button>
-        </>
-      )}
-    >
-      <Typography variant="caption" color="text.secondary">Proveedor</Typography>
-      {proveedores.length > 0 ? (
-        <TextField select fullWidth size="small" label="Proveedor (con contrato)" value={sel} onChange={(e) => setSel(e.target.value)} sx={{ mt: 1, mb: 2 }}>
-          <MenuItem value="">Otro (escribir)</MenuItem>
-          {proveedores.map((p) => (
-            <MenuItem key={p.proveedor_id || p.proveedor_nombre} value={p.proveedor_id || p.proveedor_nombre}>{p.proveedor_nombre}</MenuItem>
-          ))}
-        </TextField>
-      ) : (
-        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 1 }}>
-          No hay proveedores con contrato asignado en la obra. Escribí el nombre a mano.
-        </Typography>
-      )}
-
-      {!seleccionado && (
-        <TextField label="Nombre del proveedor" fullWidth size="small" value={proveedorLibre} onChange={(e) => setProveedorLibre(e.target.value)} sx={{ mb: 2 }} />
-      )}
-
-      <TextField label="Nombre del plan (opcional)" fullWidth size="small" value={nombre} onChange={(e) => setNombre(e.target.value)} placeholder="Pagos: <proveedor>" />
-
-      {error && <Typography color="error" variant="body2" mt={1}>{error}</Typography>}
-    </FormDrawer>
   );
 }
 

--- a/src/components/controlObra/ResumenTab.js
+++ b/src/components/controlObra/ResumenTab.js
@@ -82,7 +82,9 @@ export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
 
   // Lado gastar (T2 en getEjecucion).
   const gastado = ejec?.totales?.gastado || 0;
-  const costoRef = ejec?.totales?.costo_ref || 0; // contratado o estimado, por precedencia
+  const costoRef = ejec?.totales?.costo_ref || 0; // proveedor + directo
+  const costoProveedor = ejec?.totales?.costo_proveedor || 0; // parte del proveedor (contratado o estimado)
+  const costoDirecto = ejec?.totales?.costo_directo || 0; // parte directa (materiales/gastos sueltos)
   const margen = ejec?.totales?.margen || 0; // realizado (certificado − gastado)
   const margenEsperado = ejec?.totales?.margen_esperado || 0; // proyectado (contrato − costo_ref)
 
@@ -171,7 +173,13 @@ export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
             <PaymentsIcon fontSize="small" color="action" />
             <Typography variant="subtitle2" fontWeight={700}>Gastar (proveedor)</Typography>
           </Stack>
-          <LadoRow label="Costo de referencia" value={costoRef ? fmt(costoRef) : '—'} sub="contratado o estimado" />
+          <LadoRow label="Costo de referencia" value={costoRef ? fmt(costoRef) : '—'} sub={costoDirecto > 0 ? 'proveedor + directo' : 'contratado o estimado'} />
+          {costoDirecto > 0 && (
+            <>
+              <LadoRow label="· Proveedor" value={fmt(costoProveedor)} sub="contratado o estimado" />
+              <LadoRow label="· Directo (materiales)" value={fmt(costoDirecto)} sub="se imputa suelto" />
+            </>
+          )}
           <LadoRow label="Gastado real" value={fmt(gastado)} />
           <Divider sx={{ my: 0.5 }} />
           <LadoRow label="Margen esperado" value={`${margenEsperado >= 0 ? '+' : ''}${fmt(margenEsperado)}`} color={margenEsperado >= 0 ? 'success.main' : 'error.main'} strong sub="contrato − costo de referencia" />

--- a/src/components/controlObra/ResumenTab.js
+++ b/src/components/controlObra/ResumenTab.js
@@ -49,6 +49,11 @@ export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
     queryKey: ['control-obra', 'cartera', empresaId],
     queryFn: () => ControlObraService.resumenCartera(empresaId),
     enabled: !!empresaId,
+    // La composición del cobro depende de los planes (monto_total), que se editan
+    // en otras pantallas (/cobros). Refrescamos siempre al entrar para no mostrar
+    // un esperado_planes viejo cuando una cuota cambió afuera.
+    refetchOnMount: 'always',
+    staleTime: 0,
   });
   const incQ = useQuery({
     queryKey: ['control-obra', 'inconvenientes', obra._id, empresaId],
@@ -59,6 +64,8 @@ export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
     queryKey: ['control-obra', 'curva-s', obra._id, empresaId],
     queryFn: () => ControlObraService.curvaS(obra._id, empresaId),
     enabled: !!empresaId,
+    refetchOnMount: 'always',
+    staleTime: 0,
   });
   const curva = curvaQ.data || { meses: [], certificado: [], cobrado: [], plan: [] };
 

--- a/src/components/controlObra/ResumenTab.js
+++ b/src/components/controlObra/ResumenTab.js
@@ -1,6 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
-import { Box, Divider, Paper, Stack, Typography } from '@mui/material';
-import { BarChart } from '@mui/x-charts/BarChart';
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Box, Chip, Divider, IconButton, InputAdornment, Paper, Stack, TextField, Tooltip, Typography,
+} from '@mui/material';
 import { LineChart } from '@mui/x-charts/LineChart';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
@@ -8,11 +10,41 @@ import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import ReportProblemIcon from '@mui/icons-material/ReportProblem';
 import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import PriceCheckIcon from '@mui/icons-material/PriceCheck';
+import PaymentsIcon from '@mui/icons-material/Payments';
+import SaveIcon from '@mui/icons-material/Save';
 import ControlObraService from 'src/services/controlObra/controlObraService';
 import { KpiCard, fmt, fmtM } from 'src/components/controlObra/ui';
 
-// Tablero de la obra (cockpit): snapshot financiero + qué necesita atención + circuito de plata.
+// Fila de una columna del tablero (label izquierda, monto derecha).
+function LadoRow({ label, value, color = 'text.primary', strong = false, sub = null }) {
+  return (
+    <Stack direction="row" justifyContent="space-between" alignItems="baseline" py={0.5}>
+      <Box>
+        <Typography variant="body2" fontWeight={strong ? 700 : 500}>{label}</Typography>
+        {sub && <Typography variant="caption" color="text.secondary">{sub}</Typography>}
+      </Box>
+      <Typography variant="body2" fontWeight={strong ? 800 : 600} color={color}>{value}</Typography>
+    </Stack>
+  );
+}
+
+// Chip de cobertura de la composición del cobro (señal blanda).
+function CoberturaChip({ cobertura }) {
+  if (!cobertura) return <Chip size="small" variant="outlined" label="Sin declarar" />;
+  const map = {
+    falta_asignar: { label: 'Falta asignar', color: 'warning' },
+    cubierto: { label: 'Cubierto', color: 'success' },
+    sobre_asignado: { label: 'Sobre-asignado', color: 'error' },
+  };
+  const c = map[cobertura] || { label: cobertura, color: 'default' };
+  return <Chip size="small" color={c.color} label={c.label} />;
+}
+
+// Tablero de la obra (cockpit): dos lados espejados (cobrar / gastar) + composición
+// del cobro + qué necesita atención + curva financiera.
 export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
+  const queryClient = useQueryClient();
   const carteraQ = useQuery({
     queryKey: ['control-obra', 'cartera', empresaId],
     queryFn: () => ControlObraService.resumenCartera(empresaId),
@@ -35,21 +67,67 @@ export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
   const avance = row.avance_pct ?? (total ? ((ejec?.totales?.valor_avance || 0) / total) * 100 : 0);
   const certAprob = (certs || []).filter((c) => c.estado === 'aprobado').reduce((s, c) => s + (c.monto_total || 0), 0);
   const cobrado = row.cobrado || 0;
-  const pendiente = row.pendiente || 0;
-  const gastado = ejec?.totales?.gastado || 0;
-  const margen = ejec?.totales?.margen || 0;
 
-  // Alertas (síntesis cross-pestaña — el diferenciador del tablero)
+  // Pendiente de cobro — aditivo, desglosado por fuente (el label ya no miente).
+  const pendiente = row.pendiente || 0;
+  const pendienteCert = row.pendiente_certificados || 0;
+  const pendientePlanes = row.pendiente_planes || 0;
+
+  // Lado gastar (T2 en getEjecucion).
+  const gastado = ejec?.totales?.gastado || 0;
+  const costoRef = ejec?.totales?.costo_ref || 0; // contratado o estimado, por precedencia
+  const margen = ejec?.totales?.margen || 0; // realizado (certificado − gastado)
+  const margenEsperado = ejec?.totales?.margen_esperado || 0; // proyectado (contrato − costo_ref)
+
+  // Composición del cobro: cuánto se espera por certificación + Σ planes.
+  const esperadoCert = row.esperado_certificados; // null si sin declarar
+  const esperadoPlanes = row.esperado_planes || 0;
+  const cobertura = row.cobertura || null;
+
+  // Editor de cobro_esperado_certificados (composición del cobro).
+  const [certInput, setCertInput] = useState('');
+  useEffect(() => {
+    setCertInput(obra.cobro_esperado_certificados != null ? String(obra.cobro_esperado_certificados) : '');
+  }, [obra._id, obra.cobro_esperado_certificados]);
+
+  const guardarComposicion = useMutation({
+    mutationFn: () => {
+      const raw = certInput.trim();
+      const val = raw === '' ? null : Number(raw);
+      return ControlObraService.actualizarObra(obra._id, empresaId, { cobro_esperado_certificados: val });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['control-obra', 'obra', obra._id, empresaId] });
+      queryClient.invalidateQueries({ queryKey: ['control-obra', 'obra', obra._id] });
+      queryClient.invalidateQueries({ queryKey: ['control-obra', 'cartera', empresaId] });
+    },
+  });
+  const inputVal = certInput.trim() === '' ? null : Number(certInput.trim());
+  const inputInvalido = inputVal != null && (!Number.isFinite(inputVal) || inputVal < 0);
+  const dirty = String(obra.cobro_esperado_certificados ?? '') !== certInput.trim();
+
+  // Alertas (síntesis cross-pestaña — el diferenciador del tablero).
+  const subs = (ejec?.rubros || []).flatMap((r) => r.subrubros || []);
   const certsPend = (certs || []).filter((c) => c.estado === 'enviado');
   const montoCertPend = certsPend.reduce((s, c) => s + (c.monto_total || 0), 0);
   const incAbiertos = (incQ.data || []).filter((i) => i.estado === 'abierto').length;
-  const subsNeg = (ejec?.rubros || []).flatMap((r) => r.subrubros || []).filter((s) => (s.gastado || 0) > 0 && s.margen < 0);
+  // Margen realizado negativo: gastás más de lo certificado en ese sub-rubro.
+  const subsNeg = subs.filter((s) => (s.gastado || 0) > 0 && s.margen < 0);
+  // Margen ESPERADO negativo (T2): el contrato no cubre el costo de referencia.
+  const subsMargEspNeg = subs.filter((s) => s.margen_esperado != null && s.margen_esperado < 0);
+  // Sobrecosto: gastado > costo de referencia (T2).
+  const subsSobrecosto = subs.filter((s) => s.sobrecosto);
+  // Avance físico alto con poco gastado → posibles gastos sin imputar.
+  const avanceAltoSinGasto = avance >= 40 && total > 0 && gastado < total * 0.1;
 
   const alertas = [];
-  if (certsPend.length) alertas.push({ icon: <AccessTimeIcon color="warning" />, label: `${certsPend.length} certificado${certsPend.length > 1 ? 's' : ''} esperando aprobación`, sub: 'destraba la cobranza', value: fmt(montoCertPend), color: 'warning.main' });
-  if (pendiente > 0) alertas.push({ icon: <HourglassEmptyIcon color="warning" />, label: 'Pendiente de cobro', sub: 'certificado aprobado, sin cobrar', value: fmt(pendiente), color: 'warning.main' });
-  if (incAbiertos > 0) alertas.push({ icon: <ReportProblemIcon color="error" />, label: `${incAbiertos} inconveniente${incAbiertos > 1 ? 's' : ''} abierto${incAbiertos > 1 ? 's' : ''}`, sub: 'resolver antes del cierre', value: null, color: 'error.main' });
+  if (certsPend.length) alertas.push({ icon: <AccessTimeIcon color="warning" />, label: `${certsPend.length} certificado${certsPend.length > 1 ? 's' : ''} enviado${certsPend.length > 1 ? 's' : ''} sin aprobar`, sub: 'destraba la cobranza', value: fmt(montoCertPend), color: 'warning.main' });
+  if (pendiente > 0) alertas.push({ icon: <HourglassEmptyIcon color="warning" />, label: 'Pendiente de cobro', sub: `por certificados ${fmt(pendienteCert)} + por planes ${fmt(pendientePlanes)}`, value: fmt(pendiente), color: 'warning.main' });
+  if (avanceAltoSinGasto) alertas.push({ icon: <ReportProblemIcon color="warning" />, label: `Avance ${avance.toFixed(0)}% con poco gastado`, sub: 'posibles gastos sin imputar', value: fmt(gastado), color: 'warning.main' });
+  if (subsSobrecosto.length) alertas.push({ icon: <TrendingDownIcon color="error" />, label: `${subsSobrecosto.length} sub-rubro${subsSobrecosto.length > 1 ? 's' : ''} con sobrecosto`, sub: 'gastado supera el costo de referencia', value: null, color: 'error.main' });
+  if (subsMargEspNeg.length) alertas.push({ icon: <TrendingDownIcon color="error" />, label: `${subsMargEspNeg.length} sub-rubro${subsMargEspNeg.length > 1 ? 's' : ''} con margen esperado negativo`, sub: 'el contrato no cubre el costo', value: null, color: 'error.main' });
   if (subsNeg.length) alertas.push({ icon: <TrendingDownIcon color="error" />, label: `${subsNeg.length} sub-rubro${subsNeg.length > 1 ? 's' : ''} con margen negativo`, sub: 'gastás más de lo certificado', value: null, color: 'error.main' });
+  if (incAbiertos > 0) alertas.push({ icon: <ReportProblemIcon color="error" />, label: `${incAbiertos} inconveniente${incAbiertos > 1 ? 's' : ''} abierto${incAbiertos > 1 ? 's' : ''}`, sub: 'resolver antes del cierre', value: null, color: 'error.main' });
 
   return (
     <Box>
@@ -59,45 +137,115 @@ export default function ResumenTab({ obra, ejec, certs = [], empresaId }) {
         <KpiCard label="Certificado" value={fmtM(certAprob)} sub={`${total ? ((certAprob / total) * 100).toFixed(0) : 0}% · aprobado`} color="warning.main" />
         <KpiCard label="Cobrado" value={fmtM(cobrado)} sub={`${total ? ((cobrado / total) * 100).toFixed(0) : 0}% del contrato`} color="success.main" />
         <KpiCard label="Gastado real" value={fmtM(gastado)} sub="caja + mano de obra" />
-        <KpiCard label="Margen" value={`${margen >= 0 ? '+' : ''}${fmtM(margen)}`} sub="certificado − gastado" color={margen >= 0 ? 'success.main' : 'error.main'} />
+        <KpiCard label="Margen" value={`${margen >= 0 ? '+' : ''}${fmtM(margen)}`} sub={`realizado · esperado ${margenEsperado >= 0 ? '+' : ''}${fmtM(margenEsperado)}`} color={margen >= 0 ? 'success.main' : 'error.main'} tooltip="Realizado = certificado − gastado · Esperado = contrato − costo de referencia" />
       </Stack>
 
-      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} useFlexGap>
-        <Paper variant="outlined" sx={{ p: 2, flex: 1.2, minWidth: 300 }}>
+      {/* Tablero de DOS LADOS espejados: cobrar (cliente) vs gastar (proveedor). */}
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} useFlexGap mb={2}>
+        <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 280 }}>
           <Stack direction="row" alignItems="center" spacing={1} mb={1}>
-            <DashboardIcon fontSize="small" color="action" />
-            <Typography variant="subtitle2" fontWeight={600}>Qué necesita atención</Typography>
+            <PriceCheckIcon fontSize="small" color="success" />
+            <Typography variant="subtitle2" fontWeight={700}>Cobrar (cliente)</Typography>
           </Stack>
-          {alertas.length === 0 ? (
-            <Stack direction="row" alignItems="center" spacing={1} py={2}>
-              <CheckCircleIcon color="success" /><Typography variant="body2" color="text.secondary">Todo en orden — sin pendientes.</Typography>
-            </Stack>
-          ) : (
-            <Stack divider={<Divider flexItem />}>
-              {alertas.map((a, i) => (
-                <Stack key={i} direction="row" alignItems="center" spacing={1.5} py={1}>
-                  {a.icon}
-                  <Box flex={1}>
-                    <Typography variant="body2" fontWeight={500}>{a.label}</Typography>
-                    <Typography variant="caption" color="text.secondary">{a.sub}</Typography>
-                  </Box>
-                  {a.value && <Typography variant="body2" fontWeight={700} color={a.color}>{a.value}</Typography>}
-                </Stack>
-              ))}
-            </Stack>
+          <LadoRow label="Contrato cliente" value={fmt(total)} sub="lo que se espera cobrar" />
+          <LadoRow label="Certificado" value={fmt(certAprob)} color="warning.main" />
+          <LadoRow label="Cobrado" value={fmt(cobrado)} color="success.main" />
+          <Divider sx={{ my: 0.5 }} />
+          <LadoRow label="Pendiente de cobro" value={fmt(pendiente)} color="warning.main" strong />
+          {pendiente > 0 && (
+            <Typography variant="caption" color="text.secondary" display="block" pl={0.5}>
+              por certificados {fmt(pendienteCert)} + por planes {fmt(pendientePlanes)} = {fmt(pendiente)}
+            </Typography>
           )}
         </Paper>
 
-        <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 260 }}>
-          <Typography variant="subtitle2" fontWeight={600} mb={1}>Circuito de plata ($M)</Typography>
-          <BarChart
-            series={[{ data: [certAprob / 1e6, cobrado / 1e6, gastado / 1e6].map((v) => Math.round(v * 10) / 10), label: '$M', color: '#90caf9' }]}
-            xAxis={[{ data: ['Certificado', 'Cobrado', 'Gastado'], scaleType: 'band' }]}
-            height={200}
-            margin={{ top: 10, bottom: 30, left: 48, right: 10 }}
-          />
+        <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 280 }}>
+          <Stack direction="row" alignItems="center" spacing={1} mb={1}>
+            <PaymentsIcon fontSize="small" color="action" />
+            <Typography variant="subtitle2" fontWeight={700}>Gastar (proveedor)</Typography>
+          </Stack>
+          <LadoRow label="Costo de referencia" value={costoRef ? fmt(costoRef) : '—'} sub="contratado o estimado" />
+          <LadoRow label="Gastado real" value={fmt(gastado)} />
+          <Divider sx={{ my: 0.5 }} />
+          <LadoRow label="Margen esperado" value={`${margenEsperado >= 0 ? '+' : ''}${fmt(margenEsperado)}`} color={margenEsperado >= 0 ? 'success.main' : 'error.main'} strong sub="contrato − costo de referencia" />
+          <LadoRow label="Margen realizado" value={`${margen >= 0 ? '+' : ''}${fmt(margen)}`} color={margen >= 0 ? 'success.main' : 'error.main'} sub="certificado − gastado" />
         </Paper>
       </Stack>
+
+      {/* Composición del cobro: cómo se reparte el total entre certificación y planes. */}
+      <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+        <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1} mb={1}>
+          <Typography variant="subtitle2" fontWeight={700}>Composición del cobro</Typography>
+          <CoberturaChip cobertura={cobertura} />
+        </Stack>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ sm: 'center' }} useFlexGap flexWrap="wrap">
+          <TextField
+            size="small"
+            label="Se cobra por certificación"
+            value={certInput}
+            onChange={(e) => setCertInput(e.target.value)}
+            error={inputInvalido}
+            helperText={inputInvalido ? 'Número ≥ 0 o vacío' : 'ej. inversores'}
+            type="number"
+            InputProps={{
+              startAdornment: <InputAdornment position="start">$</InputAdornment>,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip title="Guardar">
+                    <span>
+                      <IconButton size="small" color="primary" disabled={!dirty || inputInvalido || guardarComposicion.isLoading} onClick={() => guardarComposicion.mutate()}>
+                        <SaveIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            }}
+            sx={{ maxWidth: 260 }}
+          />
+          <Typography variant="body2" color="text.secondary">+</Typography>
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block">Por planes (Σ planes)</Typography>
+            <Typography variant="body1" fontWeight={700}>{fmt(esperadoPlanes)}</Typography>
+          </Box>
+          <Typography variant="body2" color="text.secondary">=</Typography>
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block">Total esperado</Typography>
+            <Typography variant="body1" fontWeight={700}>{fmt((esperadoCert != null ? esperadoCert : 0) + esperadoPlanes)}</Typography>
+            <Typography variant="caption" color="text.secondary">vs contrato {fmt(total)}</Typography>
+          </Box>
+        </Stack>
+        {esperadoCert == null && (
+          <Typography variant="caption" color="text.secondary" display="block" mt={1}>
+            Declará cuánto se espera cobrar por certificación para validar la cobertura vs el contrato.
+          </Typography>
+        )}
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Stack direction="row" alignItems="center" spacing={1} mb={1}>
+          <DashboardIcon fontSize="small" color="action" />
+          <Typography variant="subtitle2" fontWeight={600}>Qué necesita atención</Typography>
+        </Stack>
+        {alertas.length === 0 ? (
+          <Stack direction="row" alignItems="center" spacing={1} py={2}>
+            <CheckCircleIcon color="success" /><Typography variant="body2" color="text.secondary">Todo en orden — sin pendientes.</Typography>
+          </Stack>
+        ) : (
+          <Stack divider={<Divider flexItem />}>
+            {alertas.map((a, i) => (
+              <Stack key={i} direction="row" alignItems="center" spacing={1.5} py={1}>
+                {a.icon}
+                <Box flex={1}>
+                  <Typography variant="body2" fontWeight={500}>{a.label}</Typography>
+                  <Typography variant="caption" color="text.secondary">{a.sub}</Typography>
+                </Box>
+                {a.value && <Typography variant="body2" fontWeight={700} color={a.color}>{a.value}</Typography>}
+              </Stack>
+            ))}
+          </Stack>
+        )}
+      </Paper>
 
       {curva.meses.length > 0 && (
         <Paper variant="outlined" sx={{ p: 2, mt: 2 }}>

--- a/src/components/controlObra/SubrubroAccionesMenu.js
+++ b/src/components/controlObra/SubrubroAccionesMenu.js
@@ -1,10 +1,6 @@
 import { useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  Autocomplete, Box, Button, Divider, ListItemIcon, Menu, MenuItem, Stack, TextField, ToggleButton,
-  ToggleButtonGroup, Typography,
-} from '@mui/material';
-import FormDrawer from 'src/components/controlObra/FormDrawer';
+import { useQueryClient } from '@tanstack/react-query';
+import { Divider, ListItemIcon, Menu, MenuItem, Typography } from '@mui/material';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
 import PaidIcon from '@mui/icons-material/Paid';
@@ -12,12 +8,12 @@ import EngineeringIcon from '@mui/icons-material/Engineering';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import ControlObraService from 'src/services/controlObra/controlObraService';
-import proveedorService from 'src/services/proveedorService';
-import profileService from 'src/services/profileService';
 import NuevoCertificadoDialog from 'src/components/controlObra/NuevoCertificadoDialog';
 import ImputarGastoDialog from 'src/components/controlObra/ImputarGastoDialog';
 import EditarTareaDrawer from 'src/components/controlObra/EditarTareaDrawer';
+import {
+  RegistrarAvanceDialog, ResponsableDrawer, ContratoProveedorDrawer, EliminarSubrubroDialog,
+} from 'src/components/controlObra/subrubroEditores';
 
 // Menú de acciones sobre una tarea (sub-rubro) de Ejecución.
 export default function SubrubroAccionesMenu({ obra, subrubro, empresaId, anchorEl, onClose }) {
@@ -85,223 +81,6 @@ export default function SubrubroAccionesMenu({ obra, subrubro, empresaId, anchor
         <EliminarSubrubroDialog obra={obra} subrubro={subrubro} empresaId={empresaId} onClose={cerrarTodo} onDone={() => { refresh(); cerrarTodo(); }} />
       )}
     </>
-  );
-}
-
-function EliminarSubrubroDialog({ obra, subrubro, empresaId, onClose, onDone }) {
-  const [error, setError] = useState(null);
-  const borrar = useMutation({
-    mutationFn: () => ControlObraService.eliminarSubrubro(obra._id, subrubro.uid, empresaId),
-    onSuccess: onDone,
-    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
-  });
-  return (
-    <FormDrawer
-      open onClose={onClose} title="Eliminar tarea"
-      actions={(
-        <>
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button color="error" variant="contained" disabled={borrar.isPending} onClick={() => { setError(null); borrar.mutate(); }}>Eliminar</Button>
-        </>
-      )}
-    >
-      <Typography variant="body2">¿Eliminar <b>{subrubro.nombre}</b>? Queda registrado en el historial.</Typography>
-      {(subrubro.cert_pct || 0) > 0 && <Typography variant="caption" color="error" display="block" mt={1}>No se puede: tiene avance certificado.</Typography>}
-      {error && <Typography color="error" variant="body2" mt={1}>{error}</Typography>}
-    </FormDrawer>
-  );
-}
-
-function RegistrarAvanceDialog({ obra, subrubro, empresaId, onClose, onDone }) {
-  const [pct, setPct] = useState(String(subrubro.avance_pct ?? 0));
-  const [error, setError] = useState(null);
-  const guardar = useMutation({
-    mutationFn: () => ControlObraService.registrarAvance(obra._id, subrubro.uid, empresaId, Number(pct)),
-    onSuccess: onDone,
-    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
-  });
-  return (
-    <FormDrawer
-      open onClose={onClose} title={`Registrar avance · ${subrubro.nombre}`}
-      subtitle={`% de avance físico acumulado (lo ejecutado en obra). Mínimo: lo ya certificado (${subrubro.cert_pct || 0}%).`}
-      actions={(
-        <>
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button variant="contained" disabled={guardar.isPending} onClick={() => { setError(null); guardar.mutate(); }}>Guardar</Button>
-        </>
-      )}
-    >
-      <TextField type="number" label="Avance físico %" value={pct} onChange={(e) => setPct(e.target.value)} fullWidth size="small" inputProps={{ min: subrubro.cert_pct || 0, max: 100 }} />
-      {error && <Typography color="error" variant="body2" mt={1}>{error}</Typography>}
-    </FormDrawer>
-  );
-}
-
-const nombreProfile = (p) => [p?.firstName, p?.lastName].filter(Boolean).join(' ').trim() || p?.email || '';
-const fmtArs = (n) => (Number(n) || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 });
-
-// Asigna el responsable interno de la tarea: un miembro del equipo (Profile) o
-// un nombre de texto libre.
-function ResponsableDrawer({ obra, subrubro, empresaId, onClose, onDone }) {
-  const r = subrubro.responsable || null;
-  const [valor, setValor] = useState(r ? { _id: r.user_id, nombre: r.nombre } : null);
-  const [error, setError] = useState(null);
-
-  const equipoQ = useQuery({
-    queryKey: ['profiles', empresaId],
-    queryFn: () => profileService.getProfileByEmpresa(empresaId),
-    enabled: !!empresaId,
-  });
-  const equipo = Array.isArray(equipoQ.data) ? equipoQ.data : [];
-
-  const guardar = useMutation({
-    mutationFn: () => ControlObraService.asignarResponsable(obra._id, subrubro.uid, empresaId, {
-      user_id: valor?._id || valor?.user_id || null,
-      nombre: typeof valor === 'string' ? valor : (valor?.nombre || nombreProfile(valor)),
-    }),
-    onSuccess: onDone,
-    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
-  });
-  const quitar = useMutation({
-    mutationFn: () => ControlObraService.asignarResponsable(obra._id, subrubro.uid, empresaId, null),
-    onSuccess: onDone,
-    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
-  });
-
-  const nombreFinal = typeof valor === 'string' ? valor.trim() : (valor?.nombre || nombreProfile(valor)).trim();
-
-  return (
-    <FormDrawer
-      open onClose={onClose} title="Responsable de la tarea"
-      subtitle={subrubro.nombre}
-      actions={(
-        <>
-          {r && <Button color="error" disabled={quitar.isPending} onClick={() => { setError(null); quitar.mutate(); }} sx={{ mr: 'auto' }}>Quitar</Button>}
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button variant="contained" disabled={guardar.isPending || !nombreFinal} onClick={() => { setError(null); guardar.mutate(); }}>Guardar</Button>
-        </>
-      )}
-    >
-      <Autocomplete
-        freeSolo
-        options={equipo}
-        loading={equipoQ.isLoading}
-        getOptionLabel={(p) => (typeof p === 'string' ? p : (p?.nombre || nombreProfile(p)))}
-        value={valor}
-        onChange={(_, v) => setValor(typeof v === 'string' ? { _id: null, nombre: v } : v)}
-        onInputChange={(_, v, reason) => { if (reason === 'input') setValor({ _id: null, nombre: v }); }}
-        isOptionEqualToValue={(o, v) => (o._id || o.nombre) === (v._id || v.nombre)}
-        renderInput={(params) => <TextField {...params} label="Responsable" size="small" helperText="Elegí un miembro del equipo o escribí un nombre" />}
-      />
-      {error && <Typography color="error" variant="body2" mt={1}>{error}</Typography>}
-    </FormDrawer>
-  );
-}
-
-// Asigna el contrato del contratista que ejecuta esta tarea: costo + modalidad
-// de devengo (avance físico o certificado). Es la base de las órdenes de pago.
-function ContratoProveedorDrawer({ obra, subrubro, empresaId, onClose, onDone }) {
-  const c = subrubro.contrato_proveedor || null;
-  const [proveedor, setProveedor] = useState(c ? { _id: c.proveedor_id, nombre: c.proveedor_nombre } : null);
-  const [monto, setMonto] = useState(c ? String(c.monto ?? '') : '');
-  const [modalidad, setModalidad] = useState(c?.modalidad || 'avance_fisico');
-  const [error, setError] = useState(null);
-
-  const proveedoresQ = useQuery({
-    queryKey: ['proveedores', empresaId],
-    queryFn: () => proveedorService.getByEmpresa(empresaId),
-    enabled: !!empresaId,
-  });
-  const proveedores = Array.isArray(proveedoresQ.data) ? proveedoresQ.data : [];
-
-  const guardar = useMutation({
-    mutationFn: () => ControlObraService.asignarContrato(obra._id, subrubro.uid, empresaId, {
-      proveedor_id: proveedor?._id || null,
-      proveedor_nombre: proveedor?.nombre || proveedor?.razon_social || '',
-      monto: Number(monto) || 0,
-      modalidad,
-    }),
-    onSuccess: onDone,
-    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
-  });
-  const quitar = useMutation({
-    mutationFn: () => ControlObraService.asignarContrato(obra._id, subrubro.uid, empresaId, null),
-    onSuccess: onDone,
-    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
-  });
-
-  const nombreValido = !!(proveedor?.nombre || proveedor?.razon_social);
-
-  return (
-    <FormDrawer
-      open onClose={onClose} title="Proveedor / contrato"
-      subtitle={`${subrubro.nombre} · contrato con el cliente ${(subrubro.contrato || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 })}`}
-      width={460}
-      actions={(
-        <>
-          {c && <Button color="error" disabled={quitar.isPending} onClick={() => { setError(null); quitar.mutate(); }} sx={{ mr: 'auto' }}>Quitar</Button>}
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button variant="contained" disabled={guardar.isPending || !nombreValido} onClick={() => { setError(null); guardar.mutate(); }}>Guardar</Button>
-        </>
-      )}
-    >
-      <Stack spacing={2}>
-        <Autocomplete
-          freeSolo
-          options={proveedores}
-          loading={proveedoresQ.isLoading}
-          getOptionLabel={(p) => (typeof p === 'string' ? p : (p?.nombre || p?.razon_social || ''))}
-          value={proveedor}
-          onChange={(_, v) => setProveedor(typeof v === 'string' ? { _id: null, nombre: v } : v)}
-          onInputChange={(_, v, reason) => { if (reason === 'input') setProveedor({ _id: null, nombre: v }); }}
-          isOptionEqualToValue={(o, v) => (o._id || o.nombre) === (v._id || v.nombre)}
-          renderInput={(params) => <TextField {...params} label="Contratista / proveedor" size="small" helperText="Elegí uno existente o escribí un nombre nuevo" />}
-        />
-        <TextField
-          label="Costo del contrato" type="number" size="small" value={monto}
-          onChange={(e) => setMonto(e.target.value)}
-          helperText="Lo que se le paga al contratista por esta tarea (su costo, no el precio al cliente)"
-        />
-        {(() => {
-          const precio = subrubro.contrato || 0;
-          const costo = Number(monto) || 0;
-          const margen = precio - costo;
-          const margenPct = precio > 0 ? Math.round((margen / precio) * 1000) / 10 : null;
-          return (
-            <Box sx={{ p: 1.5, borderRadius: 1, bgcolor: 'action.hover' }}>
-              <Stack direction="row" justifyContent="space-between">
-                <Typography variant="caption" color="text.secondary">Precio al cliente</Typography>
-                <Typography variant="caption">{fmtArs(precio)}</Typography>
-              </Stack>
-              <Stack direction="row" justifyContent="space-between">
-                <Typography variant="caption" color="text.secondary">Costo planificado (proveedor)</Typography>
-                <Typography variant="caption">{fmtArs(costo)}</Typography>
-              </Stack>
-              <Divider sx={{ my: 0.75 }} />
-              <Stack direction="row" justifyContent="space-between">
-                <Typography variant="caption" fontWeight={600}>Margen de la tarea</Typography>
-                <Typography variant="caption" fontWeight={600} color={margen >= 0 ? 'success.main' : 'error.main'}>
-                  {fmtArs(margen)}{margenPct != null ? ` · ${margenPct}%` : ''}
-                </Typography>
-              </Stack>
-            </Box>
-          );
-        })()}
-        <div>
-          <Typography variant="caption" color="text.secondary">Devengar el pago por…</Typography>
-          <ToggleButtonGroup exclusive size="small" value={modalidad} onChange={(_, v) => v && setModalidad(v)} sx={{ mt: 0.5, display: 'flex' }}>
-            <ToggleButton value="avance_fisico" sx={{ flex: 1 }}>Avance físico</ToggleButton>
-            <ToggleButton value="certificado" sx={{ flex: 1 }}>Certificado</ToggleButton>
-          </ToggleButtonGroup>
-          <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
-            {modalidad === 'avance_fisico'
-              ? 'La orden se sugiere según lo ejecutado en obra (avance físico).'
-              : 'La orden se sugiere según lo certificado al cliente.'}
-          </Typography>
-        </div>
-      </Stack>
-      {error && <Typography color="error" variant="body2" mt={1}>{error}</Typography>}
-    </FormDrawer>
   );
 }
 

--- a/src/components/controlObra/SubrubroDetalleDrawer.js
+++ b/src/components/controlObra/SubrubroDetalleDrawer.js
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  Box, Button, Chip, Divider, LinearProgress, Paper, Stack, Typography,
+} from '@mui/material';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
+import PaidIcon from '@mui/icons-material/Paid';
+import EngineeringIcon from '@mui/icons-material/Engineering';
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import FormDrawer from 'src/components/controlObra/FormDrawer';
+import { fmt } from 'src/components/controlObra/ui';
+import NuevoCertificadoDialog from 'src/components/controlObra/NuevoCertificadoDialog';
+import ImputarGastoDialog from 'src/components/controlObra/ImputarGastoDialog';
+import EditarTareaDrawer from 'src/components/controlObra/EditarTareaDrawer';
+import {
+  RegistrarAvanceDialog, ResponsableDrawer, ContratoProveedorDrawer, EliminarSubrubroDialog,
+} from 'src/components/controlObra/subrubroEditores';
+
+const margenColor = (m) => (m >= 0 ? 'success.main' : 'error.main');
+const fmtFecha = (d) => (d ? new Date(d).toLocaleDateString('es-AR', { day: '2-digit', month: 'short', timeZone: 'UTC' }) : '—');
+const signo = (n) => `${n >= 0 ? '+' : ''}${fmt(n)}`;
+
+// Métrica compacta de la cabecera-resumen.
+function Metric({ label, value, color, sub }) {
+  return (
+    <Box sx={{ flex: 1, minWidth: 120 }}>
+      <Typography variant="caption" color="text.secondary" display="block">{label}</Typography>
+      <Typography variant="subtitle2" fontWeight={700} sx={{ color: color || 'text.primary' }}>{value}</Typography>
+      {sub && <Typography variant="caption" color="text.secondary">{sub}</Typography>}
+    </Box>
+  );
+}
+
+// Sección editable: título + icono, un resumen y un botón que abre el editor.
+function Seccion({ icon, title, resumen, actionLabel, onAction, danger }) {
+  return (
+    <Paper variant="outlined" sx={{ p: 1.5, borderRadius: 2 }}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: 0 }}>
+          {icon}
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="subtitle2" fontWeight={600}>{title}</Typography>
+            {resumen && <Typography variant="caption" color="text.secondary" display="block">{resumen}</Typography>}
+          </Box>
+        </Stack>
+        <Button size="small" color={danger ? 'error' : 'primary'} onClick={onAction} sx={{ flexShrink: 0 }}>{actionLabel}</Button>
+      </Stack>
+    </Paper>
+  );
+}
+
+// Drawer de detalle de una tarea (sub-rubro): muestra todo de un vistazo y permite
+// editar cada aspecto reusando los editores del módulo. `subrubro` = fila de Ejecución.
+export default function SubrubroDetalleDrawer({ obra, subrubro: s, empresaId, onClose }) {
+  const qc = useQueryClient();
+  const [editor, setEditor] = useState(null);
+  const cerrarEditor = () => setEditor(null);
+  const onDone = () => { qc.invalidateQueries({ queryKey: ['control-obra'] }); setEditor(null); };
+
+  const cp = s.contrato_proveedor;
+  const resp = s.responsable;
+  const costoResumen = s.costo_directo != null
+    ? `prov ${fmt(s.costo_proveedor || 0)} + dir ${fmt(s.costo_directo)}`
+    : (s.costo_ref != null ? 'proveedor / estimado' : 'sin costo cargado');
+
+  return (
+    <>
+      <FormDrawer
+        open onClose={onClose} width={520}
+        title={s.nombre}
+        subtitle={`físico ${s.avance_pct || 0}% · certificado ${s.cert_pct || 0}%`}
+        actions={<Button onClick={onClose}>Cerrar</Button>}
+      >
+        <Stack spacing={2}>
+          {/* Chips de estado */}
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            {s.atrasada && <Chip size="small" color="error" variant="outlined" label="atrasada" />}
+            {s.sobrecosto && <Chip size="small" color="error" variant="outlined" label="sobrecosto" />}
+            {(s.fecha_inicio || s.fecha_fin) && <Chip size="small" variant="outlined" label={`📅 ${fmtFecha(s.fecha_inicio)} → ${fmtFecha(s.fecha_fin)}`} />}
+          </Stack>
+
+          {/* Cabecera-resumen: números clave */}
+          <Paper variant="outlined" sx={{ p: 1.5, borderRadius: 2 }}>
+            <Stack direction="row" flexWrap="wrap" useFlexGap rowGap={1.5}>
+              <Metric label="Contrato cliente" value={fmt(s.contrato)} />
+              <Metric label="Costo de referencia" value={s.costo_ref != null ? fmt(s.costo_ref) : '—'} sub={costoResumen} color={s.sobrecosto ? 'error.main' : undefined} />
+              <Metric label="Gastado real" value={fmt(s.gastado)} color={s.sobrecosto ? 'error.main' : undefined} />
+              <Metric label="Certificado" value={fmt(s.certificado)} />
+              <Metric label="Margen esperado" value={s.margen_esperado != null ? signo(s.margen_esperado) : '—'} color={s.margen_esperado != null ? margenColor(s.margen_esperado) : undefined} />
+              <Metric label="Margen realizado" value={signo(s.margen)} color={margenColor(s.margen)} sub="certificado − gastado" />
+            </Stack>
+            <Box sx={{ mt: 1.5 }}>
+              <Stack direction="row" justifyContent="space-between">
+                <Typography variant="caption" color="text.secondary">Avance físico</Typography>
+                <Typography variant="caption">{s.avance_pct || 0}%{(s.cert_pct || 0) < (s.avance_pct || 0) ? ` · cert ${s.cert_pct || 0}%` : ''}</Typography>
+              </Stack>
+              <LinearProgress variant="determinate" value={Math.min(s.avance_pct || 0, 100)} sx={{ height: 6, borderRadius: 3, mt: 0.5 }} />
+            </Box>
+          </Paper>
+
+          <Divider textAlign="left"><Typography variant="caption" color="text.secondary">Acciones</Typography></Divider>
+
+          <Seccion
+            icon={<TimelineIcon fontSize="small" color="action" />}
+            title="Avance físico"
+            resumen={`${s.avance_pct || 0}% ejecutado`}
+            actionLabel="Registrar"
+            onAction={() => setEditor('avance')}
+          />
+          <Seccion
+            icon={<AssignmentTurnedInIcon fontSize="small" color="action" />}
+            title="Certificación"
+            resumen={`${s.cert_pct || 0}% certificado · ${fmt(s.certificado)}`}
+            actionLabel="Certificar"
+            onAction={() => setEditor('certificar')}
+          />
+          <Seccion
+            icon={<PaidIcon fontSize="small" color="action" />}
+            title="Gastos imputados"
+            resumen={`${fmt(s.gastado)} gastado`}
+            actionLabel="Imputar"
+            onAction={() => setEditor('imputar')}
+          />
+          <Seccion
+            icon={<EngineeringIcon fontSize="small" color="action" />}
+            title="Proveedor / contrato"
+            resumen={cp ? `${cp.proveedor_nombre} · ${fmt(cp.monto)} · ${cp.modalidad === 'certificado' ? 'por certificado' : 'por avance'}` : 'Sin contrato asignado'}
+            actionLabel={cp ? 'Editar' : 'Asignar'}
+            onAction={() => setEditor('contrato')}
+          />
+          <Seccion
+            icon={<PersonOutlineIcon fontSize="small" color="action" />}
+            title="Responsable"
+            resumen={resp ? resp.nombre : 'Sin asignar'}
+            actionLabel={resp ? 'Editar' : 'Asignar'}
+            onAction={() => setEditor('responsable')}
+          />
+          <Seccion
+            icon={<EditIcon fontSize="small" color="action" />}
+            title="Datos y costos"
+            resumen={`estimado ${s.costo_estimado != null ? fmt(s.costo_estimado) : '—'} · directo ${s.costo_directo != null ? fmt(s.costo_directo) : '—'}`}
+            actionLabel="Editar"
+            onAction={() => setEditor('editar')}
+          />
+          <Seccion
+            icon={<DeleteOutlineIcon fontSize="small" color="error" />}
+            title="Eliminar tarea"
+            resumen={(s.cert_pct || 0) > 0 ? 'Tiene avance certificado' : 'Queda en el historial'}
+            actionLabel="Eliminar"
+            onAction={() => setEditor('eliminar')}
+            danger
+          />
+        </Stack>
+      </FormDrawer>
+
+      {editor === 'avance' && (
+        <RegistrarAvanceDialog obra={obra} subrubro={s} empresaId={empresaId} onClose={cerrarEditor} onDone={onDone} />
+      )}
+      {editor === 'certificar' && (
+        <NuevoCertificadoDialog open obra={obra} empresaId={empresaId} subrubroUid={s.uid} onClose={cerrarEditor} onCreated={onDone} />
+      )}
+      {editor === 'imputar' && (
+        <ImputarGastoDialog open obra={obra} empresaId={empresaId} subrubroUid={s.uid} onClose={cerrarEditor} onDone={onDone} />
+      )}
+      {editor === 'contrato' && (
+        <ContratoProveedorDrawer obra={obra} subrubro={s} empresaId={empresaId} onClose={cerrarEditor} onDone={onDone} />
+      )}
+      {editor === 'responsable' && (
+        <ResponsableDrawer obra={obra} subrubro={s} empresaId={empresaId} onClose={cerrarEditor} onDone={onDone} />
+      )}
+      {editor === 'editar' && (
+        <EditarTareaDrawer obra={obra} subrubro={s} empresaId={empresaId} onClose={cerrarEditor} onDone={onDone} />
+      )}
+      {editor === 'eliminar' && (
+        <EliminarSubrubroDialog obra={obra} subrubro={s} empresaId={empresaId} onClose={cerrarEditor} onDone={() => { onDone(); onClose(); }} />
+      )}
+    </>
+  );
+}

--- a/src/components/controlObra/subrubroEditores.js
+++ b/src/components/controlObra/subrubroEditores.js
@@ -1,0 +1,229 @@
+import { useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import {
+  Autocomplete, Box, Button, Divider, Stack, TextField, ToggleButton, ToggleButtonGroup, Typography,
+} from '@mui/material';
+import FormDrawer from 'src/components/controlObra/FormDrawer';
+import ControlObraService from 'src/services/controlObra/controlObraService';
+import proveedorService from 'src/services/proveedorService';
+import profileService from 'src/services/profileService';
+
+// Editores de una tarea (sub-rubro) reutilizables por el menú de acciones y por el
+// drawer de detalle. Cada uno es un FormDrawer autocontenido.
+
+export function EliminarSubrubroDialog({ obra, subrubro, empresaId, onClose, onDone }) {
+  const [error, setError] = useState(null);
+  const borrar = useMutation({
+    mutationFn: () => ControlObraService.eliminarSubrubro(obra._id, subrubro.uid, empresaId),
+    onSuccess: onDone,
+    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
+  });
+  return (
+    <FormDrawer
+      open onClose={onClose} title="Eliminar tarea"
+      actions={(
+        <>
+          <Button onClick={onClose}>Cancelar</Button>
+          <Button color="error" variant="contained" disabled={borrar.isPending} onClick={() => { setError(null); borrar.mutate(); }}>Eliminar</Button>
+        </>
+      )}
+    >
+      <Typography variant="body2">¿Eliminar <b>{subrubro.nombre}</b>? Queda registrado en el historial.</Typography>
+      {(subrubro.cert_pct || 0) > 0 && <Typography variant="caption" color="error" display="block" mt={1}>No se puede: tiene avance certificado.</Typography>}
+      {error && <Typography color="error" variant="body2" mt={1}>{error}</Typography>}
+    </FormDrawer>
+  );
+}
+
+export function RegistrarAvanceDialog({ obra, subrubro, empresaId, onClose, onDone }) {
+  const [pct, setPct] = useState(String(subrubro.avance_pct ?? 0));
+  const [error, setError] = useState(null);
+  const guardar = useMutation({
+    mutationFn: () => ControlObraService.registrarAvance(obra._id, subrubro.uid, empresaId, Number(pct)),
+    onSuccess: onDone,
+    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
+  });
+  return (
+    <FormDrawer
+      open onClose={onClose} title={`Registrar avance · ${subrubro.nombre}`}
+      subtitle={`% de avance físico acumulado (lo ejecutado en obra). Mínimo: lo ya certificado (${subrubro.cert_pct || 0}%).`}
+      actions={(
+        <>
+          <Button onClick={onClose}>Cancelar</Button>
+          <Button variant="contained" disabled={guardar.isPending} onClick={() => { setError(null); guardar.mutate(); }}>Guardar</Button>
+        </>
+      )}
+    >
+      <TextField type="number" label="Avance físico %" value={pct} onChange={(e) => setPct(e.target.value)} fullWidth size="small" inputProps={{ min: subrubro.cert_pct || 0, max: 100 }} />
+      {error && <Typography color="error" variant="body2" mt={1}>{error}</Typography>}
+    </FormDrawer>
+  );
+}
+
+const nombreProfile = (p) => [p?.firstName, p?.lastName].filter(Boolean).join(' ').trim() || p?.email || '';
+const fmtArs = (n) => (Number(n) || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 });
+
+// Asigna el responsable interno de la tarea: un miembro del equipo (Profile) o
+// un nombre de texto libre.
+export function ResponsableDrawer({ obra, subrubro, empresaId, onClose, onDone }) {
+  const r = subrubro.responsable || null;
+  const [valor, setValor] = useState(r ? { _id: r.user_id, nombre: r.nombre } : null);
+  const [error, setError] = useState(null);
+
+  const equipoQ = useQuery({
+    queryKey: ['profiles', empresaId],
+    queryFn: () => profileService.getProfileByEmpresa(empresaId),
+    enabled: !!empresaId,
+  });
+  const equipo = Array.isArray(equipoQ.data) ? equipoQ.data : [];
+
+  const guardar = useMutation({
+    mutationFn: () => ControlObraService.asignarResponsable(obra._id, subrubro.uid, empresaId, {
+      user_id: valor?._id || valor?.user_id || null,
+      nombre: typeof valor === 'string' ? valor : (valor?.nombre || nombreProfile(valor)),
+    }),
+    onSuccess: onDone,
+    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
+  });
+  const quitar = useMutation({
+    mutationFn: () => ControlObraService.asignarResponsable(obra._id, subrubro.uid, empresaId, null),
+    onSuccess: onDone,
+    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
+  });
+
+  const nombreFinal = typeof valor === 'string' ? valor.trim() : (valor?.nombre || nombreProfile(valor)).trim();
+
+  return (
+    <FormDrawer
+      open onClose={onClose} title="Responsable de la tarea"
+      subtitle={subrubro.nombre}
+      actions={(
+        <>
+          {r && <Button color="error" disabled={quitar.isPending} onClick={() => { setError(null); quitar.mutate(); }} sx={{ mr: 'auto' }}>Quitar</Button>}
+          <Button onClick={onClose}>Cancelar</Button>
+          <Button variant="contained" disabled={guardar.isPending || !nombreFinal} onClick={() => { setError(null); guardar.mutate(); }}>Guardar</Button>
+        </>
+      )}
+    >
+      <Autocomplete
+        freeSolo
+        options={equipo}
+        loading={equipoQ.isLoading}
+        getOptionLabel={(p) => (typeof p === 'string' ? p : (p?.nombre || nombreProfile(p)))}
+        value={valor}
+        onChange={(_, v) => setValor(typeof v === 'string' ? { _id: null, nombre: v } : v)}
+        onInputChange={(_, v, reason) => { if (reason === 'input') setValor({ _id: null, nombre: v }); }}
+        isOptionEqualToValue={(o, v) => (o._id || o.nombre) === (v._id || v.nombre)}
+        renderInput={(params) => <TextField {...params} label="Responsable" size="small" helperText="Elegí un miembro del equipo o escribí un nombre" />}
+      />
+      {error && <Typography color="error" variant="body2" mt={1}>{error}</Typography>}
+    </FormDrawer>
+  );
+}
+
+// Asigna el contrato del contratista que ejecuta esta tarea: costo + modalidad
+// de devengo (avance físico o certificado). Es la base de las órdenes de pago.
+export function ContratoProveedorDrawer({ obra, subrubro, empresaId, onClose, onDone }) {
+  const c = subrubro.contrato_proveedor || null;
+  const [proveedor, setProveedor] = useState(c ? { _id: c.proveedor_id, nombre: c.proveedor_nombre } : null);
+  const [monto, setMonto] = useState(c ? String(c.monto ?? '') : '');
+  const [modalidad, setModalidad] = useState(c?.modalidad || 'avance_fisico');
+  const [error, setError] = useState(null);
+
+  const proveedoresQ = useQuery({
+    queryKey: ['proveedores', empresaId],
+    queryFn: () => proveedorService.getByEmpresa(empresaId),
+    enabled: !!empresaId,
+  });
+  const proveedores = Array.isArray(proveedoresQ.data) ? proveedoresQ.data : [];
+
+  const guardar = useMutation({
+    mutationFn: () => ControlObraService.asignarContrato(obra._id, subrubro.uid, empresaId, {
+      proveedor_id: proveedor?._id || null,
+      proveedor_nombre: proveedor?.nombre || proveedor?.razon_social || '',
+      monto: Number(monto) || 0,
+      modalidad,
+    }),
+    onSuccess: onDone,
+    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
+  });
+  const quitar = useMutation({
+    mutationFn: () => ControlObraService.asignarContrato(obra._id, subrubro.uid, empresaId, null),
+    onSuccess: onDone,
+    onError: (e) => setError(e?.response?.data?.error?.message || e.message),
+  });
+
+  const nombreValido = !!(proveedor?.nombre || proveedor?.razon_social);
+
+  return (
+    <FormDrawer
+      open onClose={onClose} title="Proveedor / contrato"
+      subtitle={`${subrubro.nombre} · contrato con el cliente ${(subrubro.contrato || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 })}`}
+      width={460}
+      actions={(
+        <>
+          {c && <Button color="error" disabled={quitar.isPending} onClick={() => { setError(null); quitar.mutate(); }} sx={{ mr: 'auto' }}>Quitar</Button>}
+          <Button onClick={onClose}>Cancelar</Button>
+          <Button variant="contained" disabled={guardar.isPending || !nombreValido} onClick={() => { setError(null); guardar.mutate(); }}>Guardar</Button>
+        </>
+      )}
+    >
+      <Stack spacing={2}>
+        <Autocomplete
+          freeSolo
+          options={proveedores}
+          loading={proveedoresQ.isLoading}
+          getOptionLabel={(p) => (typeof p === 'string' ? p : (p?.nombre || p?.razon_social || ''))}
+          value={proveedor}
+          onChange={(_, v) => setProveedor(typeof v === 'string' ? { _id: null, nombre: v } : v)}
+          onInputChange={(_, v, reason) => { if (reason === 'input') setProveedor({ _id: null, nombre: v }); }}
+          isOptionEqualToValue={(o, v) => (o._id || o.nombre) === (v._id || v.nombre)}
+          renderInput={(params) => <TextField {...params} label="Contratista / proveedor" size="small" helperText="Elegí uno existente o escribí un nombre nuevo" />}
+        />
+        <TextField
+          label="Costo del contrato" type="number" size="small" value={monto}
+          onChange={(e) => setMonto(e.target.value)}
+          helperText="Lo que se le paga al contratista por esta tarea (su costo, no el precio al cliente)"
+        />
+        {(() => {
+          const precio = subrubro.contrato || 0;
+          const costo = Number(monto) || 0;
+          const margen = precio - costo;
+          const margenPct = precio > 0 ? Math.round((margen / precio) * 1000) / 10 : null;
+          return (
+            <Box sx={{ p: 1.5, borderRadius: 1, bgcolor: 'action.hover' }}>
+              <Stack direction="row" justifyContent="space-between">
+                <Typography variant="caption" color="text.secondary">Precio al cliente</Typography>
+                <Typography variant="caption">{fmtArs(precio)}</Typography>
+              </Stack>
+              <Stack direction="row" justifyContent="space-between">
+                <Typography variant="caption" color="text.secondary">Costo planificado (proveedor)</Typography>
+                <Typography variant="caption">{fmtArs(costo)}</Typography>
+              </Stack>
+              <Divider sx={{ my: 0.75 }} />
+              <Stack direction="row" justifyContent="space-between">
+                <Typography variant="caption" fontWeight={600}>Margen de la tarea</Typography>
+                <Typography variant="caption" fontWeight={600} color={margen >= 0 ? 'success.main' : 'error.main'}>
+                  {fmtArs(margen)}{margenPct != null ? ` · ${margenPct}%` : ''}
+                </Typography>
+              </Stack>
+            </Box>
+          );
+        })()}
+        <div>
+          <Typography variant="caption" color="text.secondary">Devengar el pago por…</Typography>
+          <ToggleButtonGroup exclusive size="small" value={modalidad} onChange={(_, v) => v && setModalidad(v)} sx={{ mt: 0.5, display: 'flex' }}>
+            <ToggleButton value="avance_fisico" sx={{ flex: 1 }}>Avance físico</ToggleButton>
+            <ToggleButton value="certificado" sx={{ flex: 1 }}>Certificado</ToggleButton>
+          </ToggleButtonGroup>
+          <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
+            {modalidad === 'avance_fisico'
+              ? 'La orden se sugiere según lo ejecutado en obra (avance físico).'
+              : 'La orden se sugiere según lo certificado al cliente.'}
+          </Typography>
+        </div>
+      </Stack>
+      {error && <Typography color="error" variant="body2" mt={1}>{error}</Typography>}
+    </FormDrawer>
+  );
+}

--- a/src/hooks/useDashboardNavGroups.js
+++ b/src/hooks/useDashboardNavGroups.js
@@ -155,6 +155,10 @@ async function buildDefaultGroups({ user, empresa, permisosUsuario }) {
     // Plan de cobros (PlanCobroModel) es para constructoras. En corralón no aplica.
     finanzasItems.push({ title: "Plan de cobros", path: "/cobros", icon: icon(AttachMoneyIcon) });
   }
+  if (permisosUsuario.includes("VER_PLANES_PAGO") && !esCorralon) {
+    // Planes de pago a proveedores (PlanPago, lado costo). Espejo de "Plan de cobros".
+    finanzasItems.push({ title: "Planes de pago", path: "/pagos-proveedores", icon: icon(PaymentsIcon) });
+  }
   if (esAdmin && !esCorralon) {
     // Control de presupuestos / presupuestos profesionales son de obra (constructora).
     finanzasItems.push({ title: "Control presupuestos", path: "/control-presupuestos", icon: icon(NoteAltIcon) });

--- a/src/pages/pagos-proveedores.js
+++ b/src/pages/pagos-proveedores.js
@@ -46,34 +46,25 @@ const puedeVerPlanesPago = (user, empresa) => {
 
 const money = (n) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 });
 
-// Agrupa las cuotas cross-obra (una fila por cuota) en planes de pago.
-const agruparPorPlan = (cuotas) => {
-  const byPlan = new Map();
-  cuotas.forEach((c) => {
-    let p = byPlan.get(c.plan_id);
-    if (!p) {
-      p = {
-        plan_id: c.plan_id,
-        obra_id: c.obra_id,
-        obra_titulo: c.obra_titulo,
-        proveedor_nombre: c.proveedor_nombre,
-        total: 0,
-        pagado: 0,
-        pendiente: 0,
-        cuotas: 0,
-        proxima_vencimiento: null,
-      };
-      byPlan.set(c.plan_id, p);
-    }
-    p.total += c.monto || 0;
-    p.pagado += c.pagado || 0;
-    p.pendiente += c.saldo || 0;
-    p.cuotas += 1;
-    if (c.fecha_vencimiento && (!p.proxima_vencimiento || c.fecha_vencimiento < p.proxima_vencimiento)) {
-      p.proxima_vencimiento = c.fecha_vencimiento;
-    }
-  });
-  return [...byPlan.values()];
+// Normaliza un plan de pago (endpoint por-plan) a la forma que muestra la tabla.
+const normalizarPlan = (p) => {
+  const r = p.resumen || {};
+  const proxima = (p.cuotas || [])
+    .filter((c) => (c.saldo || 0) > 0 || (c.estado && c.estado !== 'pagada'))
+    .map((c) => c.fecha_vencimiento)
+    .filter(Boolean)
+    .sort()[0] || null;
+  return {
+    plan_id: p._id,
+    obra_id: p.control_obra_id,
+    obra_titulo: p.obra_titulo,
+    proveedor_nombre: p.proveedor_nombre,
+    total: r.total || 0,
+    pagado: r.pagado || 0,
+    pendiente: r.pendiente || 0,
+    cuotas: r.cuotas_total != null ? r.cuotas_total : (p.cuotas || []).length,
+    proxima_vencimiento: proxima,
+  };
 };
 
 const PagosProveedoresList = () => {
@@ -81,7 +72,7 @@ const PagosProveedoresList = () => {
   const [empresa, setEmpresa] = useState(null);
   const [empresaResuelta, setEmpresaResuelta] = useState(false);
   const [empresaId, setEmpresaId] = useState(null);
-  const [cuotas, setCuotas] = useState([]);
+  const [planesRaw, setPlanesRaw] = useState([]);
   const [loading, setLoading] = useState(true);
   const [busqueda, setBusqueda] = useState('');
   const [sortBy, setSortBy] = useState('proxima_cuota');
@@ -104,14 +95,14 @@ const PagosProveedoresList = () => {
       return;
     }
     setLoading(true);
-    ControlObraService.listarPlanesPagoCartera(empresaId)
-      .then((items) => setCuotas(items || []))
+    ControlObraService.listarPlanesPagoEmpresa(empresaId)
+      .then((items) => setPlanesRaw(items || []))
       .catch(() => setAlert({ open: true, message: 'Error al cargar los planes de pago', severity: 'error' }))
       .finally(() => setLoading(false));
   }, [empresaId, tienePermiso, empresaResuelta]);
 
   const planes = useMemo(() => {
-    let result = agruparPorPlan(cuotas);
+    let result = planesRaw.map(normalizarPlan);
     if (busqueda.trim()) {
       const q = busqueda.toLowerCase();
       result = result.filter(
@@ -129,7 +120,7 @@ const PagosProveedoresList = () => {
       default:
         return result.sort((a, b) => (a.proxima_vencimiento || '9999').localeCompare(b.proxima_vencimiento || '9999'));
     }
-  }, [cuotas, busqueda, sortBy]);
+  }, [planesRaw, busqueda, sortBy]);
 
   // Gating: sin permiso, pantalla consistente con el resto del producto.
   if (empresaResuelta && !tienePermiso) {
@@ -197,7 +188,7 @@ const PagosProveedoresList = () => {
             <Box textAlign="center" py={8}>
               <InboxIcon sx={{ fontSize: 64, color: 'text.disabled', mb: 2 }} />
               <Typography variant="h6" color="text.secondary" mb={1}>
-                No hay planes de pago con cuotas pendientes
+                No hay planes de pago
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 Los planes de pago a proveedores se crean dentro de cada obra, en la pestaña de pagos.

--- a/src/pages/pagos-proveedores.js
+++ b/src/pages/pagos-proveedores.js
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import {
   Alert,
   Box,
+  Button,
   Chip,
   Container,
   FormControl,
@@ -24,6 +25,7 @@ import {
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import InboxIcon from '@mui/icons-material/Inbox';
+import AddIcon from '@mui/icons-material/Add';
 import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
@@ -149,6 +151,9 @@ const PagosProveedoresList = () => {
             <Typography variant="h5" fontWeight={700}>
               Planes de Pago
             </Typography>
+            <Button variant="contained" startIcon={<AddIcon />} onClick={() => router.push('/pagos-proveedores/nuevo')}>
+              Nuevo plan
+            </Button>
           </Stack>
 
           <Stack direction="row" spacing={2} mb={3} alignItems="center" flexWrap="wrap" useFlexGap>

--- a/src/pages/pagos-proveedores.js
+++ b/src/pages/pagos-proveedores.js
@@ -1,0 +1,273 @@
+import { useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+import {
+  Alert,
+  Box,
+  Chip,
+  Container,
+  FormControl,
+  InputAdornment,
+  InputLabel,
+  MenuItem,
+  Select,
+  Skeleton,
+  Snackbar,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import InboxIcon from '@mui/icons-material/Inbox';
+import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
+import { useAuthContext } from 'src/contexts/auth-context';
+import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
+import ControlObraService from 'src/services/controlObra/controlObraService';
+
+const SORT_OPTIONS = [
+  { value: 'proxima_cuota', label: 'Próxima cuota' },
+  { value: 'monto', label: 'Mayor monto' },
+  { value: 'proveedor', label: 'Proveedor (A-Z)' },
+];
+
+// Devuelve true si el usuario puede ver la hoja de planes de pago.
+// Espejo de puedeVerControlObra: acción explícita VER_PLANES_PAGO (admin global pasa).
+const puedeVerPlanesPago = (user, empresa) => {
+  if (!user) return false;
+  if (user.admin) return true;
+  const acciones = empresa?.acciones || user?.empresaData?.acciones || [];
+  const ocultos = user?.permisosOcultos || [];
+  return acciones.includes('VER_PLANES_PAGO') && !ocultos.includes('VER_PLANES_PAGO');
+};
+
+const money = (n) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 });
+
+// Agrupa las cuotas cross-obra (una fila por cuota) en planes de pago.
+const agruparPorPlan = (cuotas) => {
+  const byPlan = new Map();
+  cuotas.forEach((c) => {
+    let p = byPlan.get(c.plan_id);
+    if (!p) {
+      p = {
+        plan_id: c.plan_id,
+        obra_id: c.obra_id,
+        obra_titulo: c.obra_titulo,
+        proveedor_nombre: c.proveedor_nombre,
+        total: 0,
+        pagado: 0,
+        pendiente: 0,
+        cuotas: 0,
+        proxima_vencimiento: null,
+      };
+      byPlan.set(c.plan_id, p);
+    }
+    p.total += c.monto || 0;
+    p.pagado += c.pagado || 0;
+    p.pendiente += c.saldo || 0;
+    p.cuotas += 1;
+    if (c.fecha_vencimiento && (!p.proxima_vencimiento || c.fecha_vencimiento < p.proxima_vencimiento)) {
+      p.proxima_vencimiento = c.fecha_vencimiento;
+    }
+  });
+  return [...byPlan.values()];
+};
+
+const PagosProveedoresList = () => {
+  const { user } = useAuthContext();
+  const [empresa, setEmpresa] = useState(null);
+  const [empresaResuelta, setEmpresaResuelta] = useState(false);
+  const [empresaId, setEmpresaId] = useState(null);
+  const [cuotas, setCuotas] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [busqueda, setBusqueda] = useState('');
+  const [sortBy, setSortBy] = useState('proxima_cuota');
+  const [alert, setAlert] = useState({ open: false, message: '', severity: 'info' });
+
+  useEffect(() => {
+    if (!user) return;
+    getEmpresaDetailsFromUser(user).then((emp) => {
+      setEmpresa(emp || null);
+      if (emp?.id) setEmpresaId(emp.id);
+      setEmpresaResuelta(true);
+    });
+  }, [user]);
+
+  const tienePermiso = useMemo(() => puedeVerPlanesPago(user, empresa), [user, empresa]);
+
+  useEffect(() => {
+    if (!empresaId || !tienePermiso) {
+      if (empresaResuelta) setLoading(false);
+      return;
+    }
+    setLoading(true);
+    ControlObraService.listarPlanesPagoCartera(empresaId)
+      .then((items) => setCuotas(items || []))
+      .catch(() => setAlert({ open: true, message: 'Error al cargar los planes de pago', severity: 'error' }))
+      .finally(() => setLoading(false));
+  }, [empresaId, tienePermiso, empresaResuelta]);
+
+  const planes = useMemo(() => {
+    let result = agruparPorPlan(cuotas);
+    if (busqueda.trim()) {
+      const q = busqueda.toLowerCase();
+      result = result.filter(
+        (p) =>
+          (p.proveedor_nombre || '').toLowerCase().includes(q) ||
+          (p.obra_titulo || '').toLowerCase().includes(q)
+      );
+    }
+    switch (sortBy) {
+      case 'monto':
+        return result.sort((a, b) => b.total - a.total);
+      case 'proveedor':
+        return result.sort((a, b) => (a.proveedor_nombre || '').localeCompare(b.proveedor_nombre || ''));
+      case 'proxima_cuota':
+      default:
+        return result.sort((a, b) => (a.proxima_vencimiento || '9999').localeCompare(b.proxima_vencimiento || '9999'));
+    }
+  }, [cuotas, busqueda, sortBy]);
+
+  // Gating: sin permiso, pantalla consistente con el resto del producto.
+  if (empresaResuelta && !tienePermiso) {
+    return (
+      <Box component="main" sx={{ flexGrow: 1, py: 4 }}>
+        <Container maxWidth="xl">
+          <Alert severity="warning">
+            No tenés permiso para acceder a los planes de pago a proveedores. Pedile a un administrador que habilite la
+            acción <strong>VER_PLANES_PAGO</strong> en la configuración de la empresa.
+          </Alert>
+        </Container>
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Planes de Pago | Sorby</title>
+      </Head>
+      <Box component="main" sx={{ flexGrow: 1, py: 4 }}>
+        <Container maxWidth="xl">
+          <Stack direction="row" justifyContent="space-between" alignItems="center" mb={3}>
+            <Typography variant="h5" fontWeight={700}>
+              Planes de Pago
+            </Typography>
+          </Stack>
+
+          <Stack direction="row" spacing={2} mb={3} alignItems="center" flexWrap="wrap" useFlexGap>
+            <TextField
+              size="small"
+              placeholder="Buscar por proveedor u obra..."
+              value={busqueda}
+              onChange={(e) => setBusqueda(e.target.value)}
+              sx={{ minWidth: 220 }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              }}
+            />
+            <FormControl size="small" sx={{ minWidth: 160 }}>
+              <InputLabel>Ordenar</InputLabel>
+              <Select value={sortBy} label="Ordenar" onChange={(e) => setSortBy(e.target.value)}>
+                {SORT_OPTIONS.map((o) => (
+                  <MenuItem key={o.value} value={o.value}>
+                    {o.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Stack>
+
+          {loading && (
+            <Stack spacing={1}>
+              {[1, 2, 3, 4].map((k) => (
+                <Skeleton key={k} variant="rounded" height={48} />
+              ))}
+            </Stack>
+          )}
+
+          {!loading && planes.length === 0 && (
+            <Box textAlign="center" py={8}>
+              <InboxIcon sx={{ fontSize: 64, color: 'text.disabled', mb: 2 }} />
+              <Typography variant="h6" color="text.secondary" mb={1}>
+                No hay planes de pago con cuotas pendientes
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Los planes de pago a proveedores se crean dentro de cada obra, en la pestaña de pagos.
+              </Typography>
+            </Box>
+          )}
+
+          {!loading && planes.length > 0 && (
+            <Box sx={{ overflowX: 'auto', border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+              <Table size="small" stickyHeader>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Proveedor</TableCell>
+                    <TableCell>Obra</TableCell>
+                    <TableCell align="right">Total</TableCell>
+                    <TableCell align="right">Pagado</TableCell>
+                    <TableCell align="right">Pendiente</TableCell>
+                    <TableCell align="center">Cuotas</TableCell>
+                    <TableCell>Próxima</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {planes.map((p) => (
+                    <TableRow key={p.plan_id} hover>
+                      <TableCell>{p.proveedor_nombre || '—'}</TableCell>
+                      <TableCell>
+                        {p.obra_titulo || '—'}
+                        {p.obra_id && (
+                          <Chip
+                            size="small"
+                            label="Ver obra"
+                            component="a"
+                            clickable
+                            href={`/control-obra/${p.obra_id}`}
+                            sx={{ ml: 1 }}
+                          />
+                        )}
+                      </TableCell>
+                      <TableCell align="right">{money(p.total)}</TableCell>
+                      <TableCell align="right" sx={{ color: 'success.main' }}>{money(p.pagado)}</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 700 }}>{money(p.pendiente)}</TableCell>
+                      <TableCell align="center">{p.cuotas}</TableCell>
+                      <TableCell>
+                        {p.proxima_vencimiento
+                          ? new Date(p.proxima_vencimiento).toLocaleDateString('es-AR')
+                          : '—'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </Box>
+          )}
+        </Container>
+      </Box>
+
+      <Snackbar
+        open={alert.open}
+        autoHideDuration={4000}
+        onClose={() => setAlert((a) => ({ ...a, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={alert.severity} onClose={() => setAlert((a) => ({ ...a, open: false }))}>
+          {alert.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+PagosProveedoresList.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default PagosProveedoresList;

--- a/src/pages/pagos-proveedores.js
+++ b/src/pages/pagos-proveedores.js
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import {
   Alert,
   Box,
@@ -69,6 +70,7 @@ const normalizarPlan = (p) => {
 
 const PagosProveedoresList = () => {
   const { user } = useAuthContext();
+  const router = useRouter();
   const [empresa, setEmpresa] = useState(null);
   const [empresaResuelta, setEmpresaResuelta] = useState(false);
   const [empresaId, setEmpresaId] = useState(null);
@@ -212,7 +214,12 @@ const PagosProveedoresList = () => {
                 </TableHead>
                 <TableBody>
                   {planes.map((p) => (
-                    <TableRow key={p.plan_id} hover>
+                    <TableRow
+                      key={p.plan_id}
+                      hover
+                      sx={{ cursor: 'pointer' }}
+                      onClick={() => router.push(`/pagos-proveedores/${p.plan_id}`)}
+                    >
                       <TableCell>{p.proveedor_nombre || '—'}</TableCell>
                       <TableCell>
                         {p.obra_titulo || '—'}
@@ -223,6 +230,7 @@ const PagosProveedoresList = () => {
                             component="a"
                             clickable
                             href={`/control-obra/${p.obra_id}`}
+                            onClick={(e) => e.stopPropagation()}
                             sx={{ ml: 1 }}
                           />
                         )}

--- a/src/pages/pagos-proveedores/[id].js
+++ b/src/pages/pagos-proveedores/[id].js
@@ -280,7 +280,10 @@ const DetallePlanPagoPage = () => {
                 <>
                   <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={() => setShowAddCuota(true)}>Agregar cuota</Button>
                   <Button size="small" variant="outlined" startIcon={<AutorenewIcon />} onClick={() => setShowPeriodicas(true)}>Periódicas</Button>
-                  <Button size="small" variant="outlined" disabled={busy} onClick={handleGenerarAvance}>Generar por avance</Button>
+                  {/* "Por avance" solo aplica dentro de una obra (devenga contra sus sub-rubros). */}
+                  {plan.control_obra_id && (
+                    <Button size="small" variant="outlined" disabled={busy} onClick={handleGenerarAvance}>Generar por avance</Button>
+                  )}
                 </>
               )}
               <Button size="small" color="error" variant="outlined" startIcon={<DeleteIcon />} onClick={() => setConfirmEliminarPlan(true)}>Eliminar plan</Button>
@@ -311,7 +314,7 @@ const DetallePlanPagoPage = () => {
             <Typography variant="subtitle1" fontWeight={600} mb={1.5}>Cronograma de cuotas</Typography>
             {cuotas.length === 0 ? (
               <Typography variant="body2" color="text.secondary">
-                Este plan todavía no tiene cuotas. Agregá una cuota, generá periódicas o generá por avance devengado del proveedor.
+                Este plan todavía no tiene cuotas. Agregá una cuota{plan.control_obra_id ? ', generá periódicas o generá por avance devengado del proveedor.' : ' o generá cuotas periódicas.'}
               </Typography>
             ) : (
               <Box sx={{ overflowX: 'auto' }}>

--- a/src/pages/pagos-proveedores/[id].js
+++ b/src/pages/pagos-proveedores/[id].js
@@ -1,0 +1,599 @@
+import { useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Grid,
+  InputAdornment,
+  LinearProgress,
+  Paper,
+  Skeleton,
+  Snackbar,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import UndoIcon from '@mui/icons-material/Undo';
+import AutorenewIcon from '@mui/icons-material/Autorenew';
+import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
+import { useAuthContext } from 'src/contexts/auth-context';
+import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
+import ControlObraService from 'src/services/controlObra/controlObraService';
+import { formatCurrency, formatNumberInput, parseNumberInput } from 'src/utils/formatters';
+
+// Estados de cuota de PAGO (difieren de cobro: hay 'aprobada' + 'pagada_parcial').
+const ESTADO_COLOR = {
+  pendiente: 'info',
+  pendiente_vencida: 'error',
+  aprobada: 'primary',
+  pagada: 'success',
+  pagada_parcial: 'warning',
+  pagada_parcial_vencida: 'warning',
+  anulada: 'default',
+};
+const ESTADO_LABEL = {
+  pendiente: 'Pendiente',
+  pendiente_vencida: 'Vencida',
+  aprobada: 'Aprobada',
+  pagada: 'Pagada',
+  pagada_parcial: 'Pagada parcial',
+  pagada_parcial_vencida: 'Pagada parcial vencida',
+  anulada: 'Anulada',
+};
+const PLAN_COLOR = { activo: 'primary', completado: 'success', anulado: 'default' };
+
+const money = (n, moneda) =>
+  (Number(n) || 0).toLocaleString('es-AR', { style: 'currency', currency: moneda === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
+
+const fmtDate = (d) => (d ? new Date(d).toLocaleDateString('es-AR') : '—');
+
+const DetallePlanPagoPage = () => {
+  const { user } = useAuthContext();
+  const router = useRouter();
+  const { id } = router.query;
+  const planId = id ? String(id) : null;
+
+  const [empresaId, setEmpresaId] = useState(null);
+  const [plan, setPlan] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [alert, setAlert] = useState({ open: false, message: '', severity: 'info' });
+  const [busy, setBusy] = useState(false);
+
+  // Dialogs
+  const [pagarCuota, setPagarCuota] = useState(null);
+  const [tipoPago, setTipoPago] = useState('total'); // 'total' | 'parcial'
+  const [montoParcial, setMontoParcial] = useState('');
+  const [fechaPago, setFechaPago] = useState('');
+  const [editCuota, setEditCuota] = useState(null);
+  const [editForm, setEditForm] = useState({ monto: '', fecha_vencimiento: '', descripcion: '' });
+  const [deleteCuota, setDeleteCuota] = useState(null);
+  const [showAddCuota, setShowAddCuota] = useState(false);
+  const [addForm, setAddForm] = useState({ monto: '', fecha_vencimiento: '', descripcion: '' });
+  const [showPeriodicas, setShowPeriodicas] = useState(false);
+  const [periForm, setPeriForm] = useState({ monto: '', cantidad: '', frecuencia: 'mensual', fecha_inicio: '', descripcion: '' });
+  const [confirmEliminarPlan, setConfirmEliminarPlan] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    getEmpresaDetailsFromUser(user).then((emp) => { if (emp?.id) setEmpresaId(emp.id); });
+  }, [user]);
+
+  const refresh = () => {
+    if (!planId || !empresaId) return Promise.resolve();
+    setLoading(true);
+    return ControlObraService.getPlanPago(planId, empresaId)
+      .then((p) => setPlan(p || null))
+      .catch(() => setAlert({ open: true, message: 'No se pudo cargar el plan de pago', severity: 'error' }))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    if (!planId || !empresaId) return;
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [planId, empresaId]);
+
+  const moneda = plan?.moneda || 'ARS';
+  const resumen = plan?.resumen || {};
+  const cuotas = useMemo(
+    () => [...(plan?.cuotas || [])].sort((a, b) => (a.numero || 0) - (b.numero || 0)),
+    [plan]
+  );
+  const pct = resumen.total ? Math.round((resumen.pagado || 0) / resumen.total * 100) : 0;
+
+  const notify = (message, severity = 'success') => setAlert({ open: true, message, severity });
+
+  const run = async (fn, okMsg) => {
+    setBusy(true);
+    try {
+      await fn();
+      await refresh();
+      if (okMsg) notify(okMsg);
+    } catch (err) {
+      notify(err?.response?.data?.error?.message || err.message || 'Error en la operación', 'error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // ─── Acciones de cuota ───────────────────────────────────────────────────
+  const handleAprobar = (cuota) =>
+    run(() => ControlObraService.aprobarCuotaPago(planId, cuota._id, empresaId), 'Cuota aprobada');
+
+  const handleRevertir = (cuota) =>
+    run(() => ControlObraService.revertirPagoCuota(planId, cuota._id, empresaId), 'Pago revertido');
+
+  const openPagar = (cuota) => {
+    setPagarCuota(cuota);
+    setTipoPago('total');
+    setMontoParcial('');
+    setFechaPago('');
+  };
+  const confirmarPago = () =>
+    run(async () => {
+      await ControlObraService.pagarCuotaPago(planId, pagarCuota._id, empresaId, {
+        monto_parcial: tipoPago === 'parcial' ? Number(parseNumberInput(montoParcial)) : null,
+        fecha_pago: fechaPago || null,
+      });
+      setPagarCuota(null);
+    }, 'Pago registrado');
+
+  const openEdit = (cuota) => {
+    setEditCuota(cuota);
+    setEditForm({
+      monto: String(cuota.monto ?? ''),
+      fecha_vencimiento: cuota.fecha_vencimiento ? new Date(cuota.fecha_vencimiento).toISOString().split('T')[0] : '',
+      descripcion: cuota.descripcion || '',
+    });
+  };
+  const confirmarEdit = () =>
+    run(async () => {
+      await ControlObraService.editarCuotaPago(planId, editCuota._id, empresaId, {
+        monto: Number(parseNumberInput(editForm.monto)),
+        fecha_vencimiento: editForm.fecha_vencimiento || null,
+        descripcion: editForm.descripcion || null,
+      });
+      setEditCuota(null);
+    }, 'Cuota actualizada');
+
+  const confirmarDelete = () =>
+    run(async () => {
+      await ControlObraService.eliminarCuotaPago(planId, deleteCuota._id, empresaId);
+      setDeleteCuota(null);
+    }, 'Cuota eliminada');
+
+  const confirmarAdd = () =>
+    run(async () => {
+      await ControlObraService.agregarCuotaPago(planId, {
+        empresa_id: empresaId,
+        tipo: 'fija',
+        monto: Number(parseNumberInput(addForm.monto)),
+        fecha_vencimiento: addForm.fecha_vencimiento || null,
+        descripcion: addForm.descripcion || null,
+      });
+      setShowAddCuota(false);
+      setAddForm({ monto: '', fecha_vencimiento: '', descripcion: '' });
+    }, 'Cuota agregada');
+
+  const confirmarPeriodicas = () =>
+    run(async () => {
+      await ControlObraService.generarCuotasPeriodicas(planId, {
+        empresa_id: empresaId,
+        monto: Number(parseNumberInput(periForm.monto)),
+        cantidad: Number(periForm.cantidad),
+        frecuencia: periForm.frecuencia,
+        fecha_inicio: periForm.fecha_inicio || null,
+        descripcion: periForm.descripcion || null,
+      });
+      setShowPeriodicas(false);
+      setPeriForm({ monto: '', cantidad: '', frecuencia: 'mensual', fecha_inicio: '', descripcion: '' });
+    }, 'Cuotas periódicas generadas');
+
+  const handleGenerarAvance = () =>
+    run(() => ControlObraService.generarCuotasPorAvance(planId, empresaId), 'Cuotas por avance generadas');
+
+  const handleEliminarPlan = () =>
+    run(async () => {
+      await ControlObraService.eliminarPlanPago(planId, empresaId);
+      router.push(plan?.control_obra_id ? `/control-obra/${plan.control_obra_id}` : '/pagos-proveedores');
+    });
+
+  if (loading && !plan) {
+    return (
+      <Box component="main" sx={{ flexGrow: 1, py: 4 }}>
+        <Container maxWidth="lg">
+          <Stack spacing={2}>
+            <Skeleton variant="rounded" height={64} />
+            <Skeleton variant="rounded" height={120} />
+            <Skeleton variant="rounded" height={240} />
+          </Stack>
+        </Container>
+      </Box>
+    );
+  }
+
+  if (!plan) {
+    return (
+      <Box component="main" sx={{ flexGrow: 1, py: 4 }}>
+        <Container maxWidth="lg">
+          <Alert severity="error">No se encontró el plan de pago.</Alert>
+          <Button sx={{ mt: 2 }} startIcon={<ArrowBackIcon />} onClick={() => router.push('/pagos-proveedores')}>
+            Volver
+          </Button>
+        </Container>
+      </Box>
+    );
+  }
+
+  const editable = plan.estado === 'activo';
+
+  return (
+    <>
+      <Head>
+        <title>{plan.nombre || 'Plan de pago'} | Sorby</title>
+      </Head>
+      <Box component="main" sx={{ flexGrow: 1, py: 4 }}>
+        <Container maxWidth="lg">
+          {/* Header */}
+          <Button startIcon={<ArrowBackIcon />} onClick={() => router.push(plan.control_obra_id ? `/control-obra/${plan.control_obra_id}` : '/pagos-proveedores')} sx={{ mb: 1 }}>
+            Volver
+          </Button>
+
+          <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ md: 'flex-start' }} spacing={2} mb={3}>
+            <Box>
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <Typography variant="h5" fontWeight={700}>{plan.nombre}</Typography>
+                <Chip size="small" label={plan.estado} color={PLAN_COLOR[plan.estado] || 'default'} />
+                {plan.indexacion && <Chip size="small" variant="outlined" label={plan.indexacion} />}
+              </Stack>
+              <Typography variant="body2" color="text.secondary" mt={0.5}>
+                Proveedor: <strong>{plan.proveedor_nombre || 's/d'}</strong>
+                {plan.obra_titulo ? ` · Obra: ${plan.obra_titulo}` : ''}
+                {plan.moneda ? ` · ${plan.moneda}` : ''}
+              </Typography>
+              {plan.notas && <Typography variant="body2" color="text.secondary" mt={0.5}>{plan.notas}</Typography>}
+            </Box>
+
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+              {editable && (
+                <>
+                  <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={() => setShowAddCuota(true)}>Agregar cuota</Button>
+                  <Button size="small" variant="outlined" startIcon={<AutorenewIcon />} onClick={() => setShowPeriodicas(true)}>Periódicas</Button>
+                  <Button size="small" variant="outlined" disabled={busy} onClick={handleGenerarAvance}>Generar por avance</Button>
+                </>
+              )}
+              <Button size="small" color="error" variant="outlined" startIcon={<DeleteIcon />} onClick={() => setConfirmEliminarPlan(true)}>Eliminar plan</Button>
+            </Stack>
+          </Stack>
+
+          {/* Métricas */}
+          <Grid container spacing={2} mb={3}>
+            <MetricCard label="TOTAL DEL PLAN" value={money(resumen.total, moneda)} color="#1976d2" />
+            <MetricCard label="PAGADO" value={money(resumen.pagado, moneda)} color="#2e7d32" />
+            <MetricCard label="PENDIENTE" value={money(resumen.pendiente, moneda)} color="#c62828" />
+            {resumen.vencido > 0 && <MetricCard label="VENCIDO" value={money(resumen.vencido, moneda)} color="#ed6c02" />}
+          </Grid>
+
+          {/* Progreso */}
+          <Box mb={3}>
+            <Stack direction="row" justifyContent="space-between" mb={0.5}>
+              <Typography variant="caption" color="text.secondary">Avance de pago</Typography>
+              <Typography variant="caption" fontWeight={600}>{pct}%</Typography>
+            </Stack>
+            <LinearProgress variant="determinate" value={pct} color={plan.estado === 'completado' ? 'success' : resumen.vencido > 0 ? 'error' : 'primary'} sx={{ height: 8, borderRadius: 4 }} />
+          </Box>
+
+          {busy && <LinearProgress sx={{ mb: 2 }} />}
+
+          {/* Cronograma de cuotas */}
+          <Paper variant="outlined" sx={{ p: { xs: 1.5, sm: 3 }, borderRadius: 2 }}>
+            <Typography variant="subtitle1" fontWeight={600} mb={1.5}>Cronograma de cuotas</Typography>
+            {cuotas.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                Este plan todavía no tiene cuotas. Agregá una cuota, generá periódicas o generá por avance devengado del proveedor.
+              </Typography>
+            ) : (
+              <Box sx={{ overflowX: 'auto' }}>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>#</TableCell>
+                      <TableCell>Descripción</TableCell>
+                      <TableCell>Vencimiento</TableCell>
+                      <TableCell align="right">Monto</TableCell>
+                      <TableCell align="right">Pagado</TableCell>
+                      <TableCell>Estado</TableCell>
+                      <TableCell align="right">Acciones</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {cuotas.map((c) => {
+                      const estadoUi = c.estado_ui || c.estado;
+                      const saldo = c.saldo != null ? c.saldo : (c.monto || 0) - (c.monto_pagado || 0);
+                      const puedeAprobar = c.estado === 'pendiente';
+                      const puedePagar = ['pendiente', 'aprobada', 'pagada_parcial'].includes(c.estado);
+                      const puedeRevertir = ['pagada', 'pagada_parcial'].includes(c.estado);
+                      const puedeEditar = ['pendiente', 'aprobada'].includes(c.estado);
+                      return (
+                        <TableRow key={c._id} hover>
+                          <TableCell>{c.numero}</TableCell>
+                          <TableCell>
+                            {c.descripcion || c.tipo}
+                            {c.tipo === 'por_avance' && <Chip size="small" variant="outlined" label="avance" sx={{ ml: 0.5 }} />}
+                          </TableCell>
+                          <TableCell>{fmtDate(c.fecha_vencimiento)}</TableCell>
+                          <TableCell align="right">
+                            {money(c.monto, moneda)}
+                            {c.monto_cac != null && (
+                              <Tooltip title="Monto en unidades CAC">
+                                <Typography variant="caption" color="text.secondary" display="block">{formatNumberInput(Math.round((c.monto_cac || 0) * 100) / 100)} CAC</Typography>
+                              </Tooltip>
+                            )}
+                          </TableCell>
+                          <TableCell align="right">{c.monto_pagado ? money(c.monto_pagado, moneda) : '—'}</TableCell>
+                          <TableCell><Chip size="small" label={ESTADO_LABEL[estadoUi] || estadoUi} color={ESTADO_COLOR[estadoUi] || 'default'} /></TableCell>
+                          <TableCell align="right">
+                            <Stack direction="row" spacing={0.5} justifyContent="flex-end" flexWrap="wrap" useFlexGap>
+                              {puedeAprobar && (
+                                <Button size="small" disabled={busy} onClick={() => handleAprobar(c)}>Aprobar</Button>
+                              )}
+                              {puedePagar && (
+                                <Button size="small" variant="contained" color="success" disabled={busy} onClick={() => openPagar(c)}>
+                                  {c.estado === 'pagada_parcial' ? 'Pagar resto' : 'Pagar'}
+                                </Button>
+                              )}
+                              {puedeEditar && (
+                                <Tooltip title="Editar cuota"><span>
+                                  <Button size="small" disabled={busy} onClick={() => openEdit(c)}><EditIcon fontSize="small" /></Button>
+                                </span></Tooltip>
+                              )}
+                              {puedeRevertir && (
+                                <Tooltip title="Revertir pago"><span>
+                                  <Button size="small" color="warning" disabled={busy} onClick={() => handleRevertir(c)}><UndoIcon fontSize="small" /></Button>
+                                </span></Tooltip>
+                              )}
+                              {puedeEditar && (
+                                <Tooltip title="Eliminar cuota"><span>
+                                  <Button size="small" color="error" disabled={busy} onClick={() => setDeleteCuota(c)}><DeleteIcon fontSize="small" /></Button>
+                                </span></Tooltip>
+                              )}
+                            </Stack>
+                            {saldo > 0 && c.estado === 'pagada_parcial' && (
+                              <Typography variant="caption" color="text.secondary" display="block">Saldo: {money(saldo, moneda)}</Typography>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </Box>
+            )}
+          </Paper>
+        </Container>
+      </Box>
+
+      {/* ─── Dialog: Pagar cuota ─── */}
+      <Dialog open={!!pagarCuota} onClose={() => setPagarCuota(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Registrar pago</DialogTitle>
+        <DialogContent>
+          {pagarCuota && (
+            <Stack spacing={2} mt={0.5}>
+              <Typography variant="body2" color="text.secondary">
+                Cuota {pagarCuota.numero} · {money(pagarCuota.monto, moneda)} · vence {fmtDate(pagarCuota.fecha_vencimiento)}
+              </Typography>
+              <ToggleButtonGroup value={tipoPago} exclusive size="small" onChange={(_, v) => { if (v) setTipoPago(v); }}>
+                <ToggleButton value="total">Pago total</ToggleButton>
+                <ToggleButton value="parcial">Pago parcial</ToggleButton>
+              </ToggleButtonGroup>
+              {tipoPago === 'parcial' && (
+                <TextField
+                  label="Monto a pagar" size="small"
+                  value={formatNumberInput(montoParcial)}
+                  onChange={(e) => setMontoParcial(parseNumberInput(e.target.value))}
+                  InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                  helperText={`Saldo de la cuota: ${money((pagarCuota.saldo != null ? pagarCuota.saldo : pagarCuota.monto), moneda)}`}
+                  inputProps={{ inputMode: 'decimal' }}
+                />
+              )}
+              <TextField
+                label="Fecha de pago" type="date" size="small"
+                value={fechaPago}
+                onChange={(e) => setFechaPago(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+                helperText="Opcional. Por defecto, hoy."
+              />
+              <Typography variant="caption" color="text.secondary">
+                Se genera un egreso en la caja imputado a los sub-rubros del proveedor.
+              </Typography>
+            </Stack>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPagarCuota(null)}>Cancelar</Button>
+          <Button variant="contained" color="success" disabled={busy} onClick={confirmarPago}>Registrar pago</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ─── Dialog: Editar cuota ─── */}
+      <Dialog open={!!editCuota} onClose={() => setEditCuota(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Editar cuota</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} mt={0.5}>
+            <TextField
+              label="Monto" size="small"
+              value={formatNumberInput(editForm.monto)}
+              onChange={(e) => setEditForm((f) => ({ ...f, monto: parseNumberInput(e.target.value) }))}
+              InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+              inputProps={{ inputMode: 'decimal' }}
+            />
+            <TextField
+              label="Vencimiento" type="date" size="small"
+              value={editForm.fecha_vencimiento}
+              onChange={(e) => setEditForm((f) => ({ ...f, fecha_vencimiento: e.target.value }))}
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              label="Descripción" size="small"
+              value={editForm.descripcion}
+              onChange={(e) => setEditForm((f) => ({ ...f, descripcion: e.target.value }))}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditCuota(null)}>Cancelar</Button>
+          <Button variant="contained" disabled={busy} onClick={confirmarEdit}>Guardar</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ─── Dialog: Eliminar cuota ─── */}
+      <Dialog open={!!deleteCuota} onClose={() => setDeleteCuota(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Eliminar cuota</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {deleteCuota && `¿Eliminar la cuota ${deleteCuota.numero} de ${money(deleteCuota.monto, moneda)}? Esta acción no se puede deshacer.`}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteCuota(null)}>Cancelar</Button>
+          <Button variant="contained" color="error" disabled={busy} onClick={confirmarDelete}>Eliminar</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ─── Dialog: Agregar cuota ─── */}
+      <Dialog open={showAddCuota} onClose={() => setShowAddCuota(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Agregar cuota</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} mt={0.5}>
+            <TextField
+              label="Monto *" size="small"
+              value={formatNumberInput(addForm.monto)}
+              onChange={(e) => setAddForm((f) => ({ ...f, monto: parseNumberInput(e.target.value) }))}
+              InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+              inputProps={{ inputMode: 'decimal' }}
+            />
+            <TextField
+              label="Vencimiento" type="date" size="small"
+              value={addForm.fecha_vencimiento}
+              onChange={(e) => setAddForm((f) => ({ ...f, fecha_vencimiento: e.target.value }))}
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              label="Descripción" size="small"
+              value={addForm.descripcion}
+              onChange={(e) => setAddForm((f) => ({ ...f, descripcion: e.target.value }))}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowAddCuota(false)}>Cancelar</Button>
+          <Button variant="contained" disabled={busy || !parseNumberInput(addForm.monto)} onClick={confirmarAdd}>Agregar</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ─── Dialog: Generar periódicas ─── */}
+      <Dialog open={showPeriodicas} onClose={() => setShowPeriodicas(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Generar cuotas periódicas</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} mt={0.5}>
+            <TextField
+              label="Monto por cuota *" size="small"
+              value={formatNumberInput(periForm.monto)}
+              onChange={(e) => setPeriForm((f) => ({ ...f, monto: parseNumberInput(e.target.value) }))}
+              InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+              inputProps={{ inputMode: 'decimal' }}
+            />
+            <TextField
+              label="Cantidad *" type="number" size="small"
+              value={periForm.cantidad}
+              onChange={(e) => setPeriForm((f) => ({ ...f, cantidad: e.target.value }))}
+              inputProps={{ min: 1, max: 120 }}
+            />
+            <ToggleButtonGroup
+              value={periForm.frecuencia} exclusive size="small"
+              onChange={(_, v) => { if (v) setPeriForm((f) => ({ ...f, frecuencia: v })); }}
+            >
+              <ToggleButton value="semanal">Semanal</ToggleButton>
+              <ToggleButton value="quincenal">Quincenal</ToggleButton>
+              <ToggleButton value="mensual">Mensual</ToggleButton>
+            </ToggleButtonGroup>
+            <TextField
+              label="Fecha primera cuota" type="date" size="small"
+              value={periForm.fecha_inicio}
+              onChange={(e) => setPeriForm((f) => ({ ...f, fecha_inicio: e.target.value }))}
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              label="Descripción base" size="small"
+              value={periForm.descripcion}
+              onChange={(e) => setPeriForm((f) => ({ ...f, descripcion: e.target.value }))}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowPeriodicas(false)}>Cancelar</Button>
+          <Button variant="contained" disabled={busy || !parseNumberInput(periForm.monto) || !periForm.cantidad} onClick={confirmarPeriodicas}>Generar</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ─── Dialog: Eliminar plan ─── */}
+      <Dialog open={confirmEliminarPlan} onClose={() => setConfirmEliminarPlan(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Eliminar plan de pago</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Se eliminarán el plan y todas sus cuotas. Los egresos generados por cuotas pagadas se revierten de la caja. ¿Continuar?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmEliminarPlan(false)}>Cancelar</Button>
+          <Button variant="contained" color="error" disabled={busy} onClick={() => { setConfirmEliminarPlan(false); handleEliminarPlan(); }}>Eliminar</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={alert.open}
+        autoHideDuration={4000}
+        onClose={() => setAlert((a) => ({ ...a, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={alert.severity} onClose={() => setAlert((a) => ({ ...a, open: false }))}>{alert.message}</Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+function MetricCard({ label, value, color }) {
+  return (
+    <Grid item xs={6} sm={3}>
+      <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, borderTop: `3px solid ${color}` }}>
+        <Typography variant="caption" color="text.secondary" display="block">{label}</Typography>
+        <Typography variant="h6" fontWeight={700}>{value}</Typography>
+      </Paper>
+    </Grid>
+  );
+}
+
+DetallePlanPagoPage.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default DetallePlanPagoPage;

--- a/src/pages/pagos-proveedores/nuevo.js
+++ b/src/pages/pagos-proveedores/nuevo.js
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import {
   Alert,
+  Autocomplete,
   Box,
   Button,
   Chip,
@@ -37,6 +38,7 @@ import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
 import { getProyectosFromUser } from 'src/services/proyectosService';
+import proveedorService from 'src/services/proveedorService';
 import ControlObraService from 'src/services/controlObra/controlObraService';
 import planCobroService from 'src/services/planCobroService';
 import { CuotasTableEdit } from 'src/components/planCobro/CuotasTable';
@@ -111,6 +113,8 @@ const NuevoPlanPagoPage = () => {
   const [obraLoading, setObraLoading] = useState(true);
   const [proyectos, setProyectos] = useState([]);
   const [proyectoSel, setProyectoSel] = useState(''); // caja destino para el plan suelto
+  const [proveedoresEmpresa, setProveedoresEmpresa] = useState([]); // catálogo de proveedores (plan suelto)
+  const [proveedorIdSel, setProveedorIdSel] = useState(null); // id cuando se elige uno del catálogo
   const [proveedorSel, setProveedorSel] = useState(''); // key = proveedor_id || nombre
   const [proveedorLibre, setProveedorLibre] = useState('');
   const [planData, setPlanData] = useState(defaultPlan);
@@ -154,6 +158,12 @@ const NuevoPlanPagoPage = () => {
     if (!user || !esSuelto) return;
     getProyectosFromUser(user).then((list) => setProyectos(list || [])).catch(() => setProyectos([]));
   }, [user, esSuelto]);
+
+  // Plan suelto: catálogo de proveedores de la empresa para el autocomplete.
+  useEffect(() => {
+    if (!empresaId || !esSuelto) return;
+    proveedorService.getByEmpresa(empresaId).then((list) => setProveedoresEmpresa(list || [])).catch(() => setProveedoresEmpresa([]));
+  }, [empresaId, esSuelto]);
 
   // "Por avance" solo aplica dentro de una obra (devenga contra sus sub-rubros).
   const frecuencias = useMemo(() => (esSuelto ? FRECUENCIAS.filter((f) => f.value !== 'avance_obra') : FRECUENCIAS), [esSuelto]);
@@ -362,7 +372,7 @@ const NuevoPlanPagoPage = () => {
       //    suelto, va a nivel empresa con la caja (proyecto_id) elegida y el total manual.
       const base = {
         empresa_id: empresaId,
-        proveedor_id: seleccionado ? seleccionado.proveedor_id : null,
+        proveedor_id: seleccionado ? seleccionado.proveedor_id : (esSuelto ? proveedorIdSel : null),
         proveedor_nombre: proveedorNombre,
         nombre: planData.nombre.trim() || null,
         moneda: planData.moneda,
@@ -462,41 +472,67 @@ const NuevoPlanPagoPage = () => {
                       </TextField>
                     )}
 
-                    {/* Proveedor (en vez de cliente): candidatos = proveedores con contrato en la obra. */}
-                    {proveedores.length > 0 ? (
-                      <TextField
-                        select
-                        label="Proveedor *"
-                        value={proveedorSel}
-                        onChange={(e) => { setProveedorSel(e.target.value); setErrors((p) => ({ ...p, proveedor: '' })); }}
-                        error={!!errors.proveedor}
-                        helperText={errors.proveedor || 'Proveedores con contrato en la obra. Elegí uno o cargá otro.'}
-                        fullWidth
-                        SelectProps={{ native: true }}
-                        InputLabelProps={{ shrink: true }}
-                      >
-                        <option value="">Otro (escribir a mano)</option>
-                        {proveedores.map((p) => (
-                          <option key={p.proveedor_id || p.proveedor_nombre} value={p.proveedor_id || p.proveedor_nombre}>
-                            {p.proveedor_nombre}
-                          </option>
-                        ))}
-                      </TextField>
-                    ) : (
-                      <Typography variant="body2" color="text.secondary">
-                        No hay proveedores con contrato asignado en la obra. Escribí el nombre a mano.
-                      </Typography>
-                    )}
-
-                    {!seleccionado && (
-                      <TextField
-                        label="Nombre del proveedor *"
-                        value={proveedorLibre}
-                        onChange={(e) => { setProveedorLibre(e.target.value); setErrors((p) => ({ ...p, proveedor: '' })); }}
-                        error={!!errors.proveedor}
-                        helperText={errors.proveedor}
-                        fullWidth
+                    {/* Proveedor. Plan suelto: autocomplete del catálogo de la empresa
+                        (elegir uno o escribir uno nuevo). Con obra: proveedores con contrato. */}
+                    {esSuelto ? (
+                      <Autocomplete
+                        freeSolo
+                        options={proveedoresEmpresa}
+                        getOptionLabel={(o) => (typeof o === 'string' ? o : (o?.nombre || ''))}
+                        isOptionEqualToValue={(o, v) => (o?._id || o) === (v?._id || v)}
+                        inputValue={proveedorLibre}
+                        onInputChange={(_, v, reason) => { setProveedorLibre(v); if (reason === 'input') setProveedorIdSel(null); setErrors((p) => ({ ...p, proveedor: '' })); }}
+                        onChange={(_, v) => {
+                          if (v && typeof v === 'object') { setProveedorLibre(v.nombre || ''); setProveedorIdSel(v._id || null); }
+                        }}
+                        renderInput={(params) => (
+                          <TextField
+                            {...params}
+                            label="Proveedor *"
+                            error={!!errors.proveedor}
+                            helperText={errors.proveedor || 'Elegí uno de la empresa o escribí uno nuevo.'}
+                            fullWidth
+                          />
+                        )}
                       />
+                    ) : (
+                      <>
+                        {proveedores.length > 0 ? (
+                          <TextField
+                            select
+                            label="Proveedor *"
+                            value={proveedorSel}
+                            onChange={(e) => { setProveedorSel(e.target.value); setErrors((p) => ({ ...p, proveedor: '' })); }}
+                            error={!!errors.proveedor}
+                            helperText={errors.proveedor || 'Proveedores con contrato en la obra. Elegí uno o cargá otro.'}
+                            fullWidth
+                            SelectProps={{ native: true }}
+                            InputLabelProps={{ shrink: true }}
+                          >
+                            <option value="">Otro (escribir a mano)</option>
+                            {proveedores.map((p) => (
+                              <option key={p.proveedor_id || p.proveedor_nombre} value={p.proveedor_id || p.proveedor_nombre}>
+                                {p.proveedor_nombre}
+                              </option>
+                            ))}
+                          </TextField>
+                        ) : (
+                          <Typography variant="body2" color="text.secondary">
+                            No hay proveedores con contrato asignado en la obra. Escribí el nombre a mano.
+                          </Typography>
+                        )}
+
+                        {!seleccionado && (
+                          <TextField
+                            label="Nombre del proveedor *"
+                            value={proveedorLibre}
+                            onChange={(e) => { setProveedorLibre(e.target.value); setErrors((p) => ({ ...p, proveedor: '' })); }}
+                            error={!!errors.proveedor}
+                            helperText={errors.proveedor}
+                            fullWidth
+                          />
+                        )}
+                      </>
                     )}
 
                     <TextField

--- a/src/pages/pagos-proveedores/nuevo.js
+++ b/src/pages/pagos-proveedores/nuevo.js
@@ -36,6 +36,7 @@ import GridViewIcon from '@mui/icons-material/GridView';
 import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
+import { getProyectosFromUser } from 'src/services/proyectosService';
 import ControlObraService from 'src/services/controlObra/controlObraService';
 import planCobroService from 'src/services/planCobroService';
 import { CuotasTableEdit } from 'src/components/planCobro/CuotasTable';
@@ -103,10 +104,13 @@ const NuevoPlanPagoPage = () => {
   // El plan de pago SIEMPRE se crea dentro de una obra: ?obra=<id> es requerido
   // (a diferencia de cobros, donde la obra es opcional). Al guardar se asocia a esa obra.
   const obraId = router.query.obra ? String(router.query.obra) : null;
+  const esSuelto = !obraId; // plan de pago suelto: sin obra, elige proyecto/caja destino
   const [step, setStep] = useState(0);
   const [empresaId, setEmpresaId] = useState(null);
   const [obra, setObra] = useState(null);
   const [obraLoading, setObraLoading] = useState(true);
+  const [proyectos, setProyectos] = useState([]);
+  const [proyectoSel, setProyectoSel] = useState(''); // caja destino para el plan suelto
   const [proveedorSel, setProveedorSel] = useState(''); // key = proveedor_id || nombre
   const [proveedorLibre, setProveedorLibre] = useState('');
   const [planData, setPlanData] = useState(defaultPlan);
@@ -144,6 +148,15 @@ const NuevoPlanPagoPage = () => {
       .catch(() => setAlert({ open: true, message: 'No se pudo cargar la obra', severity: 'error' }))
       .finally(() => setObraLoading(false));
   }, [empresaId, obraId]);
+
+  // Plan suelto: cargar los proyectos/cajas de la empresa para elegir destino.
+  useEffect(() => {
+    if (!user || !esSuelto) return;
+    getProyectosFromUser(user).then((list) => setProyectos(list || [])).catch(() => setProyectos([]));
+  }, [user, esSuelto]);
+
+  // "Por avance" solo aplica dentro de una obra (devenga contra sus sub-rubros).
+  const frecuencias = useMemo(() => (esSuelto ? FRECUENCIAS.filter((f) => f.value !== 'avance_obra') : FRECUENCIAS), [esSuelto]);
 
   const proveedores = useMemo(() => proveedoresConContrato(obra), [obra]);
   const seleccionado = proveedores.find((p) => (p.proveedor_id || p.proveedor_nombre) === proveedorSel);
@@ -274,6 +287,7 @@ const NuevoPlanPagoPage = () => {
 
   const validarStep1 = () => {
     const errs = {};
+    if (esSuelto && !proyectoSel) errs.proyecto_id = 'Elegí el proyecto/caja destino';
     if (!proveedorNombre) errs.proveedor = 'Elegí o escribí un proveedor';
     if (!planData.nombre.trim()) errs.nombre = 'El nombre es requerido';
     if (!planData.moneda) errs.moneda = 'La moneda es requerida';
@@ -339,13 +353,14 @@ const NuevoPlanPagoPage = () => {
   const handleSubmit = async () => {
     const errs = validarStep3();
     if (Object.keys(errs).length > 0) { setErrors(errs); return; }
-    if (!obraId) { setAlert({ open: true, message: 'Falta la obra de destino (?obra=...)', severity: 'error' }); return; }
+    if (esSuelto && !proyectoSel) { setAlert({ open: true, message: 'Elegí el proyecto/caja destino', severity: 'error' }); return; }
 
     setSaving(true);
     try {
-      // 1) Crear el plan de pago dentro de la obra. El backend NO tiene "confirmar":
-      //    primero se crea el plan y después se agregan las cuotas una a una.
-      const plan = await ControlObraService.crearPlanPago(obraId, {
+      // 1) Crear el plan de pago. El backend NO tiene "confirmar": primero se crea el
+      //    plan y después se agregan las cuotas una a una. Con obra queda atado a ella;
+      //    suelto, va a nivel empresa con la caja (proyecto_id) elegida y el total manual.
+      const base = {
         empresa_id: empresaId,
         proveedor_id: seleccionado ? seleccionado.proveedor_id : null,
         proveedor_nombre: proveedorNombre,
@@ -356,7 +371,10 @@ const NuevoPlanPagoPage = () => {
         usd_fuente: planData.indexacion === 'USD' ? planData.usd_fuente : null,
         fecha_base: planData.fecha_base || null,
         notas: planData.notas.trim() || null,
-      });
+      };
+      const plan = esSuelto
+        ? await ControlObraService.crearPlanPagoEmpresa({ ...base, proyecto_id: proyectoSel, monto_total: montoTotal || null })
+        : await ControlObraService.crearPlanPago(obraId, base);
       if (!plan?._id) throw new Error('No se pudo crear el plan de pago');
 
       // 2) Agregar las cuotas (secuencial: cada agregarCuota reasigna número y devenga índice).
@@ -379,17 +397,12 @@ const NuevoPlanPagoPage = () => {
 
   const monedaDisplay = planData.moneda;
 
-  if (!obraLoading && !obraId) {
+  // En modo obra, esperamos a que cargue (para tener proveedores/monto referencial).
+  if (obraId && obraLoading) {
     return (
       <Box component="main" sx={{ flexGrow: 1, py: 4 }}>
-        <Container maxWidth="md">
-          <Alert severity="warning">
-            Los planes de pago se crean dentro de una obra. Abrí este asistente desde la obra
-            (botón <strong>Nuevo plan de pago</strong>) para que se asocie correctamente.
-          </Alert>
-          <Button sx={{ mt: 2 }} variant="outlined" onClick={() => router.push('/pagos-proveedores')}>
-            Volver a Planes de pago
-          </Button>
+        <Container maxWidth="md" sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
         </Container>
       </Box>
     );
@@ -405,9 +418,13 @@ const NuevoPlanPagoPage = () => {
           <Typography variant="h5" fontWeight={700} mb={1}>
             Nuevo plan de pago a proveedor
           </Typography>
-          {obra && (
+          {obra ? (
             <Typography variant="body2" color="text.secondary" mb={2}>
               Obra: <strong>{obra.titulo}</strong>
+            </Typography>
+          ) : (
+            <Typography variant="body2" color="text.secondary" mb={2}>
+              Plan suelto (sin obra) · se imputa a la caja del proyecto elegido
             </Typography>
           )}
 
@@ -425,6 +442,26 @@ const NuevoPlanPagoPage = () => {
               <Grid container spacing={4}>
                 <Grid item xs={12} md={6}>
                   <Stack spacing={3}>
+                    {/* Plan suelto: caja destino (proyecto). Con obra se hereda y no se muestra. */}
+                    {esSuelto && (
+                      <TextField
+                        select
+                        label="Proyecto / caja destino *"
+                        value={proyectoSel}
+                        onChange={(e) => { setProyectoSel(e.target.value); setErrors((p) => ({ ...p, proyecto_id: '' })); }}
+                        error={!!errors.proyecto_id}
+                        helperText={errors.proyecto_id || 'Los pagos de este plan se registran como egreso en esta caja.'}
+                        fullWidth
+                        SelectProps={{ native: true }}
+                        InputLabelProps={{ shrink: true }}
+                      >
+                        <option value="">Elegí un proyecto…</option>
+                        {proyectos.map((p) => (
+                          <option key={p.id} value={p.id}>{p.nombre}</option>
+                        ))}
+                      </TextField>
+                    )}
+
                     {/* Proveedor (en vez de cliente): candidatos = proveedores con contrato en la obra. */}
                     {proveedores.length > 0 ? (
                       <TextField
@@ -755,7 +792,7 @@ const NuevoPlanPagoPage = () => {
                             <Stack spacing={0.5}>
                               <Typography variant="caption" color="text.secondary">Frecuencia</Typography>
                               <Stack direction="row" spacing={1} flexWrap="wrap">
-                                {FRECUENCIAS.map((f) => (
+                                {frecuencias.map((f) => (
                                   <Button
                                     key={f.value}
                                     variant={generador.frecuencia === f.value ? 'contained' : 'outlined'}

--- a/src/pages/pagos-proveedores/nuevo.js
+++ b/src/pages/pagos-proveedores/nuevo.js
@@ -1,0 +1,1280 @@
+import { useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Container,
+  Divider,
+  Fade,
+  FormControlLabel,
+  Grid,
+  InputAdornment,
+  Paper,
+  Radio,
+  Snackbar,
+  Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  Switch,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import ReplayIcon from '@mui/icons-material/Replay';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import AutorenewIcon from '@mui/icons-material/Autorenew';
+import ViewListIcon from '@mui/icons-material/ViewList';
+import GridViewIcon from '@mui/icons-material/GridView';
+import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
+import { useAuthContext } from 'src/contexts/auth-context';
+import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
+import ControlObraService from 'src/services/controlObra/controlObraService';
+import planCobroService from 'src/services/planCobroService';
+import { CuotasTableEdit } from 'src/components/planCobro/CuotasTable';
+import { formatCurrency, formatNumberInput, parseNumberInput } from 'src/utils/formatters';
+
+const STEPS = ['Datos del plan', 'Distribución', 'Ajustar montos', 'Confirmar'];
+
+// Frecuencias soportadas por el backend de pago (semanal | quincenal | mensual)
+// + avance de obra (cuotas por avance devengado del proveedor, se generan luego).
+const FRECUENCIAS = [
+  { value: 'mensual',     label: 'Mensual',        dias: null },
+  { value: 'quincenal',   label: 'Quincenal',      dias: 15   },
+  { value: 'semanal',     label: 'Semanal',        dias: 7    },
+  { value: 'avance_obra', label: 'Por avance',     dias: null },
+];
+
+const FRECUENCIA_LABELS = {
+  mensual: 'mensuales', quincenal: 'quincenales', semanal: 'semanales', avance_obra: 'por avance de obra',
+};
+
+const defaultPlan = {
+  nombre: '',
+  monto_total: '',
+  moneda: 'ARS',
+  indexacion: '',
+  cac_tipo: 'general',
+  usd_fuente: 'blue',
+  usd_valor_manual: '',
+  fecha_base: '',
+  notas: '',
+};
+
+const addDays = (dateStr, days) => {
+  const d = new Date(dateStr + 'T12:00:00');
+  d.setDate(d.getDate() + days);
+  return d.toISOString().split('T')[0];
+};
+
+const addMonths = (dateStr, months) => {
+  const d = new Date(dateStr + 'T12:00:00');
+  d.setMonth(d.getMonth() + months);
+  return d.toISOString().split('T')[0];
+};
+
+const todayIso = () => new Date().toISOString().split('T')[0];
+
+// Proveedores con contrato asignado a alguna tarea de la obra (candidatos a plan de pago).
+// Espejo de la lógica de ManoObraTab (fuente de proveedores del lado costo).
+function proveedoresConContrato(obra) {
+  const map = new Map();
+  for (const r of obra?.rubros || []) {
+    for (const s of r.subrubros || []) {
+      const c = s.contrato_proveedor;
+      if (!c || !c.proveedor_nombre) continue;
+      const key = c.proveedor_id || c.proveedor_nombre;
+      if (!map.has(key)) map.set(key, { proveedor_id: c.proveedor_id || null, proveedor_nombre: c.proveedor_nombre });
+    }
+  }
+  return Array.from(map.values());
+}
+
+const NuevoPlanPagoPage = () => {
+  const { user } = useAuthContext();
+  const router = useRouter();
+  // El plan de pago SIEMPRE se crea dentro de una obra: ?obra=<id> es requerido
+  // (a diferencia de cobros, donde la obra es opcional). Al guardar se asocia a esa obra.
+  const obraId = router.query.obra ? String(router.query.obra) : null;
+  const [step, setStep] = useState(0);
+  const [empresaId, setEmpresaId] = useState(null);
+  const [obra, setObra] = useState(null);
+  const [obraLoading, setObraLoading] = useState(true);
+  const [proveedorSel, setProveedorSel] = useState(''); // key = proveedor_id || nombre
+  const [proveedorLibre, setProveedorLibre] = useState('');
+  const [planData, setPlanData] = useState(defaultPlan);
+  const [cuotas, setCuotas] = useState([]);
+  const [errors, setErrors] = useState({});
+  const [saving, setSaving] = useState(false);
+  const [alert, setAlert] = useState({ open: false, message: '', severity: 'info' });
+
+  // CAC / USD preview (reusa el servicio de cobros: los índices son globales de la empresa).
+  const [cacPreview, setCacPreview] = useState(null);
+  const [cacLoading, setCacLoading] = useState(false);
+  const [usdPreview, setUsdPreview] = useState(null);
+  const [usdLoading, setUsdLoading] = useState(false);
+
+  // Generador de cuotas (bloques componibles: anticipo / refuerzos).
+  const [generador, setGenerador] = useState({ cantidad: '', frecuencia: 'mensual', fecha_inicio: '', usarAnticipo: false, usarRefuerzo: false, anticipo_pct: '20', refuerzo_pct: '15', intervalo_meses: '6', refuerzo_modo: 'sumar' });
+  const [modoDistribucion, setModoDistribucion] = useState('iguales'); // 'iguales' | 'personalizados'
+  const [cantPersonalizados, setCantPersonalizados] = useState('');
+  const [usaPorcentaje, setUsaPorcentaje] = useState(false);
+  const [porcentajes, setPorcentajes] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+    getEmpresaDetailsFromUser(user).then((empresa) => {
+      if (empresa?.id) setEmpresaId(empresa.id);
+    });
+  }, [user]);
+
+  // Carga la obra a la que se asociará el plan (proveedores con contrato + monto referencial).
+  useEffect(() => {
+    if (!empresaId || !obraId) { if (!obraId) setObraLoading(false); return; }
+    setObraLoading(true);
+    ControlObraService.obtenerObra(obraId, empresaId)
+      .then((o) => setObra(o || null))
+      .catch(() => setAlert({ open: true, message: 'No se pudo cargar la obra', severity: 'error' }))
+      .finally(() => setObraLoading(false));
+  }, [empresaId, obraId]);
+
+  const proveedores = useMemo(() => proveedoresConContrato(obra), [obra]);
+  const seleccionado = proveedores.find((p) => (p.proveedor_id || p.proveedor_nombre) === proveedorSel);
+  const proveedorNombre = seleccionado ? seleccionado.proveedor_nombre : proveedorLibre.trim();
+
+  // Al elegir un proveedor con contrato, pre-llenar el nombre y el total referencial
+  // (suma de contratos de ese proveedor en la obra).
+  useEffect(() => {
+    if (!seleccionado || !obra) return;
+    const key = seleccionado.proveedor_id || seleccionado.proveedor_nombre;
+    let total = 0;
+    for (const r of obra.rubros || []) {
+      for (const s of r.subrubros || []) {
+        const c = s.contrato_proveedor;
+        if (c && (c.proveedor_id || c.proveedor_nombre) === key) total += c.monto || 0;
+      }
+    }
+    setPlanData((prev) => ({
+      ...prev,
+      nombre: prev.nombre || `Pagos: ${seleccionado.proveedor_nombre}`,
+      monto_total: prev.monto_total || (total > 0 ? String(Math.round(total * 100) / 100) : ''),
+    }));
+  }, [seleccionado, obra]);
+
+  // Preview CAC
+  useEffect(() => {
+    if (planData.indexacion !== 'CAC' || !planData.fecha_base) { setCacPreview(null); return; }
+    setCacLoading(true);
+    planCobroService.previewCAC(planData.fecha_base, planData.cac_tipo)
+      .then((res) => { const d = res?.data; setCacPreview(d?.ok ? d.data : null); })
+      .catch(() => setCacPreview(null))
+      .finally(() => setCacLoading(false));
+  }, [planData.indexacion, planData.fecha_base, planData.cac_tipo]);
+
+  // Preview USD
+  useEffect(() => {
+    if (planData.indexacion !== 'USD' || !planData.fecha_base) { setUsdPreview(null); return; }
+    setUsdLoading(true);
+    planCobroService.previewUSD(planData.fecha_base, planData.usd_fuente)
+      .then((res) => { const d = res?.data; setUsdPreview(d?.ok ? d.data : null); })
+      .catch(() => setUsdPreview(null))
+      .finally(() => setUsdLoading(false));
+  }, [planData.indexacion, planData.fecha_base, planData.usd_fuente]);
+
+  const handleFieldChange = (field) => (e) => {
+    const val = field === 'monto_total' ? parseNumberInput(e.target.value) : e.target.value;
+    setPlanData((prev) => ({ ...prev, [field]: val }));
+    setErrors((prev) => ({ ...prev, [field]: '' }));
+  };
+
+  // Genera la lista de cuotas a partir de la config actual (pura, sin efectos).
+  const buildCuotas = () => {
+    const cant = parseInt(generador.cantidad, 10);
+    if (!cant || cant < 1) return [];
+    const freq = FRECUENCIAS.find((f) => f.value === generador.frecuencia);
+    const esAvance = freq?.value === 'avance_obra';
+    if (!esAvance && !generador.fecha_inicio) return [];
+    const montoT = Number(planData.monto_total) || 0;
+    const inicio = generador.fecha_inicio;
+    const fechaDe = (i) => {
+      if (esAvance || !inicio) return '';
+      if (freq.value === 'mensual') return addMonths(inicio, i);
+      return addDays(inicio, freq.dias * i);
+    };
+    const r2 = (n) => Math.round(n * 100) / 100;
+
+    const usarAnticipo = !!generador.usarAnticipo && montoT > 0;
+    const usarRefuerzo = !!generador.usarRefuerzo && montoT > 0;
+    const intervalo = Math.max(1, parseInt(generador.intervalo_meses, 10) || 6);
+    const anticipo = usarAnticipo ? r2(montoT * (Number(generador.anticipo_pct) || 0) / 100) : 0;
+    const refuerzo = usarRefuerzo ? r2(montoT * (Number(generador.refuerzo_pct) || 0) / 100) : 0;
+    const nRefuerzos = usarRefuerzo
+      ? Array.from({ length: cant }, (_, i) => i + 1).filter((m) => m % intervalo === 0).length
+      : 0;
+
+    if (montoT > 0) {
+      const reemplaza = usarRefuerzo && generador.refuerzo_modo === 'reemplazar';
+      const resto = r2(montoT - anticipo - refuerzo * nRefuerzos);
+      const baseDiv = reemplaza ? Math.max(1, cant - nRefuerzos) : cant;
+      const base = Math.max(0, r2(resto / baseDiv));
+      return [
+        ...(usarAnticipo ? [{ fecha_vencimiento: inicio || '', monto: String(anticipo), descripcion: 'Anticipo' }] : []),
+        ...Array.from({ length: cant }, (_, i) => {
+          const mes = i + 1;
+          const esRefuerzo = usarRefuerzo && mes % intervalo === 0;
+          const monto = esRefuerzo ? (reemplaza ? refuerzo : r2(base + refuerzo)) : base;
+          return {
+            fecha_vencimiento: fechaDe(usarAnticipo ? mes : i),
+            monto: String(monto),
+            descripcion: esRefuerzo ? (reemplaza ? `Refuerzo ${mes}` : `Cuota ${mes} + refuerzo`) : `Cuota ${mes}`,
+          };
+        }),
+      ];
+    }
+    return Array.from({ length: cant }, (_, i) => ({
+      fecha_vencimiento: fechaDe(i),
+      monto: '',
+      descripcion: `Cuota ${i + 1}`,
+    }));
+  };
+
+  const handleGenerar = () => setCuotas(buildCuotas());
+
+  const sumaCuotas = useMemo(() => cuotas.reduce((s, c) => s + (Number(c.monto) || 0), 0), [cuotas]);
+  const previewCuotas = useMemo(buildCuotas, [generador, planData.monto_total]); // eslint-disable-line react-hooks/exhaustive-deps
+  const previewSuma = previewCuotas.reduce((s, c) => s + (Number(c.monto) || 0), 0);
+
+  const montoTotal = Number(planData.monto_total) || 0;
+  const usdIndiceEfectivo = (() => {
+    const manual = parseFloat(parseNumberInput(planData.usd_valor_manual || ''));
+    if (planData.indexacion === 'USD' && Number.isFinite(manual) && manual > 0) return manual;
+    const preview = Number(usdPreview?.dolar_indice);
+    return Number.isFinite(preview) && preview > 0 ? preview : null;
+  })();
+  const montoTotalEnCAC =
+    planData.indexacion === 'CAC' && cacPreview?.cac_indice && montoTotal > 0
+      ? Math.round((montoTotal / cacPreview.cac_indice) * 100) / 100
+      : null;
+  const montoTotalEnUSD =
+    planData.indexacion === 'USD' && usdIndiceEfectivo && montoTotal > 0
+      ? Math.round((montoTotal / usdIndiceEfectivo) * 100) / 100
+      : null;
+  const cuotasConFecha = cuotas.filter((c) => !!c.fecha_vencimiento).length;
+  const cuotasConMonto = cuotas.filter((c) => Number(c.monto) > 0).length;
+  const porcentajeDistribuido = montoTotal > 0 ? Math.round((sumaCuotas / montoTotal) * 1000) / 10 : 0;
+  const sumaDiff = montoTotal > 0 ? Math.abs(sumaCuotas - montoTotal) : 0;
+  const sumaOk = montoTotal > 0 && sumaDiff < 0.01;
+
+  const validarStep1 = () => {
+    const errs = {};
+    if (!proveedorNombre) errs.proveedor = 'Elegí o escribí un proveedor';
+    if (!planData.nombre.trim()) errs.nombre = 'El nombre es requerido';
+    if (!planData.moneda) errs.moneda = 'La moneda es requerida';
+    if (!montoTotal || montoTotal <= 0) errs.monto_total = 'El monto total debe ser mayor a 0';
+    if (planData.indexacion && planData.indexacion !== 'manual' && !planData.fecha_base)
+      errs.fecha_base = 'La fecha base es requerida para planes indexados';
+    return errs;
+  };
+
+  const validarStep2 = () => {
+    const errs = {};
+    if (modoDistribucion === 'iguales' && generador.cantidad && parseInt(generador.cantidad, 10) >= 1) {
+      if (generador.frecuencia !== 'avance_obra' && !generador.fecha_inicio)
+        errs.generador = 'Ingresá la fecha de la primera cuota';
+    }
+    return errs;
+  };
+
+  const validarStep3 = () => {
+    if (cuotas.length === 0) return { cuotas: 'Agregá al menos una cuota' };
+    const requireFecha = !!planData.indexacion || (modoDistribucion === 'iguales' && generador.frecuencia !== 'avance_obra');
+    for (const c of cuotas) {
+      if (requireFecha && !c.fecha_vencimiento) return { cuotas: 'Todas las cuotas deben tener fecha de vencimiento' };
+      if (!c.monto || isNaN(c.monto) || Number(c.monto) <= 0)
+        return { cuotas: 'Todos los montos deben ser mayores a 0' };
+    }
+    return {};
+  };
+
+  const handleNext = () => {
+    if (step === 0) {
+      const errs = validarStep1();
+      if (Object.keys(errs).length > 0) { setErrors(errs); return; }
+    }
+    if (step === 1) {
+      const errs = validarStep2();
+      if (Object.keys(errs).length > 0) { setErrors(errs); return; }
+      if (modoDistribucion === 'iguales') {
+        handleGenerar();
+      } else {
+        const cant = parseInt(cantPersonalizados, 10);
+        if (cant > 0 && usaPorcentaje) {
+          setCuotas(porcentajes.map((pct, i) => ({
+            fecha_vencimiento: '',
+            monto: montoTotal > 0 ? String(Math.round(montoTotal * (Number(pct) || 0) / 100 * 100) / 100) : '',
+            descripcion: `Cuota ${i + 1}`,
+          })));
+        } else if (cant > 0) {
+          setCuotas(Array.from({ length: cant }, (_, i) => ({ fecha_vencimiento: '', monto: '', descripcion: `Cuota ${i + 1}` })));
+        } else if (cuotas.length === 0) {
+          setCuotas([{ fecha_vencimiento: '', monto: '', descripcion: '' }]);
+        }
+      }
+    }
+    if (step === 2) {
+      const errs = validarStep3();
+      if (Object.keys(errs).length > 0) { setErrors(errs); return; }
+    }
+    setErrors({});
+    setStep((s) => s + 1);
+  };
+
+  const handleSubmit = async () => {
+    const errs = validarStep3();
+    if (Object.keys(errs).length > 0) { setErrors(errs); return; }
+    if (!obraId) { setAlert({ open: true, message: 'Falta la obra de destino (?obra=...)', severity: 'error' }); return; }
+
+    setSaving(true);
+    try {
+      // 1) Crear el plan de pago dentro de la obra. El backend NO tiene "confirmar":
+      //    primero se crea el plan y después se agregan las cuotas una a una.
+      const plan = await ControlObraService.crearPlanPago(obraId, {
+        empresa_id: empresaId,
+        proveedor_id: seleccionado ? seleccionado.proveedor_id : null,
+        proveedor_nombre: proveedorNombre,
+        nombre: planData.nombre.trim() || null,
+        moneda: planData.moneda,
+        indexacion: planData.indexacion || null,
+        cac_tipo: planData.indexacion === 'CAC' ? planData.cac_tipo : null,
+        usd_fuente: planData.indexacion === 'USD' ? planData.usd_fuente : null,
+        fecha_base: planData.fecha_base || null,
+        notas: planData.notas.trim() || null,
+      });
+      if (!plan?._id) throw new Error('No se pudo crear el plan de pago');
+
+      // 2) Agregar las cuotas (secuencial: cada agregarCuota reasigna número y devenga índice).
+      for (const c of cuotas) {
+        await ControlObraService.agregarCuotaPago(plan._id, {
+          empresa_id: empresaId,
+          tipo: 'fija',
+          descripcion: c.descripcion || null,
+          fecha_vencimiento: c.fecha_vencimiento || null,
+          monto: Number(c.monto),
+        });
+      }
+
+      router.push(`/pagos-proveedores/${plan._id}`);
+    } catch (err) {
+      setAlert({ open: true, message: err?.response?.data?.error?.message || err.message || 'Error al guardar el plan', severity: 'error' });
+      setSaving(false);
+    }
+  };
+
+  const monedaDisplay = planData.moneda;
+
+  if (!obraLoading && !obraId) {
+    return (
+      <Box component="main" sx={{ flexGrow: 1, py: 4 }}>
+        <Container maxWidth="md">
+          <Alert severity="warning">
+            Los planes de pago se crean dentro de una obra. Abrí este asistente desde la obra
+            (botón <strong>Nuevo plan de pago</strong>) para que se asocie correctamente.
+          </Alert>
+          <Button sx={{ mt: 2 }} variant="outlined" onClick={() => router.push('/pagos-proveedores')}>
+            Volver a Planes de pago
+          </Button>
+        </Container>
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Nuevo Plan de Pago | Sorby</title>
+      </Head>
+      <Box component="main" sx={{ flexGrow: 1, py: 4 }}>
+        <Container maxWidth="lg">
+          <Typography variant="h5" fontWeight={700} mb={1}>
+            Nuevo plan de pago a proveedor
+          </Typography>
+          {obra && (
+            <Typography variant="body2" color="text.secondary" mb={2}>
+              Obra: <strong>{obra.titulo}</strong>
+            </Typography>
+          )}
+
+          <Stepper activeStep={step} sx={{ mb: 4 }}>
+            {STEPS.map((label, i) => (
+              <Step key={label} completed={step > i}>
+                <StepLabel>{label}</StepLabel>
+              </Step>
+            ))}
+          </Stepper>
+
+          {/* ─── PASO 0: DATOS GENERALES ─── */}
+          <Fade in={step === 0} mountOnEnter unmountOnExit>
+            <Box sx={{ display: step === 0 ? 'block' : 'none' }}>
+              <Grid container spacing={4}>
+                <Grid item xs={12} md={6}>
+                  <Stack spacing={3}>
+                    {/* Proveedor (en vez de cliente): candidatos = proveedores con contrato en la obra. */}
+                    {proveedores.length > 0 ? (
+                      <TextField
+                        select
+                        label="Proveedor *"
+                        value={proveedorSel}
+                        onChange={(e) => { setProveedorSel(e.target.value); setErrors((p) => ({ ...p, proveedor: '' })); }}
+                        error={!!errors.proveedor}
+                        helperText={errors.proveedor || 'Proveedores con contrato en la obra. Elegí uno o cargá otro.'}
+                        fullWidth
+                        SelectProps={{ native: true }}
+                        InputLabelProps={{ shrink: true }}
+                      >
+                        <option value="">Otro (escribir a mano)</option>
+                        {proveedores.map((p) => (
+                          <option key={p.proveedor_id || p.proveedor_nombre} value={p.proveedor_id || p.proveedor_nombre}>
+                            {p.proveedor_nombre}
+                          </option>
+                        ))}
+                      </TextField>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        No hay proveedores con contrato asignado en la obra. Escribí el nombre a mano.
+                      </Typography>
+                    )}
+
+                    {!seleccionado && (
+                      <TextField
+                        label="Nombre del proveedor *"
+                        value={proveedorLibre}
+                        onChange={(e) => { setProveedorLibre(e.target.value); setErrors((p) => ({ ...p, proveedor: '' })); }}
+                        error={!!errors.proveedor}
+                        helperText={errors.proveedor}
+                        fullWidth
+                      />
+                    )}
+
+                    <TextField
+                      label="Nombre del plan *"
+                      value={planData.nombre}
+                      onChange={handleFieldChange('nombre')}
+                      error={!!errors.nombre}
+                      helperText={errors.nombre}
+                      fullWidth
+                    />
+
+                    <Stack direction="row" spacing={1} alignItems="flex-start">
+                      <ToggleButtonGroup
+                        value={planData.moneda}
+                        exclusive
+                        onChange={(_, val) => {
+                          if (!val) return;
+                          setPlanData((prev) => ({ ...prev, moneda: val, indexacion: val === 'USD' ? '' : prev.indexacion }));
+                          setErrors((prev) => ({ ...prev, moneda: '' }));
+                        }}
+                        sx={{ height: 56, '& .MuiToggleButton-root': { px: 2, fontWeight: 600 } }}
+                      >
+                        <ToggleButton value="ARS">ARS</ToggleButton>
+                        <ToggleButton value="USD">USD</ToggleButton>
+                      </ToggleButtonGroup>
+                      <TextField
+                        label="Monto total a pagar *"
+                        value={formatNumberInput(planData.monto_total)}
+                        onChange={handleFieldChange('monto_total')}
+                        error={!!errors.monto_total}
+                        helperText={
+                          errors.monto_total ||
+                          (montoTotalEnCAC
+                            ? `Equivale a ${montoTotalEnCAC.toLocaleString('es-AR', { maximumFractionDigits: 2 })} CAC al índice seleccionado`
+                            : montoTotalEnUSD
+                              ? `Equivale a ${montoTotalEnUSD.toLocaleString('es-AR', { maximumFractionDigits: 2 })} USD al tipo de cambio seleccionado`
+                              : (seleccionado ? 'Prellenado con la suma de contratos del proveedor.' : ' '))
+                        }
+                        fullWidth
+                        inputProps={{ inputMode: 'decimal' }}
+                        InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                      />
+                    </Stack>
+
+                    {planData.indexacion === 'CAC' && cacPreview?.cac_indice && (
+                      <TextField
+                        label="…o ingresá el total en CAC"
+                        value={montoTotalEnCAC ? String(Math.round(montoTotalEnCAC * 100) / 100) : ''}
+                        onChange={(e) => {
+                          const raw = e.target.value.replace(/[^\d.,]/g, '').replace(',', '.');
+                          const units = parseFloat(raw);
+                          const pesos = !isNaN(units) ? Math.round(units * cacPreview.cac_indice * 100) / 100 : '';
+                          setPlanData((prev) => ({ ...prev, monto_total: pesos === '' ? '' : String(pesos) }));
+                        }}
+                        size="small"
+                        inputProps={{ inputMode: 'decimal' }}
+                        InputProps={{ endAdornment: <InputAdornment position="end">CAC</InputAdornment> }}
+                        helperText={`Se convierte a pesos con el índice base ${cacPreview.cac_indice.toLocaleString('es-AR')}`}
+                        fullWidth
+                      />
+                    )}
+
+                    <TextField
+                      label="Notas"
+                      value={planData.notas}
+                      onChange={handleFieldChange('notas')}
+                      multiline
+                      rows={3}
+                      fullWidth
+                      placeholder="Observaciones adicionales..."
+                    />
+                  </Stack>
+                </Grid>
+
+                {/* Columna derecha: Indexación (espejo exacto de cobros) */}
+                <Grid item xs={12} md={6}>
+                  <Paper variant="outlined" sx={{ p: 3, borderRadius: 2, bgcolor: 'grey.50', height: '100%' }}>
+                    <Typography variant="subtitle1" fontWeight={600} mb={2}>Indexación</Typography>
+
+                    {planData.moneda === 'USD' ? (
+                      <Stack direction="row" alignItems="center" spacing={1} sx={{ p: 2 }}>
+                        <InfoOutlinedIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
+                        <Typography variant="body2" color="text.secondary">
+                          Al operar en dólares no se aplica indexación.
+                        </Typography>
+                      </Stack>
+                    ) : (
+                      <>
+                        <Typography variant="body2" color="text.secondary" mb={1.5}>Ajuste por inflación</Typography>
+                        <Stack spacing={1} mb={3}>
+                          {[
+                            { value: '', label: 'Sin ajuste (pesos fijos)' },
+                            { value: 'CAC', label: 'CAC (Cámara de la Construcción)' },
+                            { value: 'USD', label: 'Dólar (indexado a tipo de cambio)' },
+                            { value: 'manual', label: 'Ajuste manual (lo ajustás vos cada tanto)' },
+                          ].map((opt) => (
+                            <Paper
+                              key={opt.value}
+                              variant="outlined"
+                              onClick={() => {
+                                setPlanData((prev) => ({
+                                  ...prev,
+                                  indexacion: opt.value,
+                                  fecha_base: opt.value && !prev.fecha_base ? todayIso() : prev.fecha_base,
+                                }));
+                                setErrors((prev) => ({ ...prev, moneda: '' }));
+                              }}
+                              sx={{
+                                p: 1.5, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 1.5,
+                                borderColor: planData.indexacion === opt.value ? 'primary.main' : 'divider',
+                                borderWidth: planData.indexacion === opt.value ? 2 : 1,
+                                bgcolor: planData.indexacion === opt.value ? 'primary.50' : 'background.paper',
+                                transition: 'all 0.15s', '&:hover': { borderColor: 'primary.light' },
+                              }}
+                            >
+                              <Radio checked={planData.indexacion === opt.value} size="small" sx={{ p: 0 }} />
+                              <Typography variant="body2" fontWeight={planData.indexacion === opt.value ? 600 : 400}>
+                                {opt.label}
+                              </Typography>
+                            </Paper>
+                          ))}
+                        </Stack>
+
+                        {planData.indexacion === 'CAC' && (
+                          <>
+                            <Typography variant="body2" color="text.secondary" mb={1}>Tipo de índice CAC</Typography>
+                            <ToggleButtonGroup
+                              value={planData.cac_tipo}
+                              exclusive
+                              onChange={(_, val) => { if (val) setPlanData((prev) => ({ ...prev, cac_tipo: val })); }}
+                              size="small"
+                              sx={{ mb: 3 }}
+                            >
+                              <ToggleButton value="general">Promedio</ToggleButton>
+                              <ToggleButton value="mano_obra">M. de Obra</ToggleButton>
+                              <ToggleButton value="materiales">Materiales</ToggleButton>
+                            </ToggleButtonGroup>
+
+                            <Paper variant="outlined" sx={{ p: 2, bgcolor: 'info.50', borderColor: 'info.200', borderRadius: 1.5 }}>
+                              <Stack direction="row" justifyContent="space-between" alignItems="center" mb={1}>
+                                <Typography variant="body2" color="text.secondary">Fecha base</Typography>
+                                <TextField
+                                  type="date" size="small"
+                                  value={planData.fecha_base}
+                                  onChange={handleFieldChange('fecha_base')}
+                                  InputLabelProps={{ shrink: true }}
+                                  error={!!errors.fecha_base}
+                                  sx={{ width: 170 }}
+                                />
+                              </Stack>
+                              {cacLoading && (
+                                <Stack direction="row" alignItems="center" spacing={1}>
+                                  <CircularProgress size={14} />
+                                  <Typography variant="caption" color="text.secondary">Consultando índice...</Typography>
+                                </Stack>
+                              )}
+                              {cacPreview && !cacLoading && (
+                                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                                  <Typography variant="body2" color="text.secondary">Índice aplicado</Typography>
+                                  <Typography variant="body2" fontWeight={700} color="primary.main">
+                                    CAC {planData.cac_tipo === 'general' ? 'Promedio' : planData.cac_tipo === 'mano_obra' ? 'M. Obra' : 'Mat.'}{' '}
+                                    {cacPreview.cac_fecha || ''} = {cacPreview.cac_indice}
+                                  </Typography>
+                                </Stack>
+                              )}
+                            </Paper>
+                          </>
+                        )}
+
+                        {planData.indexacion === 'USD' && (
+                          <>
+                            <Typography variant="body2" color="text.secondary" mb={1}>Cotización de dólar</Typography>
+                            <ToggleButtonGroup
+                              value={planData.usd_fuente}
+                              exclusive
+                              onChange={(_, val) => { if (val) setPlanData((prev) => ({ ...prev, usd_fuente: val })); }}
+                              size="small"
+                              sx={{ mb: 3 }}
+                            >
+                              <ToggleButton value="blue">USD Blue</ToggleButton>
+                              <ToggleButton value="oficial">USD Oficial</ToggleButton>
+                            </ToggleButtonGroup>
+
+                            <Paper variant="outlined" sx={{ p: 2, bgcolor: 'info.50', borderColor: 'info.200', borderRadius: 1.5 }}>
+                              <Stack direction="row" justifyContent="space-between" alignItems="center" mb={1}>
+                                <Typography variant="body2" color="text.secondary">Fecha base</Typography>
+                                <TextField
+                                  type="date" size="small"
+                                  value={planData.fecha_base}
+                                  onChange={handleFieldChange('fecha_base')}
+                                  InputLabelProps={{ shrink: true }}
+                                  error={!!errors.fecha_base}
+                                  sx={{ width: 170 }}
+                                />
+                              </Stack>
+                              {usdLoading && (
+                                <Stack direction="row" alignItems="center" spacing={1}>
+                                  <CircularProgress size={14} />
+                                  <Typography variant="caption" color="text.secondary">Consultando cotización...</Typography>
+                                </Stack>
+                              )}
+                              {usdPreview && !usdLoading && (
+                                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                                  <Typography variant="body2" color="text.secondary">Tipo de cambio aplicado</Typography>
+                                  <Typography variant="body2" fontWeight={700} color="primary.main">
+                                    USD {planData.usd_fuente === 'oficial' ? 'Oficial' : 'Blue'} {usdPreview.dolar_fecha || ''} = ${Number(usdPreview.dolar_indice).toLocaleString('es-AR')}
+                                  </Typography>
+                                </Stack>
+                              )}
+                              {!planData.usd_valor_manual ? (
+                                <Typography
+                                  variant="caption" color="text.disabled"
+                                  sx={{ display: 'block', mt: 1, cursor: 'pointer', '&:hover': { color: 'text.secondary' } }}
+                                  onClick={() => setPlanData((prev) => ({ ...prev, usd_valor_manual: usdPreview?.dolar_indice ? String(usdPreview.dolar_indice) : '' }))}
+                                >
+                                  Modificar valor base manualmente…
+                                </Typography>
+                              ) : (
+                                <Stack spacing={1} sx={{ mt: 1.5, p: 1.5, bgcolor: 'grey.50', borderRadius: 1 }}>
+                                  <Stack direction="row" justifyContent="space-between" alignItems="center">
+                                    <Typography variant="caption" color="text.secondary" fontWeight={600}>Dólar personalizado</Typography>
+                                    <Typography variant="caption" color="primary" sx={{ cursor: 'pointer' }} onClick={() => setPlanData((prev) => ({ ...prev, usd_valor_manual: '' }))}>
+                                      Usar automático
+                                    </Typography>
+                                  </Stack>
+                                  <TextField
+                                    size="small" type="number"
+                                    label={`USD ${planData.usd_fuente === 'oficial' ? 'Oficial' : 'Blue'} manual`}
+                                    placeholder={`Ej: ${usdPreview?.dolar_indice || '1405'}`}
+                                    value={planData.usd_valor_manual}
+                                    onChange={(e) => setPlanData((prev) => ({ ...prev, usd_valor_manual: e.target.value }))}
+                                    fullWidth
+                                  />
+                                </Stack>
+                              )}
+                            </Paper>
+                          </>
+                        )}
+                      </>
+                    )}
+                  </Paper>
+                </Grid>
+              </Grid>
+
+              <Stack direction="row" justifyContent="flex-end" spacing={2} mt={4}>
+                <Button variant="outlined" onClick={() => router.push(obraId ? `/control-obra/${obraId}` : '/pagos-proveedores')}>
+                  Cancelar
+                </Button>
+                <Button variant="contained" onClick={handleNext} sx={{ px: 4 }}>Continuar →</Button>
+              </Stack>
+            </Box>
+          </Fade>
+
+          {/* ─── PASO 1: DISTRIBUCIÓN ─── */}
+          <Fade in={step === 1} mountOnEnter unmountOnExit>
+            <Box sx={{ display: step === 1 ? 'block' : 'none' }}>
+              <Stack direction="row" justifyContent="space-between" alignItems="baseline" mb={3} flexWrap="wrap" useFlexGap>
+                <Box>
+                  <Typography variant="h6" fontWeight={600} mb={0.5}>
+                    {modoDistribucion === 'personalizados' ? 'Definí tus cuotas' : '¿Cómo distribuir los pagos?'}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Total a pagar: <strong>{formatCurrency(montoTotal, monedaDisplay)}</strong>
+                  </Typography>
+                </Box>
+                <Button
+                  variant="text" size="small"
+                  startIcon={modoDistribucion === 'iguales' ? <ViewListIcon /> : <GridViewIcon />}
+                  onClick={() => setModoDistribucion(modoDistribucion === 'iguales' ? 'personalizados' : 'iguales')}
+                  sx={{ textTransform: 'none' }}
+                >
+                  {modoDistribucion === 'iguales' ? 'Prefiero cargar montos personalizados' : 'Volver a cuotas iguales'}
+                </Button>
+              </Stack>
+
+              <Grid container spacing={3}>
+                <Grid item xs={12} xl={8}>
+                  {modoDistribucion === 'iguales' && (
+                    <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+                      <Stack spacing={2}>
+                        {/* Bloque 1 — Cuotas base */}
+                        <Paper variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+                          <Typography variant="subtitle2" fontWeight={700}>Cuotas</Typography>
+                          <Typography variant="caption" color="text.secondary">En cuántas cuotas se reparte el pago y con qué frecuencia.</Typography>
+                          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="flex-start" flexWrap="wrap" mt={1.5}>
+                            <TextField
+                              label="Cantidad de cuotas" type="number" size="small"
+                              value={generador.cantidad}
+                              onChange={(e) => setGenerador((g) => ({ ...g, cantidad: e.target.value }))}
+                              error={!!errors.generador}
+                              sx={{ width: 140 }} inputProps={{ min: 1 }}
+                            />
+                            <Stack spacing={0.5}>
+                              <Typography variant="caption" color="text.secondary">Frecuencia</Typography>
+                              <Stack direction="row" spacing={1} flexWrap="wrap">
+                                {FRECUENCIAS.map((f) => (
+                                  <Button
+                                    key={f.value}
+                                    variant={generador.frecuencia === f.value ? 'contained' : 'outlined'}
+                                    size="small"
+                                    onClick={() => setGenerador((g) => ({ ...g, frecuencia: f.value }))}
+                                    sx={{ borderRadius: 2, textTransform: 'none', minWidth: 0 }}
+                                  >
+                                    {f.label}
+                                  </Button>
+                                ))}
+                              </Stack>
+                            </Stack>
+                            {generador.frecuencia !== 'avance_obra' && (
+                              <TextField
+                                label="Fecha primera cuota" type="date" size="small"
+                                value={generador.fecha_inicio}
+                                onChange={(e) => setGenerador((g) => ({ ...g, fecha_inicio: e.target.value }))}
+                                InputLabelProps={{ shrink: true }}
+                                sx={{ width: 180 }}
+                              />
+                            )}
+                          </Stack>
+                          {generador.frecuencia === 'avance_obra' && (
+                            <Typography variant="caption" color="text.secondary" display="block" mt={1}>
+                              <InfoOutlinedIcon sx={{ fontSize: 12, verticalAlign: 'middle', mr: 0.5 }} />
+                              Las cuotas por avance se calculan del devengado del proveedor. Podés cargar acá una base y luego, en el detalle, usar “Generar por avance”.
+                            </Typography>
+                          )}
+                        </Paper>
+
+                        {/* Bloque 2 — Anticipo */}
+                        <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, borderColor: generador.usarAnticipo ? 'primary.main' : 'divider' }}>
+                          <FormControlLabel
+                            control={<Switch checked={!!generador.usarAnticipo} onChange={() => setGenerador((g) => ({ ...g, usarAnticipo: !g.usarAnticipo }))} />}
+                            label={<Typography variant="subtitle2" fontWeight={700}>Anticipo</Typography>}
+                          />
+                          <Typography variant="caption" color="text.secondary" display="block">Un pago inicial al arrancar, antes de las cuotas.</Typography>
+                          {generador.usarAnticipo && (
+                            <TextField
+                              label="Anticipo (%)" type="number" size="small"
+                              value={generador.anticipo_pct}
+                              onChange={(e) => setGenerador((g) => ({ ...g, anticipo_pct: e.target.value }))}
+                              sx={{ width: 180, mt: 1.5 }} inputProps={{ min: 0, max: 100 }}
+                              helperText={montoTotal > 0 ? `= ${formatCurrency(Math.round(montoTotal * (Number(generador.anticipo_pct) || 0) / 100), monedaDisplay)} del total` : ' '}
+                            />
+                          )}
+                        </Paper>
+
+                        {/* Bloque 3 — Refuerzos */}
+                        <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, borderColor: generador.usarRefuerzo ? 'primary.main' : 'divider' }}>
+                          <FormControlLabel
+                            control={<Switch checked={!!generador.usarRefuerzo} onChange={() => setGenerador((g) => ({ ...g, usarRefuerzo: !g.usarRefuerzo }))} />}
+                            label={<Typography variant="subtitle2" fontWeight={700}>Refuerzos</Typography>}
+                          />
+                          <Typography variant="caption" color="text.secondary" display="block">Pagos extra cada cierto tiempo (ej. cada 6 cuotas), además de las cuotas.</Typography>
+                          {generador.usarRefuerzo && (
+                            <Stack spacing={1.5} mt={1.5}>
+                              <Stack direction="row" spacing={2} flexWrap="wrap">
+                                <TextField
+                                  label="Refuerzo (%)" type="number" size="small"
+                                  value={generador.refuerzo_pct}
+                                  onChange={(e) => setGenerador((g) => ({ ...g, refuerzo_pct: e.target.value }))}
+                                  sx={{ width: 160 }} inputProps={{ min: 0, max: 100 }}
+                                  helperText={montoTotal > 0 ? `= ${formatCurrency(Math.round(montoTotal * (Number(generador.refuerzo_pct) || 0) / 100), monedaDisplay)} c/u` : ' '}
+                                />
+                                <TextField
+                                  label="Cada (cuotas)" type="number" size="small"
+                                  value={generador.intervalo_meses}
+                                  onChange={(e) => setGenerador((g) => ({ ...g, intervalo_meses: e.target.value }))}
+                                  sx={{ width: 130 }} inputProps={{ min: 1 }}
+                                />
+                              </Stack>
+                              <Box>
+                                <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>En la cuota del refuerzo</Typography>
+                                <ToggleButtonGroup
+                                  value={generador.refuerzo_modo} exclusive size="small"
+                                  onChange={(_, v) => { if (v) setGenerador((g) => ({ ...g, refuerzo_modo: v })); }}
+                                >
+                                  <ToggleButton value="sumar">Se suma a la cuota</ToggleButton>
+                                  <ToggleButton value="reemplazar">Reemplaza la cuota</ToggleButton>
+                                </ToggleButtonGroup>
+                              </Box>
+                            </Stack>
+                          )}
+                        </Paper>
+
+                        {/* Aviso de sobre-asignación */}
+                        {(() => {
+                          const cant = parseInt(generador.cantidad, 10) || 0;
+                          if (!cant || montoTotal <= 0) return null;
+                          const intervalo = Math.max(1, parseInt(generador.intervalo_meses, 10) || 6);
+                          const nRef = generador.usarRefuerzo ? Array.from({ length: cant }, (_, i) => i + 1).filter((m) => m % intervalo === 0).length : 0;
+                          const pctComprometido = (generador.usarAnticipo ? Number(generador.anticipo_pct) || 0 : 0) + nRef * (generador.usarRefuerzo ? Number(generador.refuerzo_pct) || 0 : 0);
+                          if (pctComprometido <= 100) return null;
+                          return (
+                            <Paper sx={{ p: 1.5, bgcolor: '#FFF5F5', border: '1px solid #F2B8B5', borderRadius: 1.5 }}>
+                              <Typography variant="caption" color="error.main">
+                                ⚠ El anticipo + los refuerzos suman <strong>{Math.round(pctComprometido)}%</strong> del total (más de 100%).
+                                Las cuotas base quedarían en 0. Bajá el % de refuerzo, la cantidad de refuerzos o el anticipo.
+                              </Typography>
+                            </Paper>
+                          );
+                        })()}
+
+                        {errors.generador && <Typography color="error" variant="caption">{errors.generador}</Typography>}
+                        <Stack direction="row" alignItems="center" spacing={1} sx={{ color: 'text.secondary' }}>
+                          <AutorenewIcon sx={{ fontSize: 18 }} />
+                          <Typography variant="caption">Las cuotas se arman solas — mirá la vista previa. Podrás ajustarlas en el paso siguiente.</Typography>
+                        </Stack>
+                      </Stack>
+                    </Paper>
+                  )}
+
+                  {modoDistribucion === 'personalizados' && (
+                    <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+                      <Stack spacing={2.5}>
+                        <TextField
+                          label="Cantidad de cuotas" type="number" size="small"
+                          value={cantPersonalizados}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            setCantPersonalizados(val);
+                            const n = parseInt(val, 10);
+                            if (n > 0) setPorcentajes(Array.from({ length: n }, () => ''));
+                          }}
+                          inputProps={{ min: 1, max: 120 }}
+                          sx={{ width: 200 }}
+                        />
+
+                        {cantPersonalizados && parseInt(cantPersonalizados, 10) > 0 && (
+                          <>
+                            <FormControlLabel
+                              control={<Switch checked={usaPorcentaje} onChange={(e) => setUsaPorcentaje(e.target.checked)} />}
+                              label="Distribuir por porcentaje"
+                            />
+                            {usaPorcentaje && (
+                              <Box>
+                                <Typography variant="body2" color="text.secondary" mb={1.5}>
+                                  Ingresá el % de cada cuota (deben sumar 100%)
+                                </Typography>
+                                <Stack spacing={1}>
+                                  {porcentajes.map((pct, i) => (
+                                    <Stack key={i} direction="row" alignItems="center" spacing={1.5}>
+                                      <Typography variant="body2" sx={{ minWidth: 70 }}>Cuota {i + 1}</Typography>
+                                      <TextField
+                                        size="small" type="number"
+                                        value={pct}
+                                        onChange={(e) => {
+                                          const newPcts = [...porcentajes];
+                                          newPcts[i] = e.target.value;
+                                          setPorcentajes(newPcts);
+                                        }}
+                                        InputProps={{ endAdornment: <InputAdornment position="end">%</InputAdornment> }}
+                                        inputProps={{ min: 0, max: 100, step: 0.1 }}
+                                        sx={{ width: 120 }}
+                                      />
+                                      {montoTotal > 0 && pct && (
+                                        <Typography variant="caption" color="text.secondary">
+                                          = {formatCurrency(Math.round(montoTotal * Number(pct) / 100 * 100) / 100, monedaDisplay)}
+                                        </Typography>
+                                      )}
+                                    </Stack>
+                                  ))}
+                                </Stack>
+                                <Typography
+                                  variant="body2" sx={{ mt: 1.5 }}
+                                  color={Math.abs(porcentajes.reduce((s, p) => s + (Number(p) || 0), 0) - 100) < 0.01 ? 'success.main' : 'warning.main'}
+                                  fontWeight={600}
+                                >
+                                  Total: {porcentajes.reduce((s, p) => s + (Number(p) || 0), 0).toFixed(1)}%
+                                  {Math.abs(porcentajes.reduce((s, p) => s + (Number(p) || 0), 0) - 100) < 0.01 ? ' ✓' : ' (debe sumar 100%)'}
+                                </Typography>
+                              </Box>
+                            )}
+                          </>
+                        )}
+
+                        {(!usaPorcentaje || !cantPersonalizados) && (
+                          <Stack direction="row" alignItems="center" spacing={1}>
+                            <InfoOutlinedIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
+                            <Typography variant="body2" color="text.secondary">
+                              {cantPersonalizados && parseInt(cantPersonalizados, 10) > 0
+                                ? 'En el siguiente paso vas a poder editar los montos y fechas de cada cuota.'
+                                : 'En el siguiente paso vas a poder agregar y editar cada cuota manualmente.'}
+                            </Typography>
+                          </Stack>
+                        )}
+                      </Stack>
+                    </Paper>
+                  )}
+                </Grid>
+
+                {/* Resumen de distribución */}
+                <Grid item xs={12} lg={4}>
+                  <Paper variant="outlined" sx={{ p: 3, borderRadius: 2, height: '100%' }}>
+                    <Typography variant="overline" color="text.secondary" display="block" mb={1.5}>Resumen de distribución</Typography>
+                    <Stack spacing={1.5}>
+                      <Stack direction="row" justifyContent="space-between" alignItems="center">
+                        <Typography variant="body2" color="text.secondary">Modo</Typography>
+                        <Chip size="small" color={modoDistribucion === 'iguales' ? 'primary' : 'default'} label={modoDistribucion === 'iguales' ? 'Cuotas iguales' : 'Personalizado'} />
+                      </Stack>
+                      <Stack direction="row" justifyContent="space-between" alignItems="center">
+                        <Typography variant="body2" color="text.secondary">Total</Typography>
+                        <Typography variant="body2" fontWeight={700}>{formatCurrency(montoTotal, monedaDisplay)}</Typography>
+                      </Stack>
+                      {montoTotalEnCAC && (
+                        <Stack direction="row" justifyContent="space-between" alignItems="center">
+                          <Typography variant="body2" color="text.secondary">Equiv. CAC</Typography>
+                          <Typography variant="body2" fontWeight={700} color="primary.main">{montoTotalEnCAC.toLocaleString('es-AR', { maximumFractionDigits: 2 })} CAC</Typography>
+                        </Stack>
+                      )}
+
+                      <Divider sx={{ my: 0.5 }} />
+
+                      {modoDistribucion === 'iguales' ? (
+                        (() => {
+                          const cant = parseInt(generador.cantidad, 10) || 0;
+                          const antMonto = generador.usarAnticipo ? Math.round(montoTotal * (Number(generador.anticipo_pct) || 0) / 100) : 0;
+                          const intervalo = Math.max(1, parseInt(generador.intervalo_meses, 10) || 6);
+                          const nRef = generador.usarRefuerzo ? Array.from({ length: cant }, (_, i) => i + 1).filter((m) => m % intervalo === 0).length : 0;
+                          const refMonto = generador.usarRefuerzo ? Math.round(montoTotal * (Number(generador.refuerzo_pct) || 0) / 100) : 0;
+                          const refTotal = refMonto * nRef;
+                          const cuotasTotal = Math.max(0, montoTotal - antMonto - refTotal);
+                          const pct = (n) => (montoTotal > 0 ? Math.round(n / montoTotal * 100) : 0);
+                          const freqLabel = FRECUENCIA_LABELS[generador.frecuencia] || generador.frecuencia;
+                          return (
+                            <>
+                              <Typography variant="body2">
+                                {generador.usarAnticipo && <><strong>{generador.anticipo_pct}%</strong> de anticipo ({formatCurrency(antMonto, monedaDisplay)}) + </>}
+                                <strong>{cant || '—'}</strong> cuota{cant !== 1 ? 's' : ''} {freqLabel}
+                                {cant > 0 && <> de ~{formatCurrency(Math.round(cuotasTotal / cant), monedaDisplay)}</>}
+                                {generador.usarRefuerzo && <>, con refuerzo del <strong>{generador.refuerzo_pct}%</strong> cada {intervalo} cuotas ({generador.refuerzo_modo === 'reemplazar' ? 'reemplaza esa cuota' : 'se suma'})</>}
+                                {generador.fecha_inicio && <> desde el {new Date(generador.fecha_inicio + 'T12:00:00').toLocaleDateString('es-AR')}</>}.
+                              </Typography>
+
+                              {montoTotal > 0 && (
+                                <Box>
+                                  <Box sx={{ display: 'flex', height: 10, borderRadius: 5, overflow: 'hidden', bgcolor: 'grey.200' }}>
+                                    {antMonto > 0 && <Box sx={{ width: `${pct(antMonto)}%`, bgcolor: '#7E57C2' }} />}
+                                    <Box sx={{ width: `${pct(cuotasTotal)}%`, bgcolor: '#42A5F5' }} />
+                                    {refTotal > 0 && <Box sx={{ width: `${pct(refTotal)}%`, bgcolor: '#26A69A' }} />}
+                                  </Box>
+                                  <Stack direction="row" spacing={1.5} mt={0.5} flexWrap="wrap">
+                                    {antMonto > 0 && <Typography variant="caption" sx={{ color: '#7E57C2' }}>Anticipo {pct(antMonto)}%</Typography>}
+                                    <Typography variant="caption" sx={{ color: '#42A5F5' }}>Cuotas {pct(cuotasTotal)}%</Typography>
+                                    {refTotal > 0 && <Typography variant="caption" sx={{ color: '#26A69A' }}>Refuerzos {pct(refTotal)}%</Typography>}
+                                  </Stack>
+                                </Box>
+                              )}
+
+                              <Divider sx={{ my: 0.5 }} />
+                              <Typography variant="caption" color="text.secondary">Vista previa ({previewCuotas.length} cuota{previewCuotas.length !== 1 ? 's' : ''})</Typography>
+                              {previewCuotas.length === 0 ? (
+                                <Typography variant="caption" color="text.disabled">Completá cantidad y fecha para ver el detalle.</Typography>
+                              ) : (
+                                <Stack spacing={0.25} sx={{ maxHeight: 220, overflowY: 'auto' }}>
+                                  {previewCuotas.slice(0, 12).map((c, i) => (
+                                    <Stack key={i} direction="row" justifyContent="space-between">
+                                      <Typography variant="caption" color="text.secondary" noWrap sx={{ maxWidth: 140 }}>
+                                        {c.descripcion}{c.fecha_vencimiento ? ` · ${new Date(c.fecha_vencimiento + 'T12:00:00').toLocaleDateString('es-AR')}` : ''}
+                                      </Typography>
+                                      <Typography variant="caption" fontWeight={600}>{formatCurrency(Number(c.monto) || 0, monedaDisplay)}</Typography>
+                                    </Stack>
+                                  ))}
+                                  {previewCuotas.length > 12 && <Typography variant="caption" color="text.disabled">…y {previewCuotas.length - 12} más</Typography>}
+                                  <Divider sx={{ my: 0.5 }} />
+                                  <Stack direction="row" justifyContent="space-between">
+                                    <Typography variant="caption" fontWeight={700}>Suma</Typography>
+                                    <Typography variant="caption" fontWeight={700} color={Math.abs(previewSuma - montoTotal) < 1 || montoTotal === 0 ? 'success.main' : 'warning.main'}>
+                                      {formatCurrency(previewSuma, monedaDisplay)}{montoTotal > 0 && Math.abs(previewSuma - montoTotal) >= 1 ? ` (total ${formatCurrency(montoTotal, monedaDisplay)})` : ''}
+                                    </Typography>
+                                  </Stack>
+                                </Stack>
+                              )}
+                            </>
+                          );
+                        })()
+                      ) : (
+                        <>
+                          <Typography variant="body2" fontWeight={600}>Edición manual</Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            Podés crear cuotas a medida y, si querés, repartir primero por porcentaje para arrancar con una base.
+                          </Typography>
+                          {!!cantPersonalizados && (
+                            <Typography variant="caption" color="text.secondary">
+                              {cantPersonalizados} cuota{parseInt(cantPersonalizados, 10) !== 1 ? 's' : ''}
+                              {usaPorcentaje ? ` · ${porcentajes.reduce((s, p) => s + (Number(p) || 0), 0).toFixed(1)}% cargado` : ''}
+                            </Typography>
+                          )}
+                        </>
+                      )}
+                    </Stack>
+                  </Paper>
+                </Grid>
+              </Grid>
+
+              <Stack direction="row" justifyContent="flex-end" spacing={2} mt={4}>
+                <Button variant="outlined" onClick={() => setStep(0)}>← Atrás</Button>
+                <Button variant="contained" onClick={handleNext} sx={{ px: 4 }}>Continuar →</Button>
+              </Stack>
+            </Box>
+          </Fade>
+
+          {/* ─── PASO 2: AJUSTAR MONTOS ─── */}
+          <Fade in={step === 2} mountOnEnter unmountOnExit>
+            <Box sx={{ display: step === 2 ? 'block' : 'none' }}>
+              <Typography variant="h6" fontWeight={600} mb={0.5}>
+                {modoDistribucion === 'iguales' ? 'Revisá y ajustá los montos' : 'Definí tus cuotas'}
+              </Typography>
+              <Typography variant="body2" color="text.secondary" mb={3}>
+                {modoDistribucion === 'iguales'
+                  ? 'Las cuotas se generaron automáticamente. Podés ajustar montos individuales si necesitás redondear o redistribuir.'
+                  : 'Agregá las cuotas con las fechas y montos que necesites.'}
+              </Typography>
+
+              <Grid container spacing={3}>
+                <Grid item xs={12}>
+                  {montoTotal > 0 && cuotas.length > 0 && (
+                    <Paper
+                      variant="outlined"
+                      sx={{ p: 2, mb: 3, borderColor: sumaOk ? 'success.main' : 'warning.main', bgcolor: sumaOk ? '#E8F5E9' : '#FFF8E1', borderRadius: 2 }}
+                    >
+                      <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ sm: 'center' }} spacing={1}>
+                        <Typography variant="body2">Total del plan: <strong>{formatCurrency(montoTotal, monedaDisplay)}</strong></Typography>
+                        <Stack direction="row" alignItems="center" spacing={1}>
+                          {sumaOk ? <CheckCircleOutlineIcon sx={{ fontSize: 18, color: 'success.main' }} /> : <WarningAmberIcon sx={{ fontSize: 18, color: 'warning.main' }} />}
+                          <Typography variant="body2" fontWeight={600} color={sumaOk ? 'success.main' : 'warning.main'}>
+                            Suma de cuotas: {formatCurrency(sumaCuotas, monedaDisplay)}
+                            {sumaOk ? ' — cuadra' : ` (dif: ${formatCurrency(sumaDiff, monedaDisplay)})`}
+                          </Typography>
+                        </Stack>
+                      </Stack>
+                    </Paper>
+                  )}
+
+                  <CuotasTableEdit
+                    cuotas={cuotas}
+                    onChange={setCuotas}
+                    moneda={monedaDisplay}
+                    showCAC={planData.indexacion === 'CAC'}
+                    cacPreview={cacPreview}
+                    montoTotal={montoTotal}
+                  />
+
+                  {errors.cuotas && <Typography variant="caption" color="error" mt={1} display="block">{errors.cuotas}</Typography>}
+                </Grid>
+
+                <Grid item xs={12}>
+                  <Stack spacing={2}>
+                    <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+                      <Typography variant="overline" color="text.secondary" display="block" mb={1.5}>Chequeo del plan</Typography>
+                      <Stack spacing={1.25}>
+                        <Stack direction="row" justifyContent="space-between">
+                          <Typography variant="body2" color="text.secondary">Total del plan</Typography>
+                          <Typography variant="body2" fontWeight={700}>{formatCurrency(montoTotal, monedaDisplay)}</Typography>
+                        </Stack>
+                        <Stack direction="row" justifyContent="space-between">
+                          <Typography variant="body2" color="text.secondary">Suma cargada</Typography>
+                          <Typography variant="body2" fontWeight={700}>{formatCurrency(sumaCuotas, monedaDisplay)}</Typography>
+                        </Stack>
+                        <Stack direction="row" justifyContent="space-between">
+                          <Typography variant="body2" color="text.secondary">Diferencia</Typography>
+                          <Typography variant="body2" fontWeight={700} color={sumaOk ? 'success.main' : 'warning.main'}>{formatCurrency(sumaDiff, monedaDisplay)}</Typography>
+                        </Stack>
+                        <Stack direction="row" justifyContent="space-between">
+                          <Typography variant="body2" color="text.secondary">Cuotas con monto</Typography>
+                          <Typography variant="body2" fontWeight={600}>{cuotasConMonto}/{cuotas.length}</Typography>
+                        </Stack>
+                        <Stack direction="row" justifyContent="space-between">
+                          <Typography variant="body2" color="text.secondary">Cuotas con fecha</Typography>
+                          <Typography variant="body2" fontWeight={600}>{cuotasConFecha}/{cuotas.length}</Typography>
+                        </Stack>
+                        {montoTotal > 0 && (
+                          <Stack direction="row" justifyContent="space-between">
+                            <Typography variant="body2" color="text.secondary">Distribuido</Typography>
+                            <Typography variant="body2" fontWeight={600}>{porcentajeDistribuido.toLocaleString('es-AR', { maximumFractionDigits: 1 })}%</Typography>
+                          </Stack>
+                        )}
+                      </Stack>
+                    </Paper>
+
+                    {modoDistribucion === 'iguales' && (
+                      <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 2 }}>
+                        <Typography variant="body2" fontWeight={600} mb={1}>Regeneración rápida</Typography>
+                        <Typography variant="body2" color="text.secondary" mb={2}>
+                          Si cambiás cantidad, frecuencia o fecha inicial, podés volver a generar la base y después retocar manualmente.
+                        </Typography>
+                        <Button variant="outlined" size="small" startIcon={<ReplayIcon />} onClick={handleGenerar}>Regenerar cuotas</Button>
+                      </Paper>
+                    )}
+
+                    <Paper sx={{ p: 2.5, borderRadius: 2, bgcolor: sumaOk ? '#E8F5E9' : '#FFF8E1', border: `1px solid ${sumaOk ? '#A5D6A7' : '#FFE082'}` }}>
+                      <Stack direction="row" spacing={1} alignItems="flex-start">
+                        {sumaOk ? <CheckCircleOutlineIcon sx={{ color: 'success.main', mt: 0.1 }} /> : <WarningAmberIcon sx={{ color: '#F9A825', mt: 0.1 }} />}
+                        <Typography variant="body2">
+                          {sumaOk
+                            ? 'La distribución ya cierra contra el total del plan.'
+                            : <>Los montos no suman exactamente el total. <strong>No bloquea la creación</strong>, pero conviene revisarlo antes de confirmar.</>}
+                        </Typography>
+                      </Stack>
+                    </Paper>
+                  </Stack>
+                </Grid>
+              </Grid>
+
+              <Stack direction="row" justifyContent="flex-end" spacing={2} mt={4}>
+                <Button variant="outlined" onClick={() => setStep(1)}>← Atrás</Button>
+                <Button variant="contained" onClick={handleNext} sx={{ px: 4 }}>Continuar → Revisar</Button>
+              </Stack>
+            </Box>
+          </Fade>
+
+          {/* ─── PASO 3: RESUMEN Y CONFIRMACIÓN ─── */}
+          <Fade in={step === 3} mountOnEnter unmountOnExit>
+            <Box sx={{ display: step === 3 ? 'block' : 'none' }}>
+              <Typography variant="h6" fontWeight={600} mb={3}>Resumen del plan de pago</Typography>
+
+              <Paper variant="outlined" sx={{ p: 3, borderRadius: 2, mb: 3 }}>
+                <Typography variant="overline" color="text.secondary" display="block" mb={1}>DATOS DEL PLAN</Typography>
+                <Grid container spacing={2}>
+                  <Grid item xs={6} sm={4}>
+                    <Typography variant="caption" color="text.secondary">Proveedor</Typography>
+                    <Typography variant="body2" fontWeight={600}>{proveedorNombre || '-'}</Typography>
+                  </Grid>
+                  <Grid item xs={6} sm={4}>
+                    <Typography variant="caption" color="text.secondary">Nombre</Typography>
+                    <Typography variant="body2" fontWeight={600}>{planData.nombre}</Typography>
+                  </Grid>
+                  <Grid item xs={6} sm={4}>
+                    <Typography variant="caption" color="text.secondary">Monto total</Typography>
+                    <Typography variant="body2" fontWeight={600}>{formatCurrency(montoTotal, monedaDisplay)}</Typography>
+                  </Grid>
+                  <Grid item xs={6} sm={4}>
+                    <Typography variant="caption" color="text.secondary">Moneda</Typography>
+                    <Typography variant="body2" fontWeight={600}>{planData.moneda}{planData.indexacion === 'CAC' ? ' + CAC' : ''}</Typography>
+                  </Grid>
+                  {planData.indexacion === 'CAC' && cacPreview && (
+                    <Grid item xs={6} sm={4}>
+                      <Typography variant="caption" color="text.secondary">Índice CAC</Typography>
+                      <Typography variant="body2" fontWeight={600}>
+                        {planData.cac_tipo === 'general' ? 'Promedio' : planData.cac_tipo === 'mano_obra' ? 'M. Obra' : 'Materiales'} = {cacPreview.cac_indice}
+                      </Typography>
+                    </Grid>
+                  )}
+                  {planData.notas && (
+                    <Grid item xs={12}>
+                      <Typography variant="caption" color="text.secondary">Notas</Typography>
+                      <Typography variant="body2">{planData.notas}</Typography>
+                    </Grid>
+                  )}
+                </Grid>
+              </Paper>
+
+              <Paper variant="outlined" sx={{ p: 3, borderRadius: 2, mb: 3 }}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+                  <Typography variant="overline" color="text.secondary">CUOTAS ({cuotas.length})</Typography>
+                  <Typography variant="body2">
+                    Suma: <strong>{formatCurrency(sumaCuotas, monedaDisplay)}</strong>
+                    {montoTotal > 0 && (
+                      <Chip label={sumaOk ? 'Cuadra' : `Dif: ${formatCurrency(sumaDiff, monedaDisplay)}`} color={sumaOk ? 'success' : 'warning'} size="small" sx={{ ml: 1 }} />
+                    )}
+                  </Typography>
+                </Stack>
+                <Divider sx={{ mb: 2 }} />
+                <Stack spacing={1}>
+                  {cuotas.map((c, i) => (
+                    <Stack key={i} direction="row" justifyContent="space-between" alignItems="center" sx={{ py: 1, px: 1.5, bgcolor: i % 2 === 0 ? 'grey.50' : 'transparent', borderRadius: 1 }}>
+                      <Stack direction="row" spacing={2} alignItems="center">
+                        <Typography variant="body2" fontWeight={600} sx={{ minWidth: 24 }}>{i + 1}</Typography>
+                        <Typography variant="body2">
+                          {c.fecha_vencimiento ? new Date(c.fecha_vencimiento + 'T12:00:00').toLocaleDateString('es-AR') : 'Sin fecha'}
+                        </Typography>
+                        {c.descripcion && <Typography variant="body2" color="text.secondary">{c.descripcion}</Typography>}
+                      </Stack>
+                      <Typography variant="body2" fontWeight={600}>{formatCurrency(Number(c.monto) || 0, monedaDisplay)}</Typography>
+                    </Stack>
+                  ))}
+                </Stack>
+              </Paper>
+
+              {montoTotal > 0 && !sumaOk && (
+                <Paper sx={{ p: 2, mb: 3, bgcolor: '#FFF8E1', border: '1px solid #FFE082', borderRadius: 1.5 }}>
+                  <Stack direction="row" spacing={1} alignItems="flex-start">
+                    <WarningAmberIcon sx={{ color: '#F9A825', mt: 0.2 }} />
+                    <Typography variant="body2">La suma de cuotas no coincide con el total. El plan se creará igual.</Typography>
+                  </Stack>
+                </Paper>
+              )}
+
+              <Stack direction="row" justifyContent="flex-end" spacing={2}>
+                <Button variant="outlined" onClick={() => setStep(2)}>← Modificar cuotas</Button>
+                <Button
+                  variant="contained"
+                  onClick={handleSubmit}
+                  disabled={saving}
+                  sx={{ px: 5, py: 1.5, bgcolor: '#1B9E85', '&:hover': { bgcolor: '#15836E' }, fontWeight: 700, fontSize: '0.95rem' }}
+                >
+                  {saving ? 'Creando plan...' : 'Crear plan de pago'}
+                </Button>
+              </Stack>
+            </Box>
+          </Fade>
+        </Container>
+      </Box>
+
+      <Snackbar
+        open={alert.open}
+        autoHideDuration={5000}
+        onClose={() => setAlert((a) => ({ ...a, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={alert.severity} onClose={() => setAlert((a) => ({ ...a, open: false }))}>
+          {alert.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+NuevoPlanPagoPage.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default NuevoPlanPagoPage;

--- a/src/pages/pagos-proveedores/nuevo.js
+++ b/src/pages/pagos-proveedores/nuevo.js
@@ -105,10 +105,16 @@ const NuevoPlanPagoPage = () => {
   const router = useRouter();
   // El plan de pago SIEMPRE se crea dentro de una obra: ?obra=<id> es requerido
   // (a diferencia de cobros, donde la obra es opcional). Al guardar se asocia a esa obra.
-  const obraId = router.query.obra ? String(router.query.obra) : null;
-  const esSuelto = !obraId; // plan de pago suelto: sin obra, elige proyecto/caja destino
+  // Obra: puede venir fija por URL (?obra=, al entrar desde la obra) o elegirse
+  // acá en el asistente general. Si no hay ninguna, el plan es suelto (proyecto/caja).
+  const obraFijaId = router.query.obra ? String(router.query.obra) : null;
   const [step, setStep] = useState(0);
   const [empresaId, setEmpresaId] = useState(null);
+  const [obrasEmpresa, setObrasEmpresa] = useState([]); // para el selector de obra (asistente general)
+  const [obraSel, setObraSel] = useState(''); // obra elegida en el asistente
+  const [subrubroSel, setSubrubroSel] = useState(''); // tarea opcional dentro de la obra
+  const obraId = obraFijaId || obraSel || null;
+  const esSuelto = !obraId; // sin obra → plan suelto (elige proyecto/caja destino)
   const [obra, setObra] = useState(null);
   const [obraLoading, setObraLoading] = useState(true);
   const [proyectos, setProyectos] = useState([]);
@@ -145,13 +151,21 @@ const NuevoPlanPagoPage = () => {
 
   // Carga la obra a la que se asociará el plan (proveedores con contrato + monto referencial).
   useEffect(() => {
-    if (!empresaId || !obraId) { if (!obraId) setObraLoading(false); return; }
+    if (!empresaId || !obraId) { setObra(null); setObraLoading(false); return; }
     setObraLoading(true);
     ControlObraService.obtenerObra(obraId, empresaId)
       .then((o) => setObra(o || null))
       .catch(() => setAlert({ open: true, message: 'No se pudo cargar la obra', severity: 'error' }))
       .finally(() => setObraLoading(false));
   }, [empresaId, obraId]);
+
+  // Asistente general (sin ?obra=): lista de obras para el selector opcional.
+  useEffect(() => {
+    if (!empresaId || obraFijaId) return;
+    ControlObraService.listarObras({ empresa_id: empresaId })
+      .then((r) => setObrasEmpresa(r?.items || []))
+      .catch(() => setObrasEmpresa([]));
+  }, [empresaId, obraFijaId]);
 
   // Plan suelto: cargar los proyectos/cajas de la empresa para elegir destino.
   useEffect(() => {
@@ -171,6 +185,17 @@ const NuevoPlanPagoPage = () => {
   const proveedores = useMemo(() => proveedoresConContrato(obra), [obra]);
   const seleccionado = proveedores.find((p) => (p.proveedor_id || p.proveedor_nombre) === proveedorSel);
   const proveedorNombre = seleccionado ? seleccionado.proveedor_nombre : proveedorLibre.trim();
+
+  // Tareas (sub-rubros) de la obra elegida, para asociar el plan a una puntual.
+  const subrubrosDeObra = useMemo(() => (obra?.rubros || []).flatMap((r) =>
+    (r.subrubros || []).map((s) => ({ uid: s.uid, nombre: s.nombre, rubro: r.nombre, contrato: s.contrato_proveedor?.monto ?? null }))), [obra]);
+
+  // Al elegir una tarea, pre-llenar el total con su contrato de proveedor (si tiene).
+  useEffect(() => {
+    if (!subrubroSel) return;
+    const s = subrubrosDeObra.find((x) => x.uid === subrubroSel);
+    if (s && s.contrato != null) setPlanData((prev) => ({ ...prev, monto_total: String(s.contrato) }));
+  }, [subrubroSel, subrubrosDeObra]);
 
   // Al elegir un proveedor con contrato, pre-llenar el nombre y el total referencial
   // (suma de contratos de ese proveedor en la obra).
@@ -384,7 +409,7 @@ const NuevoPlanPagoPage = () => {
       };
       const plan = esSuelto
         ? await ControlObraService.crearPlanPagoEmpresa({ ...base, proyecto_id: proyectoSel, monto_total: montoTotal || null })
-        : await ControlObraService.crearPlanPago(obraId, base);
+        : await ControlObraService.crearPlanPago(obraId, { ...base, subrubro_uid: subrubroSel || null });
       if (!plan?._id) throw new Error('No se pudo crear el plan de pago');
 
       // 2) Agregar las cuotas (secuencial: cada agregarCuota reasigna número y devenga índice).
@@ -407,8 +432,9 @@ const NuevoPlanPagoPage = () => {
 
   const monedaDisplay = planData.moneda;
 
-  // En modo obra, esperamos a que cargue (para tener proveedores/monto referencial).
-  if (obraId && obraLoading) {
+  // Solo bloqueamos con spinner cuando la obra viene fija por URL (carga inicial).
+  // Si se elige en el asistente, la obra carga en segundo plano sin tapar el form.
+  if (obraFijaId && obraLoading) {
     return (
       <Box component="main" sx={{ flexGrow: 1, py: 4 }}>
         <Container maxWidth="md" sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
@@ -452,6 +478,45 @@ const NuevoPlanPagoPage = () => {
               <Grid container spacing={4}>
                 <Grid item xs={12} md={6}>
                   <Stack spacing={3}>
+                    {/* Asistente general: elegir obra (opcional). Al elegir una, el plan
+                        queda atado a ella y la caja la define su proyecto. */}
+                    {!obraFijaId && (
+                      <TextField
+                        select
+                        label="Obra (opcional)"
+                        value={obraSel}
+                        onChange={(e) => { setObraSel(e.target.value); setSubrubroSel(''); setErrors((p) => ({ ...p, proyecto_id: '' })); }}
+                        helperText="Dejala vacía para un plan suelto (elegís proyecto/caja). Si elegís una, se imputa a esa obra."
+                        fullWidth
+                        SelectProps={{ native: true }}
+                        InputLabelProps={{ shrink: true }}
+                      >
+                        <option value="">Sin obra (plan suelto)</option>
+                        {obrasEmpresa.map((o) => (
+                          <option key={o._id} value={o._id}>{o.titulo}</option>
+                        ))}
+                      </TextField>
+                    )}
+
+                    {/* Con obra: tarea (sub-rubro) opcional a la que queda asociado el plan. */}
+                    {obraId && subrubrosDeObra.length > 0 && (
+                      <TextField
+                        select
+                        label="Tarea de la obra (opcional)"
+                        value={subrubroSel}
+                        onChange={(e) => setSubrubroSel(e.target.value)}
+                        helperText="Si elegís una tarea, los pagos de este plan se imputan a ella."
+                        fullWidth
+                        SelectProps={{ native: true }}
+                        InputLabelProps={{ shrink: true }}
+                      >
+                        <option value="">Toda la obra (reparto entre las tareas del proveedor)</option>
+                        {subrubrosDeObra.map((s) => (
+                          <option key={s.uid} value={s.uid}>{s.rubro} · {s.nombre}</option>
+                        ))}
+                      </TextField>
+                    )}
+
                     {/* Plan suelto: caja destino (proyecto). Con obra se hereda y no se muestra. */}
                     {esSuelto && (
                       <TextField

--- a/src/sections/empresa/configuracionGeneral.js
+++ b/src/sections/empresa/configuracionGeneral.js
@@ -234,6 +234,7 @@ export const ConfiguracionGeneral = ({ empresa, updateEmpresaData, hasPermission
     "VER_VALIDACION_BORRADORES",
     "VER_PRESUPUESTOS_PROFESIONALES",
     "VER_PLANES_COBRO",
+    "VER_PLANES_PAGO",
     "VER_CONTROL_OBRA",
     "VER_CONTROL_PAGOS",
     "VER_GASTOS_RECURRENTES",

--- a/src/services/controlObra/controlObraService.js
+++ b/src/services/controlObra/controlObraService.js
@@ -46,6 +46,8 @@ const ControlObraService = {
   registrarAvance: async (id, subrubroUid, empresa_id, avance_pct) => unwrap(await api.patch(`${BASE}/${id}/subrubros/${subrubroUid}/avance`, { empresa_id, avance_pct })),
   editarSubrubro: async (id, subrubroUid, empresa_id, cambios) => unwrap(await api.patch(`${BASE}/${id}/subrubros/${subrubroUid}`, { empresa_id, cambios })),
   eliminarSubrubro: async (id, subrubroUid, empresa_id) => unwrap(await api.delete(`${BASE}/${id}/subrubros/${subrubroUid}`, { params: { empresa_id } })),
+  // Carga masiva de costo_estimado. direccion: 'costo_desde_contrato' | 'contrato_desde_costo'
+  estimarCostos: async (id, empresa_id, { direccion, pct, solo_vacios = false }) => unwrap(await api.post(`${BASE}/${id}/estimar-costos`, { empresa_id, direccion, pct, solo_vacios })),
   // contrato = { proveedor_id, proveedor_nombre, monto, modalidad } | null (para borrar)
   asignarContrato: async (id, subrubroUid, empresa_id, contrato) => unwrap(await api.patch(`${BASE}/${id}/subrubros/${subrubroUid}/contrato`, { empresa_id, contrato })),
   // responsable = { user_id, nombre } | null (para borrar)
@@ -190,8 +192,33 @@ const ControlObraService = {
     return Array.isArray(res.data?.items) ? res.data.items : [];
   },
   crearPlanPago: async (obraId, data) => unwrap(await api.post(`${BASE}/${obraId}/planes-pago`, data)),
+
+  // Detalle de un plan de pago (con cuotas + resumen embebidos).
+  getPlanPago: async (planId, empresa_id) => unwrap(await api.get(`${BASE}/planes-pago/${planId}`, { params: { empresa_id } })),
+  editarPlanPago: async (planId, empresa_id, cambios) =>
+    unwrap(await api.patch(`${BASE}/planes-pago/${planId}`, { empresa_id, cambios })),
+  eliminarPlanPago: async (planId, empresa_id) =>
+    unwrap(await api.delete(`${BASE}/planes-pago/${planId}`, { params: { empresa_id } })),
+
+  // Cuotas del plan de pago.
+  // data = { empresa_id, tipo?, descripcion?, fecha_vencimiento?, monto, subrubro_uids?, hito_pct? }
+  agregarCuotaPago: async (planId, data) => unwrap(await api.post(`${BASE}/planes-pago/${planId}/cuotas`, data)),
+  // data = { empresa_id, monto, cantidad, frecuencia?, fecha_inicio, descripcion? }
+  generarCuotasPeriodicas: async (planId, data) =>
+    unwrap(await api.post(`${BASE}/planes-pago/${planId}/cuotas/periodicas`, data)),
   generarCuotasPorAvance: async (planId, empresa_id, fecha_vencimiento = null) =>
     unwrap(await api.post(`${BASE}/planes-pago/${planId}/cuotas/por-avance`, { empresa_id, fecha_vencimiento })),
+  editarCuotaPago: async (planId, cuotaId, empresa_id, cambios) =>
+    unwrap(await api.patch(`${BASE}/planes-pago/${planId}/cuotas/${cuotaId}`, { empresa_id, cambios })),
+  eliminarCuotaPago: async (planId, cuotaId, empresa_id) =>
+    unwrap(await api.delete(`${BASE}/planes-pago/${planId}/cuotas/${cuotaId}`, { params: { empresa_id } })),
+  aprobarCuotaPago: async (planId, cuotaId, empresa_id) =>
+    unwrap(await api.post(`${BASE}/planes-pago/${planId}/cuotas/${cuotaId}/aprobar`, { empresa_id })),
+  // monto_parcial null => paga el saldo total. fecha_pago opcional.
+  pagarCuotaPago: async (planId, cuotaId, empresa_id, { monto_parcial = null, fecha_pago = null } = {}) =>
+    unwrap(await api.post(`${BASE}/planes-pago/${planId}/cuotas/${cuotaId}/pagar`, { empresa_id, monto_parcial, fecha_pago })),
+  revertirPagoCuota: async (planId, cuotaId, empresa_id) =>
+    unwrap(await api.post(`${BASE}/planes-pago/${planId}/cuotas/${cuotaId}/revertir`, { empresa_id })),
 
   // Cartera cross-obra (T6): cuotas de pago a proveedores pendientes de TODAS las obras
   // de la empresa. El backend devuelve una fila por cuota; la hoja standalone las

--- a/src/services/controlObra/controlObraService.js
+++ b/src/services/controlObra/controlObraService.js
@@ -201,6 +201,12 @@ const ControlObraService = {
     if (res.status !== 200) throw new Error('Error al obtener los planes de pago');
     return Array.isArray(res.data?.items) ? res.data.items : [];
   },
+  // TODOS los planes de pago de la empresa (cross-obra, uno por plan con resumen + obra_titulo).
+  listarPlanesPagoEmpresa: async (empresa_id) => {
+    const res = await api.get(`${BASE}/cartera/planes-pago`, { params: { empresa_id } });
+    if (res.status !== 200) throw new Error('Error al obtener los planes de pago');
+    return Array.isArray(res.data?.items) ? res.data.items : [];
+  },
 };
 
 export default ControlObraService;

--- a/src/services/controlObra/controlObraService.js
+++ b/src/services/controlObra/controlObraService.js
@@ -192,6 +192,8 @@ const ControlObraService = {
     return Array.isArray(res.data?.items) ? res.data.items : [];
   },
   crearPlanPago: async (obraId, data) => unwrap(await api.post(`${BASE}/${obraId}/planes-pago`, data)),
+  // Plan de pago suelto (sin obra): requiere proyecto_id (caja destino) y monto_total.
+  crearPlanPagoEmpresa: async (data) => unwrap(await api.post(`${BASE}/planes-pago`, data)),
 
   // Detalle de un plan de pago (con cuotas + resumen embebidos).
   getPlanPago: async (planId, empresa_id) => unwrap(await api.get(`${BASE}/planes-pago/${planId}`, { params: { empresa_id } })),

--- a/src/services/controlObra/controlObraService.js
+++ b/src/services/controlObra/controlObraService.js
@@ -192,6 +192,15 @@ const ControlObraService = {
   crearPlanPago: async (obraId, data) => unwrap(await api.post(`${BASE}/${obraId}/planes-pago`, data)),
   generarCuotasPorAvance: async (planId, empresa_id, fecha_vencimiento = null) =>
     unwrap(await api.post(`${BASE}/planes-pago/${planId}/cuotas/por-avance`, { empresa_id, fecha_vencimiento })),
+
+  // Cartera cross-obra (T6): cuotas de pago a proveedores pendientes de TODAS las obras
+  // de la empresa. El backend devuelve una fila por cuota; la hoja standalone las
+  // agrupa por plan. Espejo del listado de planes de cobro.
+  listarPlanesPagoCartera: async (empresa_id) => {
+    const res = await api.get(`${BASE}/cartera/pagos-plan`, { params: { empresa_id } });
+    if (res.status !== 200) throw new Error('Error al obtener los planes de pago');
+    return Array.isArray(res.data?.items) ? res.data.items : [];
+  },
 };
 
 export default ControlObraService;

--- a/src/services/controlObra/controlObraService.js
+++ b/src/services/controlObra/controlObraService.js
@@ -181,6 +181,17 @@ const ControlObraService = {
     unwrap(await api.post(`${BASE}/${obraId}/planes`, { empresa_id, plan_cobro_id, nombre, monto_total })),
   desasociarPlan: async (obraId, empresa_id, planId) =>
     unwrap(await api.delete(`${BASE}/${obraId}/planes/${planId}`, { params: { empresa_id } })),
+
+  /* ---------- Planes de pago a proveedores (T3, lado costo) ----------
+     Espejo outbound de los planes de cobro: 0..N por obra, cada uno con sus
+     cuotas + resumen embebidos por el backend (getPlanes ya devuelve ambos). */
+  listarPlanesPago: async (obraId, empresa_id) => {
+    const res = await api.get(`${BASE}/${obraId}/planes-pago`, { params: { empresa_id } });
+    return Array.isArray(res.data?.items) ? res.data.items : [];
+  },
+  crearPlanPago: async (obraId, data) => unwrap(await api.post(`${BASE}/${obraId}/planes-pago`, data)),
+  generarCuotasPorAvance: async (planId, empresa_id, fecha_vencimiento = null) =>
+    unwrap(await api.post(`${BASE}/planes-pago/${planId}/cuotas/por-avance`, { empresa_id, fecha_vencimiento })),
 };
 
 export default ControlObraService;


### PR DESCRIPTION
Frontend de la épica **Control de Obra — Lado costo**. Backend: **sorby_bot_wa#264**. RFC: `docs/CONTROL_OBRA_LADO_COSTO_TECNICO.md`.

## Tickets incluidos (frontend)
- **T2 — Ejecución:** columnas nuevas **Costo estimado / Contratado / Margen esperado**; el Gastado se resalta en rojo cuando hay **sobrecosto** (gastado > costo de referencia).
- **T4 — Tablero de dos lados (`ResumenTab`):** dos columnas espejadas (Cobrar / Gastar); **Pendiente de cobro desglosado por fuente** (por certificados + por planes) con label honesto; panel **Composición del cobro** (input `cobro_esperado_certificados` + chip de cobertura); se **eliminó la barra "Circuito de plata"** redundante; "Qué necesita atención" enriquecido (avance alto con poco gastado, certificados sin aprobar, margen esperado negativo, sobrecosto).
- **T3 — Planes de pago dentro de la obra:** en la pestaña **Mano de obra** (`ManoObraTab`), sección de planes de pago a proveedores espejo de "Cobros": lista los `PlanPago` con cuotas/resumen, "Nuevo plan de pago" y "Generar por avance".
- **T6 — Hoja standalone `/pagos-proveedores`:** espejo de `/cobros`, lista todos los planes de pago de la empresa (cross-obra), gateada por el permiso nuevo **`VER_PLANES_PAGO`** en el nav de Finanzas + pantalla "sin permiso".

Depende del backend sorby_bot_wa#264.

## Verificación
ESLint limpio en todos los archivos. La verificación visual (navegador autenticado) va con el QA de la épica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)