### PR TITLE
Fix TAR-423 — Texto/valor del CAC según modo + adicionales en export nominal (frontend)

### DIFF
--- a/src/components/PresupuestoDrawer.js
+++ b/src/components/PresupuestoDrawer.js
@@ -105,6 +105,51 @@ const formatMesLegible = (fechaAAAAMM) => {
   return `${meses[parseInt(mes) - 1]} ${anio}`;
 };
 
+const fmtIndice = (v) => Number(v).toLocaleString('es-AR', { maximumFractionDigits: 1 });
+const fmtPct = (p) => `${p >= 0 ? '+' : ''}${Number(p).toLocaleString('es-AR', { maximumFractionDigits: 1 })}%`;
+
+// Leyenda bajo el selector de fecha: qué índice CAC se aplica y por qué, según el modo
+// de la empresa (resolucion = { modo, pendiente, fechaUtilizada, detalle } de /cac/variantes).
+// tipoSufijo: etiqueta corta del subíndice (' MO' / ' MAT') para la pestaña Adicional.
+const CacResumenFecha = ({ resolucion, fechaObjetivo, cacEfectivo, cacTipo, tipoSufijo = '' }) => {
+  const valorStr = cacEfectivo ? ` = ${fmtIndice(cacEfectivo)}` : '';
+  if (resolucion?.modo === 'legacy' && resolucion?.fechaUtilizada) {
+    return (
+      <>Índice CAC{tipoSufijo} aplicado: <strong>{formatMesLegible(resolucion.fechaUtilizada)}</strong>{valorStr} · <em>modalidad clásica: se usa el índice de dos meses antes de la fecha del presupuesto</em></>
+    );
+  }
+  if (resolucion?.pendiente && resolucion?.modo === 'estimado' && resolucion?.detalle) {
+    const d = resolucion.detalle;
+    const pct = d.variacion_mensual_pct?.[cacTipo] ?? d.variacion_mensual_pct?.general;
+    return (
+      <>Índice CAC{tipoSufijo} de <strong>{formatMesLegible(fechaObjetivo)}</strong> · <em>aún no publicado: estimado{cacEfectivo ? <> en <strong>{fmtIndice(cacEfectivo)}</strong></> : ''} proyectando desde {formatMesLegible(d.base_mes)}{pct != null ? ` la variación promedio de los últimos meses (${fmtPct(pct)} mensual)` : ''}. Se ajusta solo cuando salga el oficial.</em></>
+    );
+  }
+  if (resolucion?.pendiente) {
+    return (
+      <>Índice CAC{tipoSufijo} de <strong>{formatMesLegible(fechaObjetivo)}</strong> · <em>aún no publicado: se usa el último disponible{resolucion?.fechaUtilizada ? ` (${formatMesLegible(resolucion.fechaUtilizada)})` : ''}{valorStr}. Cuando se publique el del mes, el total se actualiza solo.</em></>
+    );
+  }
+  return <>Índice CAC{tipoSufijo} de <strong>{formatMesLegible(fechaObjetivo)}</strong>{valorStr}</>;
+};
+
+// Nota del recuadro "Equivale a CAC …": de qué mes es el índice usado y si el total se va a ajustar.
+const CacEquivalenciaNota = ({ resolucion, fechaObjetivo, cacEfectivo, cacTipo }) => {
+  const valorStr = cacEfectivo ? ` = ${fmtIndice(cacEfectivo)}` : '';
+  if (resolucion?.modo === 'legacy' && resolucion?.fechaUtilizada) {
+    return <> (CAC {formatMesLegible(resolucion.fechaUtilizada)}{valorStr}, el de dos meses antes de la fecha del presupuesto). Este índice queda fijo para el presupuesto.</>;
+  }
+  if (resolucion?.pendiente && resolucion?.modo === 'estimado' && resolucion?.detalle) {
+    const d = resolucion.detalle;
+    const pct = d.variacion_mensual_pct?.[cacTipo] ?? d.variacion_mensual_pct?.general;
+    return <> (CAC estimado de {formatMesLegible(fechaObjetivo)}{valorStr}: proyectado desde {formatMesLegible(d.base_mes)}{pct != null ? ` con la variación promedio de los últimos meses publicados, ${fmtPct(pct)} mensual` : ''}). Cuando se publique el oficial, el total se ajusta automáticamente.</>;
+  }
+  if (resolucion?.pendiente) {
+    return <> (último CAC publicado{resolucion?.fechaUtilizada ? `: ${formatMesLegible(resolucion.fechaUtilizada)}` : ''}{valorStr}). Cuando se publique el CAC de {formatMesLegible(fechaObjetivo)}, el total se actualiza automáticamente.</>;
+  }
+  return <> (CAC {formatMesLegible(fechaObjetivo)}{valorStr}). Se ajusta automáticamente por inflación.</>;
+};
+
 /**
  * PresupuestoDrawer - Drawer reutilizable para crear, editar y gestionar presupuestos
  * 
@@ -155,6 +200,9 @@ const PresupuestoDrawer = ({
   // Cuando true, oculta el bloque de filtros (categorías/proveedores/etapa) detrás de un botón "Configuración avanzada".
   // Útil cuando el usuario ya eligió los filtros fuera del drawer (p.ej. Control de presupuestos).
   filtrosColapsados = false,
+  // Modo CAC de la empresa (presupuesto_cac_modo): 'legacy' | 'automatico' | 'estimado'.
+  // Define qué variante del índice se muestra y el texto explicativo (debe coincidir con lo que guarda el backend).
+  cacModo = 'legacy',
 }) => {
   const [filtrosExpandidos, setFiltrosExpandidos] = useState(false);
   const router = useRouter();
@@ -196,16 +244,16 @@ const PresupuestoDrawer = ({
   const hoyStr = new Date().toISOString().split('T')[0];
   const [fechaPresupuesto, setFechaPresupuesto] = useState(hoyStr);
   const [fechaAdicional, setFechaAdicional] = useState(hoyStr);
-  const [cacFechaAplicada, setCacFechaAplicada] = useState(null); // YYYY-MM del CAC que se aplica
-  const [cacEsFallback, setCacEsFallback] = useState(false); // true si el CAC no existía y se usó el último disponible
-  const [cacFechaFallback, setCacFechaFallback] = useState(null); // YYYY-MM del CAC realmente usado (cuando es fallback)
+  const [cacFechaAplicada, setCacFechaAplicada] = useState(null); // YYYY-MM del mes objetivo (fecha del presupuesto)
+  // Cómo se resolvió el índice según el modo CAC de la empresa:
+  // { modo, pendiente, fechaUtilizada, detalle } — detalle solo cuando el modo estimado proyectó.
+  const [cacResolucion, setCacResolucion] = useState(null);
 
   // === Estado: Cotizaciones para adicional (separado del principal)
   const [adicionalDolarRate, setAdicionalDolarRate] = useState(null);
   const [adicionalCacIndice, setAdicionalCacIndice] = useState(null);
   const [adicionalCacFechaAplicada, setAdicionalCacFechaAplicada] = useState(null);
-  const [adicionalCacEsFallback, setAdicionalCacEsFallback] = useState(false);
-  const [adicionalCacFechaFallback, setAdicionalCacFechaFallback] = useState(null);
+  const [adicionalCacResolucion, setAdicionalCacResolucion] = useState(null);
 
   // === Estado: Historial ===
   const [mostrarHistorial, setMostrarHistorial] = useState(false);
@@ -332,8 +380,7 @@ const PresupuestoDrawer = ({
     const setCac = target === 'adicional' ? setAdicionalCacIndice : setCacIndice;
     const setCacFecha = target === 'adicional' ? setAdicionalCacFechaAplicada : setCacFechaAplicada;
     const setSubs = target === 'adicional' ? setAdicionalCacSubindices : setCacSubindices;
-    const setEsFallback = target === 'adicional' ? setAdicionalCacEsFallback : setCacEsFallback;
-    const setFechaFb = target === 'adicional' ? setAdicionalCacFechaFallback : setCacFechaFallback;
+    const setResolucion = target === 'adicional' ? setAdicionalCacResolucion : setCacResolucion;
 
     setLoadingRates(true);
     try {
@@ -352,26 +399,35 @@ const PresupuestoDrawer = ({
         }
       }
 
-      // CAC: usar el mes REAL del presupuesto (sin corrimiento). Si no salió, último disponible.
+      // CAC: resolver la variante que corresponde al modo de la empresa (legacy/automatico/estimado),
+      // la misma que va a usar el backend al guardar. El valor y el texto explicativo salen de acá.
       const cacFecha = mesDeFecha(fechaStr);
       setCacFecha(cacFecha);
       if (cacFecha) {
-        const cacData = await MonedasService.obtenerCAC(cacFecha).catch(() => null);
+        const variantes = await MonedasService.obtenerVariantesCAC(cacFecha).catch(() => null);
         if (isCancelled()) return;
-        if (cacData) {
-          setCac(cacData.general || cacData.valor || null);
-          setSubs({ general: cacData.general || cacData.valor || null, mano_obra: cacData.mano_obra || null, materiales: cacData.materiales || null });
-          setEsFallback(false);
-          setFechaFb(null);
+        const v = variantes?.[cacModo];
+        if (v && (v.general || v.mano_obra || v.materiales)) {
+          setCac(v.general ?? null);
+          setSubs({ general: v.general ?? null, mano_obra: v.mano_obra ?? null, materiales: v.materiales ?? null });
+          setResolucion({ modo: cacModo, pendiente: !!variantes.pendiente, fechaUtilizada: v.fecha_utilizada || null, detalle: v.detalle || null });
         } else {
-          // Fallback: último CAC disponible (no sobreescribir la fecha calculada)
-          const cacFallback = await MonedasService.listarCAC({ limit: 1 }).catch(() => null);
+          // Fallback (backend sin /cac/variantes todavía, o sin datos para el modo):
+          // CAC del mes real, y si no salió, el último disponible.
+          const cacData = await MonedasService.obtenerCAC(cacFecha).catch(() => null);
           if (isCancelled()) return;
-          if (cacFallback?.[0]) {
-            setCac(cacFallback[0].general || cacFallback[0].valor || null);
-            setSubs({ general: cacFallback[0].general || cacFallback[0].valor || null, mano_obra: cacFallback[0].mano_obra || null, materiales: cacFallback[0].materiales || null });
-            setEsFallback(true);
-            setFechaFb(cacFallback[0].fecha || null);
+          if (cacData) {
+            setCac(cacData.general || cacData.valor || null);
+            setSubs({ general: cacData.general || cacData.valor || null, mano_obra: cacData.mano_obra || null, materiales: cacData.materiales || null });
+            setResolucion({ modo: 'automatico', pendiente: false, fechaUtilizada: cacFecha, detalle: null });
+          } else {
+            const cacFallback = await MonedasService.listarCAC({ limit: 1 }).catch(() => null);
+            if (isCancelled()) return;
+            if (cacFallback?.[0]) {
+              setCac(cacFallback[0].general || cacFallback[0].valor || null);
+              setSubs({ general: cacFallback[0].general || cacFallback[0].valor || null, mano_obra: cacFallback[0].mano_obra || null, materiales: cacFallback[0].materiales || null });
+              setResolucion({ modo: 'automatico', pendiente: true, fechaUtilizada: cacFallback[0].fecha || null, detalle: null });
+            }
           }
         }
       }
@@ -1117,7 +1173,7 @@ const PresupuestoDrawer = ({
                     <CalendarMonthIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
                     <Typography variant="caption" color="text.secondary">
                       {indexacion === 'CAC'
-                        ? <>Índice CAC de <strong>{formatMesLegible(cacFechaAplicada)}</strong>{cacEsFallback ? <> · <em>aún no publicado, se estima con el último disponible{cacFechaFallback ? ` (${formatMesLegible(cacFechaFallback)})` : ''}</em></> : ''}{cacEfectivo ? <> = {Number(cacEfectivo).toLocaleString('es-AR', { maximumFractionDigits: 1 })}</> : ''}</>
+                        ? <CacResumenFecha resolucion={cacResolucion} fechaObjetivo={cacFechaAplicada} cacEfectivo={cacEfectivo} cacTipo={cacTipoActivo} />
                         : <>Dólar blue aplicado: <strong>{dayjs(fechaPresupuesto).format('DD/MM/YYYY')}</strong></>
                       }
                     </Typography>
@@ -1286,7 +1342,7 @@ const PresupuestoDrawer = ({
                     <Alert severity="info" variant="outlined" icon={<InfoOutlinedIcon fontSize="small" />} sx={{ mt: 1 }}>
                       <Typography variant="caption">
                         {indexacion === 'CAC' && cacEfectivo ? (
-                          <>Equivale a <strong>CAC {(parseFloat(monto) / cacEfectivo).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</strong> (CAC {formatMesLegible(cacFechaAplicada)} = {Number(cacEfectivo).toLocaleString('es-AR')}). Se ajusta automáticamente por inflación.</>
+                          <>Equivale a <strong>CAC {(parseFloat(monto) / cacEfectivo).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</strong><CacEquivalenciaNota resolucion={cacResolucion} fechaObjetivo={cacFechaAplicada} cacEfectivo={cacEfectivo} cacTipo={cacTipoActivo} /></>
                         ) : indexacion === 'USD' && dolarEfectivo ? (
                           <>Equivale a <strong>USD {(parseFloat(monto) / dolarEfectivo).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</strong> (USD {dayjs(fechaPresupuesto).format('DD/MM/YYYY')} = ${Number(dolarEfectivo).toLocaleString('es-AR')}). Se ajusta al valor del dólar.</>
                         ) : loadingRates ? (
@@ -1830,7 +1886,7 @@ const PresupuestoDrawer = ({
                         <CalendarMonthIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
                         <Typography variant="caption" color="text.secondary">
                           {nuevaIndexacion === 'CAC'
-                            ? <>Índice CAC de <strong>{formatMesLegible(cacFechaAplicada)}</strong>{cacEsFallback ? <> · <em>aún no publicado, se estima con el último disponible{cacFechaFallback ? ` (${formatMesLegible(cacFechaFallback)})` : ''}</em></> : ''}{cacEfectivo ? <> = {Number(cacEfectivo).toLocaleString('es-AR')}</> : ''}</>
+                            ? <CacResumenFecha resolucion={cacResolucion} fechaObjetivo={cacFechaAplicada} cacEfectivo={cacEfectivo} cacTipo={cacTipoActivo} />
                             : <>Dólar blue aplicado: <strong>{dayjs(fechaPresupuesto).format('DD/MM/YYYY')}</strong>{dolarEfectivo ? <> = ${Number(dolarEfectivo).toLocaleString('es-AR')}</> : ''}</>
                           }
                         </Typography>
@@ -2314,7 +2370,13 @@ const PresupuestoDrawer = ({
                           <CalendarMonthIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
                           <Typography variant="caption" color="text.secondary">
                             {presupuesto.indexacion === 'CAC'
-                              ? <>Índice CAC{presupuesto.cac_tipo === 'mano_obra' ? ' MO' : presupuesto.cac_tipo === 'materiales' ? ' MAT' : ''}: <strong>{formatMesLegible(adicionalCacFechaAplicada || cacFechaAplicada)}</strong> = {Number(adicionalCacEfectivo).toLocaleString('es-AR')}{adicionalCacOverride ? ' (manual)' : ''}</>
+                              ? <><CacResumenFecha
+                                  resolucion={adicionalCacResolucion || cacResolucion}
+                                  fechaObjetivo={adicionalCacFechaAplicada || cacFechaAplicada}
+                                  cacEfectivo={adicionalCacEfectivo}
+                                  cacTipo={presupuesto.cac_tipo || 'general'}
+                                  tipoSufijo={presupuesto.cac_tipo === 'mano_obra' ? ' MO' : presupuesto.cac_tipo === 'materiales' ? ' MAT' : ''}
+                                />{adicionalCacOverride ? ' (manual)' : ''}</>
                               : <>Dólar blue: <strong>{dayjs(fechaAdicional).format('DD/MM/YYYY')}</strong> = ${Number(adicionalDolarEfectivo).toLocaleString('es-AR')}{adicionalDolarOverride ? ' (manual)' : ''}</>
                             }
                           </Typography>
@@ -2676,7 +2738,7 @@ const PresupuestoDrawer = ({
                           cacTipo: presupuesto.cac_tipo || null,
                           baseCalculo: presupuesto.base_calculo || 'total',
                           presupuestadoNativo: Number(presupuesto.monto != null ? presupuesto.monto : presupuesto.monto_ingresado || 0),
-                          presupuestadoNominal: calcPresupuestadoNominal(presupuesto),
+                          presupuestadoNominal: calcPresupuestadoNominal(presupuesto, cacModo),
                           montoIngresado: presupuesto.monto_ingresado != null ? Number(presupuesto.monto_ingresado) : null,
                           cacIndiceActual: cacActualEfectivo || cacEfectivo,
                           tipoCambioActual: dolarEfectivo,

--- a/src/components/ProveedorDrawer.js
+++ b/src/components/ProveedorDrawer.js
@@ -1242,6 +1242,7 @@ function ProveedorDrawer({ open, onClose, proveedorId, proveedorNombreHint, empr
   const [presupuestoDrawerOpen, setPresupuestoDrawerOpen] = useState(false);
   const [etapasEmpresa, setEtapasEmpresa] = useState([]);
   const [proveedoresNombres, setProveedoresNombres] = useState([]);
+  const [cacModoEmpresa, setCacModoEmpresa] = useState('legacy');
 
   // Imputar saldo a favor (reparte monto_sin_imputar entre facturas pendientes)
   const [imputarSaldoFavorLoading, setImputarSaldoFavorLoading] = useState(false);
@@ -1338,7 +1339,10 @@ function ProveedorDrawer({ open, onClose, proveedorId, proveedorNombreHint, empr
     if (!presupuestoDrawerOpen || !empresaId) return;
     if (etapasEmpresa.length === 0) {
       getEmpresaById(empresaId)
-        .then((emp) => setEtapasEmpresa(emp?.etapas || []))
+        .then((emp) => {
+          setEtapasEmpresa(emp?.etapas || []);
+          setCacModoEmpresa(emp?.presupuesto_cac_modo || 'legacy');
+        })
         .catch(() => {});
     }
     if (proveedoresNombres.length === 0) {
@@ -1571,6 +1575,7 @@ function ProveedorDrawer({ open, onClose, proveedorId, proveedorNombreHint, empr
           proyectos={proyectos}
           categorias={categoriasEmpresa || []}
           etapas={etapasEmpresa}
+          cacModo={cacModoEmpresa}
         />
       )}
     </Drawer>

--- a/src/pages/control-presupuestos.js
+++ b/src/pages/control-presupuestos.js
@@ -2465,6 +2465,7 @@ const ControlPresupuestosPage = () => {
         presupuesto={drawerPresupuesto.presupuesto}
         drawerView={drawerPresupuesto.drawerView || 'full'}
         filtrosColapsados
+        cacModo={cacModo}
         onRecalcular={async (id) => {
           try {
             const { success } = await presupuestoService.recalcularPresupuesto(id, empresaId);

--- a/src/pages/presupuestos.js
+++ b/src/pages/presupuestos.js
@@ -83,6 +83,7 @@ const PresupuestosPage = () => {
   const [proyectos, setProyectos] = useState([]);
   const [categorias, setCategorias] = useState([]);
   const [empresaId, setEmpresaId] = useState(null);
+  const [cacModo, setCacModo] = useState('legacy');
   const [alert, setAlert] = useState({ open: false, message: '', severity: 'info' });
   const [proveedores, setProveedores] = useState([]);
   const [etapas, setEtapas] = useState([]);
@@ -239,6 +240,7 @@ const PresupuestosPage = () => {
 
         setProyectos(proyectosUsuario);
         setEmpresaId(empresa.id);
+        setCacModo(empresa.presupuesto_cac_modo || 'legacy');
         const provNombres = await proveedorService.getNombres(empresa.id);
         setProveedores(provNombres);
 
@@ -698,6 +700,7 @@ const PresupuestosPage = () => {
           categorias={categorias}
           etapas={etapas}
           proveedoresEmpresa={proveedores}
+          cacModo={cacModo}
         />
 
       </Box>

--- a/src/services/monedasService.js
+++ b/src/services/monedasService.js
@@ -74,6 +74,17 @@ const MonedasService = {
   },
 
   /**
+   * Resolver las 3 variantes del índice CAC (legacy / estimado / automatico) para un mes.
+   * Devuelve { fecha_objetivo, pendiente, legacy, estimado, automatico }; cada variante trae
+   * { general, mano_obra, materiales, fecha_utilizada, disponible } (+ detalle en estimado proyectado).
+   * @param {string} fecha - formato YYYY-MM
+   */
+  obtenerVariantesCAC: async (fecha) => {
+    const res = await api.get(`/monedas/cac/variantes/${encodeURIComponent(fecha)}`);
+    return res.data;
+  },
+
+  /**
    * Crear/actualizar índice CAC para un mes
    * @param {Object} data - { fecha, general, materiales, mano_obra }
    */

