### PR TITLE
TAR-553 — Ingreso a caja chica: el proyecto es el origen del dinero, no la imputación

### DIFF
--- a/src/components/cajaChica/MovimientoCajaChicaModal.js
+++ b/src/components/cajaChica/MovimientoCajaChicaModal.js
@@ -103,12 +103,10 @@ const MovimientoCajaChicaModal = ({
 
     const proyectoSeleccionado = proyectos.find((p) => p.id === formData.proyecto_id);
 
-    const movimientoData = {
+    const base = {
       type: formData.type,
       total: parseFloat(formData.total),
       moneda: 'ARS',
-      proyecto_id: formData.proyecto_id,
-      proyecto: proyectoSeleccionado?.nombre || '',
       categoria: formData.categoria,
       observacion: formData.observacion || '',
       nombre_proveedor: formData.nombre_proveedor || '',
@@ -116,6 +114,18 @@ const MovimientoCajaChicaModal = ({
       caja_chica: true,
       origen: 'web',
     };
+    const movimientoData = formData.type === 'ingreso'
+      ? {
+          ...base,
+          proyecto_id: null,
+          proyecto_origen_id: formData.proyecto_id || null,
+          proyecto_origen_nombre: proyectoSeleccionado?.nombre || null,
+        }
+      : {
+          ...base,
+          proyecto_id: formData.proyecto_id,
+          proyecto: proyectoSeleccionado?.nombre || '',
+        };
 
     onSubmit(movimientoData);
   };
@@ -201,14 +211,16 @@ const MovimientoCajaChicaModal = ({
             required
           />
 
-          {/* Proyecto (opcional) */}
+          {/* Proyecto (opcional). En ingreso es la caja de la que sale el dinero. */}
           <TextField
             select
-            label="Proyecto"
+            label={formData.type === 'ingreso' ? 'Proyecto de origen del dinero' : 'Proyecto'}
             value={formData.proyecto_id}
             onChange={handleChange('proyecto_id')}
             error={!!errors.proyecto_id}
-            helperText={errors.proyecto_id || 'Opcional'}
+            helperText={errors.proyecto_id || (formData.type === 'ingreso'
+              ? 'Opcional — caja de la que sale el dinero que ingresa a la caja chica'
+              : 'Opcional')}
             fullWidth
           >
             <MenuItem value="">


### PR DESCRIPTION
Ticket: [TAR-553](https://app.notion.com/p/39d50a1e534181c39faef35ffeb1409b) · Épica: [Saneamiento Caja Chica](https://app.notion.com/p/39d50a1e534181be9978e4e89ada0bca) · PR hermano (backend): https://github.com/fedemaidan/sorby_bot_wa/pull/265

---

## TAR-553 — El modal de caja chica mandaba proyecto_id en los ingresos

**Causa raíz / Problema:** el modal armaba el mismo payload para ingreso y egreso, siempre con `proyecto_id`. En un ingreso a caja chica eso hacía que el movimiento quedara imputado a la obra y apareciera en las dos cajas (caja chica + caja de la obra).

**Cómo lo hicimos (funcional):** al cargar un **ingreso** a caja chica, el proyecto elegido ahora es la "obra de origen del dinero" (el selector lo dice explícitamente): el ingreso queda solo en la caja chica y la obra registra únicamente el egreso, que lo genera el backend — igual que WhatsApp. Los **egresos** siguen exactamente igual.

**Decisiones y por qué:**
- Payload bifurcado por tipo (ingreso manda `proyecto_origen_id`/`proyecto_origen_nombre` con `proyecto_id: null`; egreso queda como estaba) → el payload es semánticamente correcto en vez de depender de que el backend lo reinterprete (el backend igual tiene un guard para fronts viejos, ver PR hermano).
- Label/helper condicionales por tipo en el selector → cambio de UX mínimo que evita que el usuario crea que está imputando el ingreso a la obra.

**Cómo lo implementamos (técnico):** solo `src/components/cajaChica/MovimientoCajaChicaModal.js` — `handleSubmit` bifurca el payload por `formData.type`; el selector cambia label ("Proyecto de origen del dinero") y helper en modo ingreso. `cajaChica.js`, `movimientosService` y el camino de prorrateo (solo egresos) no se tocan.

**Producción / compatibilidad:** deployar **después** del PR de backend (el controller nuevo acepta ingresos caja chica sin `proyecto_id`; contra el backend viejo este payload daría 400). Mientras conviva front viejo con backend nuevo, el guard del backend sanea los payloads legacy.

**Verificación:** payload verificado por tipo (ingreso: `proyecto_origen_id` sin `proyecto_id`; egreso: igual que antes). E2E con backend local: el ingreso aparece solo en la caja chica y el egreso derivado en la obra de origen.

---

## TL;DR
- Ingreso a caja chica desde la web ya no se imputa a la obra: manda `proyecto_origen_id` (origen del dinero) y `proyecto_id: null`; el backend genera el egreso en la obra.
- Egresos y prorrateo sin cambios. Un solo archivo tocado: `MovimientoCajaChicaModal.js`.
- Selector renombrado en modo ingreso: "Proyecto de origen del dinero".
- Deploy después del backend (https://github.com/fedemaidan/sorby_bot_wa/pull/265).

🤖 Generated with [Claude Code](https://claude.com/claude-code)