--- a/src/utils/controlPresupuesto/presupuestoNominal.js
+++ b/src/utils/controlPresupuesto/presupuestoNominal.js
@@ -8,6 +8,8 @@
  * cotizacion_snapshot (el valor del momento en que se agregaron, no el actual).
  */
 
+import { snapshotCacIndice } from 'src/utils/cac/pickCac';
+
 const num = (v) => {
   const n = Number(v);
   return Number.isFinite(n) ? n : 0;
@@ -17,8 +19,10 @@ const num = (v) => {
  * Presupuestado nominal en pesos (o en su moneda nativa si el presupuesto es plano).
  * - Indexado (CAC/USD): monto_ingresado original + Σ adicionales valuados a su snapshot.
  * - Plano: presupuesto.monto (ya incluye adicionales, en su moneda nativa).
+ * cacModo: modo CAC de la empresa, para elegir la variante en snapshots nuevos
+ * (snapshotCacIndice también resuelve el shape viejo cac_indice/cac_general).
  */
-export function calcPresupuestadoNominal(presupuesto) {
+export function calcPresupuestadoNominal(presupuesto, cacModo = 'legacy') {
   const p = presupuesto || {};
   if (p.indexacion === 'CAC' || p.indexacion === 'USD') {
     const base = num(p.monto_ingresado);
@@ -26,7 +30,7 @@ export function calcPresupuestadoNominal(presupuesto) {
       const monto = num(a?.monto);
       const snap = a?.cotizacion_snapshot || {};
       const cotiz = p.indexacion === 'CAC'
-        ? (snap.cac_indice ?? snap.cac_general ?? null)
+        ? snapshotCacIndice(snap, p.cac_tipo, cacModo)
         : (snap.dolar_blue ?? null);
       return s + (cotiz ? monto * num(cotiz) : 0);
     }, 0);


### PR DESCRIPTION
Ticket: [TAR-423 — Presupuesto (Notion)](https://app.notion.com/p/Presupuesto-37d50a1e534180059458dd92efcb9219?v=3384ca8149254d58b1781f468b1bf8bf&source=copy_link). PR hermano (backend): [sorby_bot_wa#266](https://github.com/fedemaidan/sorby_bot_wa/pull/266).

Follow-up del rediseño de CAC de TAR-423: el drawer de presupuestos explicaba (y a veces valuaba) el índice CAC como si todas las empresas usaran el modo automático, y el export nominal sumaba $0 por los adicionales nuevos.

---

## 1) Texto y valor del CAC según el modo de la empresa

**Causa raíz / Problema:** el drawer siempre pedía el CAC del mes real con fallback al último disponible — la lógica del modo **automático** — sin importar la configuración de la empresa. Con modo clásico decía "aún no publicado, se estima con el último disponible" y "se ajusta automáticamente por inflación": ambas cosas falsas (el clásico usa el índice de 2 meses atrás y queda fijo). Con estimado, no explicaba de dónde salía el número proyectado.

**Cómo lo hicimos (funcional):** el texto bajo la fecha y el recuadro "Equivale a CAC…" ahora cuentan lo que realmente va a pasar según la configuración:
- **Clásico:** "Índice CAC aplicado: Mayo 2026 = 17.423,2 · modalidad clásica: se usa el índice de dos meses antes de la fecha del presupuesto" / "…Este índice queda fijo para el presupuesto."
- **Automático (mes sin publicar):** "se usa el último disponible (Mayo 2026)… Cuando se publique el del mes, el total se actualiza solo."
- **Estimado (mes sin publicar):** "estimado en 21.035,6 proyectando desde Mayo 2026 la variación promedio de los últimos meses (+1,4% mensual). Se ajusta solo cuando salga el oficial." — transparencia de cómo se llegó al número.
- **Mes ya publicado:** el valor real, sin advertencias.

Aplica en los tres lugares del drawer: crear, editar y **adicional** (conservando el sufijo MO/MAT y la marca "(manual)" del override).

**Decisiones y por qué:**
- Consumir el endpoint nuevo `/monedas/cac/variantes/:fecha` y elegir la variante del modo, en vez de arreglar solo los strings → el valor mostrado y el guardado salen de la misma resolución; en clásico el drawer antes podía mostrar un índice distinto al que el backend persiste.
- Prop `cacModo` (default `legacy`) pasada por los call sites, en vez de que el drawer fetchee la empresa → los tres padres ya tienen (o ya traían) la empresa; sin requests duplicados.
- Fallback al camino viejo (`obtenerCAC` + `listarCAC`) si `/variantes` falla → deploy desfasado front/back seguro: con backend viejo el drawer se comporta exactamente como hoy.
- Componentes de texto compartidos (`CacResumenFecha`, `CacEquivalenciaNota`) a nivel módulo → un solo lugar para las 4 leyendas, reusado en crear/editar/adicional.

**Cómo lo implementamos (técnico):**
- `src/services/monedasService.js`: `obtenerVariantesCAC(fecha)`.
- `src/components/PresupuestoDrawer.js`: prop `cacModo`; `cargarCotizacionesPorFecha` resuelve por variantes y guarda `cacResolucion = { modo, pendiente, fechaUtilizada, detalle }` (reemplaza `cacEsFallback`/`cacFechaFallback`); helpers `CacResumenFecha` / `CacEquivalenciaNota`; la pestaña Adicional usa la resolución propia de su fecha con fallback a la principal.
- Call sites: `control-presupuestos.js` (ya tenía `cacModo` calculado), `presupuestos.js` (nuevo estado desde la empresa), `ProveedorDrawer.js` (lo toma del `getEmpresaById` que ya hacía).

## 2) Export nominal: adicionales con snapshot nuevo valían $0

**Causa raíz / Problema:** `calcPresupuestadoNominal` valuaba los adicionales con el shape viejo del snapshot (`cac_indice`/`cac_general`). Los adicionales creados post-rework guardan variantes (`cac.general.{legacy,estimado,automatico}`) → la cotización daba `null` y el adicional sumaba $0 en el presupuestado nominal del export PDF/Excel.

**Cómo lo hicimos (funcional):** el export en modo nominal vuelve a incluir los adicionales en pesos, valuados a la cotización de su fecha.

**Cómo lo implementamos (técnico):** `src/utils/controlPresupuesto/presupuestoNominal.js` usa `snapshotCacIndice(snap, cac_tipo, cacModo)` (resuelve ambos shapes); `calcPresupuestadoNominal` recibe `cacModo` y el drawer se lo pasa.

**Producción / compatibilidad:** sin cambios de datos. Con backend viejo (sin `/variantes`) el drawer cae al comportamiento actual. `calcPresupuestadoNominal` mantiene compatibilidad con snapshots viejos vía `snapshotCacIndice`.

**Verificación:** `next lint` limpio en los 6 archivos. El fix del resumen (adicionales en tarjetas/chips/pendiente) vive en el PR hermano de backend; validación manual pendiente: crear/editar/adicional en los 3 modos, y export nominal con adicional.

**Notas al código:**
- `PresupuestoDrawer:cargarCotizacionesPorFecha` → cuando la variante del modo viene vacía (p.ej. clásico con fecha tan futura que el mes−2 no existe) se cae al fallback etiquetado como `automatico`: el texto dice honestamente "se usa el último disponible" en vez de atribuirle al modo clásico un índice que no es el suyo.
- `adicionalCacResolucion || cacResolucion` en la pestaña Adicional → mismo patrón que ya usaban los valores (`adicionalCacEfectivo || cacEfectivo`): cuando la fecha del adicional coincide con la del presupuesto no se re-fetchea, se reusa la resolución principal.
- `calcPresupuestadoNominal` usa el modo actual de la empresa para valuar adicionales nuevos: el modo exacto activo al crear cada adicional no se persiste; `pickCac` tiene cadena de fallback si la variante falta.

---

## TL;DR
- El drawer de presupuestos (crear, editar y adicional) muestra el índice CAC y su explicación según el modo de la empresa: clásico = índice de 2 meses atrás fijo; automático = último disponible y se actualiza solo; estimado = proyección con el % mensual y desde qué mes, para dar confianza en el número.
- El valor mostrado ahora es el mismo que guarda el backend (consume `/monedas/cac/variantes`, PR hermano sorby_bot_wa#266), con fallback al comportamiento actual si el backend aún no está deployado.
- Fix export nominal: los adicionales con snapshot nuevo ya no suman $0 (`snapshotCacIndice` en `calcPresupuestadoNominal`).
- Archivos: `PresupuestoDrawer.js`, `monedasService.js`, `presupuestoNominal.js` + `cacModo` desde `control-presupuestos.js`, `presupuestos.js` y `ProveedorDrawer.js`. Sin migración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
