### PR TITLE
feat(cobros): Cash Flow multi-moneda + vista de gestión de cobranzas (TAR-574/575/576)

### DIFF
--- a/src/pages/cobros.js
+++ b/src/pages/cobros.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import {
@@ -29,6 +29,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  TablePagination,
   Chip,
   LinearProgress,
   Paper,
@@ -38,6 +39,8 @@ import { LineChart } from '@mui/x-charts/LineChart';
 import AddIcon from '@mui/icons-material/Add';
 import SearchIcon from '@mui/icons-material/Search';
 import InboxIcon from '@mui/icons-material/Inbox';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
@@ -69,6 +72,38 @@ const sortPlanes = (planes, sortBy) => {
   }
 };
 
+// ── Cash Flow: tracks ARS/USD (los buckets llegan como { ARS, USD }) ──
+// pickTrack tolera el shape viejo (número plano) y el nuevo ({ ARS, USD }).
+const pickTrack = (x, track) => (x && typeof x === 'object') ? (Number(x[track]) || 0) : (Number(x) || 0);
+const sumTrack = (arr, track) => (arr || []).reduce((a, b) => a + pickTrack(b, track), 0);
+const hasTrack = (arr, track) => (arr || []).some((x) => pickTrack(x, track) !== 0);
+const fmtMoney = (n, track = 'ARS') => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: track === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
+
+// ── Labels de período legibles (TAR-576): '2026-08' → 'ago 26'; '2026-W33' → 'Sem 33 · 3–9 ago' ──
+const MESES_CORTOS = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+const rangoSemanaISO = (year, week) => {
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const day = jan4.getUTCDay() || 7;
+  const monday = new Date(jan4);
+  monday.setUTCDate(jan4.getUTCDate() - day + 1 + (week - 1) * 7);
+  const sunday = new Date(monday);
+  sunday.setUTCDate(monday.getUTCDate() + 6);
+  return [monday, sunday];
+};
+const etiquetaPeriodo = (key) => {
+  const mes = String(key || '').match(/^(\d{4})-(\d{2})$/);
+  if (mes) return `${MESES_CORTOS[Number(mes[2]) - 1]} ${mes[1].slice(2)}`;
+  const sem = String(key || '').match(/^(\d{4})-W(\d{2})$/);
+  if (sem) {
+    const [ini, fin] = rangoSemanaISO(Number(sem[1]), Number(sem[2]));
+    const dIni = ini.getUTCDate(), dFin = fin.getUTCDate();
+    const mIni = MESES_CORTOS[ini.getUTCMonth()], mFin = MESES_CORTOS[fin.getUTCMonth()];
+    const rango = mIni === mFin ? `${dIni}–${dFin} ${mFin}` : `${dIni} ${mIni}–${dFin} ${mFin}`;
+    return `Sem ${sem[2]} · ${rango}`;
+  }
+  return String(key || '');
+};
+
 const CobrosList = () => {
   const { user } = useAuthContext();
   const router = useRouter();
@@ -78,11 +113,18 @@ const CobrosList = () => {
   const [busqueda, setBusqueda] = useState('');
   const [sortBy, setSortBy] = useState('reciente');
   const [vista, setVista] = useState('tabla'); // 'cards' | 'tabla'
-  const [seccion, setSeccion] = useState('planes'); // 'planes' | 'cashflow'
-  const [cashflow, setCashflow] = useState({ meses: [], esperado: [], cobrado: [], acumulado: [], kpis: {}, vencido: { monto: 0, cuotas: 0 }, realizado_anterior: 0 });
+  const [seccion, setSeccion] = useState('planes'); // 'planes' | 'cashflow' | 'gestion'
+  const [cashflow, setCashflow] = useState({ meses: [], esperado: [], cobrado: [], acumulado: [], kpis: {}, vencido: { ARS: 0, USD: 0, cuotas: 0 }, realizado_anterior: { ARS: 0, USD: 0 } });
   const [cfGranularidad, setCfGranularidad] = useState('adaptativo'); // 'mes' | 'semana' | 'adaptativo'
   const [cfVista, setCfVista] = useState('grafico'); // 'grafico' | 'tabla'
   const [cfHistorico, setCfHistorico] = useState(false);
+  const [cfTrack, setCfTrack] = useState('ARS'); // 'ARS' | 'USD' — track visible (sólo se ofrece si hay USD)
+  const [gestion, setGestion] = useState([]); // A2: lista accionable por cuota (detalle)
+  const [gestionMes, setGestionMes] = useState(() => new Date().toISOString().slice(0, 7)); // filtro por mes (default: mes actual)
+  const [gestionPorObra, setGestionPorObra] = useState(true); // toggle "por obra ↔ todo junto" (default: por obra)
+  const [gestionColapsadas, setGestionColapsadas] = useState(() => new Set()); // obras colapsadas (accordion)
+  const [gestionPage, setGestionPage] = useState(0);
+  const [gestionRpp, setGestionRpp] = useState(25);
   const [proyectos, setProyectos] = useState([]);
   const [alert, setAlert] = useState({ open: false, message: '', severity: 'info' });
   const [confirmEliminar, setConfirmEliminar] = useState(null); // plan object or null
@@ -101,6 +143,18 @@ const CobrosList = () => {
       .then((res) => setCashflow(res?.data?.data || {}))
       .catch(() => setCashflow({ meses: [], esperado: [], cobrado: [] }));
   }, [empresaId, filtroProyecto, cfGranularidad, cfHistorico]);
+
+  // Vista de gestión (A2): lista accionable por cuota. Se pide sólo al entrar a la pestaña.
+  // El detalle son las cuotas pendientes/vencidas (no depende de la ventana), así que no pasamos histórico.
+  useEffect(() => {
+    if (!empresaId || seccion !== 'gestion') return;
+    planCobroService.getCashflow(empresaId, filtroProyecto || null, 'mes', { detalle: true })
+      .then((res) => setGestion(res?.data?.data?.detalle || []))
+      .catch(() => setGestion([]));
+  }, [empresaId, filtroProyecto, seccion]);
+
+  // Reset de paginación al cambiar filtro/modo/datos de la vista de gestión.
+  useEffect(() => { setGestionPage(0); }, [gestionMes, gestionPorObra, gestion]);
 
   const filterParams = filtroEstado ? { estado: filtroEstado } : {};
   const { planes, loading, error, refresh } = usePlanesCobroList(empresaId, filterParams);
@@ -158,27 +212,35 @@ const CobrosList = () => {
             </Button>
           </Stack>
 
-          {/* KPIs de situación — siempre visibles, en cualquier tab */}
+          {/* KPIs de situación — siempre visibles. ARS y USD como líneas de igual peso (tracks distintos, no se suman). */}
           {(() => {
             const k = cashflow.kpis || {};
-            const venc = cashflow.vencido || { monto: 0, cuotas: 0 };
-            const money = (n) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 });
+            const venc = cashflow.vencido || { ARS: 0, USD: 0, cuotas: 0 };
+            const vencARS = pickTrack(venc, 'ARS');
+            // ¿Hay algún monto en dólares (planes USD)? Sólo entonces mostramos la línea USD.
+            const hayUSD = pickTrack(venc, 'USD') !== 0
+              || ['periodo_actual', 'vencido', 'proximos_90'].some((c) => pickTrack(k[c], 'USD') !== 0);
+            const usdLine = (obj) => (hayUSD && pickTrack(obj, 'USD') ? fmtMoney(pickTrack(obj, 'USD'), 'USD') : null);
             const items = [
-              { label: 'Vencido', value: money(venc.monto), border: '#D32F2F', danger: true, sub: venc.cuotas ? `${venc.cuotas} cuota${venc.cuotas > 1 ? 's' : ''}` : 'al día' },
-              { label: 'A cobrar este mes', value: money(k.periodo_actual), border: '#1976D2' },
-              { label: 'Próximos 90 días', value: money(k.proximos_90), border: '#2E7D32' },
+              { label: 'Vencido', value: fmtMoney(vencARS), valueUsd: usdLine(venc), border: '#D32F2F', danger: true, sub: venc.cuotas ? `${venc.cuotas} cuota${venc.cuotas > 1 ? 's' : ''}` : 'al día' },
+              { label: 'A cobrar este mes', value: fmtMoney(pickTrack(k.periodo_actual, 'ARS')), valueUsd: usdLine(k.periodo_actual), border: '#1976D2' },
+              { label: 'Próximos 90 días', value: fmtMoney(pickTrack(k.proximos_90, 'ARS')), valueUsd: usdLine(k.proximos_90), border: '#2E7D32' },
             ];
             return (
               <Grid container spacing={2} mb={3}>
-                {items.map((m) => (
+                {items.map((m) => {
+                  const color = m.danger && vencARS > 0 ? 'error.main' : 'text.primary';
+                  return (
                   <Grid item xs={12} sm={4} key={m.label}>
-                    <Paper variant="outlined" sx={{ p: 1.5, borderTop: `3px solid ${m.border}`, bgcolor: m.danger && venc.monto > 0 ? '#FFF5F5' : 'background.paper' }}>
+                    <Paper variant="outlined" sx={{ p: 1.5, borderTop: `3px solid ${m.border}`, bgcolor: m.danger && vencARS > 0 ? '#FFF5F5' : 'background.paper' }}>
                       <Typography variant="overline" color="text.secondary" display="block">{m.label}</Typography>
-                      <Typography variant="h6" fontWeight={700} color={m.danger && venc.monto > 0 ? 'error.main' : 'text.primary'}>{m.value}</Typography>
+                      <Typography variant="h6" fontWeight={700} color={color} lineHeight={1.25}>{m.value}</Typography>
+                      {m.valueUsd && <Typography variant="h6" fontWeight={700} color={color} lineHeight={1.25}>{m.valueUsd}</Typography>}
                       {m.sub && <Typography variant="caption" color="text.secondary">{m.sub}</Typography>}
                     </Paper>
                   </Grid>
-                ))}
+                  );
+                })}
               </Grid>
             );
           })()}
@@ -192,12 +254,19 @@ const CobrosList = () => {
           >
             <ToggleButton value="planes">Planes</ToggleButton>
             <ToggleButton value="cashflow">Cashflow</ToggleButton>
+            <ToggleButton value="gestion">Gestión</ToggleButton>
           </ToggleButtonGroup>
 
           {seccion === 'cashflow' && (() => {
-            const money = (n) => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: 'ARS', maximumFractionDigits: 0 });
-            const k = cashflow.kpis || {};
-            const venc = cashflow.vencido || { monto: 0, cuotas: 0 };
+            // Track ARS por defecto; el toggle USD sólo aparece si hay planes en dólares.
+            const usdPresent = hasTrack(cashflow.esperado, 'USD') || hasTrack(cashflow.cobrado, 'USD') || pickTrack(cashflow.vencido, 'USD') !== 0;
+            const track = (usdPresent && cfTrack === 'USD') ? 'USD' : 'ARS';
+            const money = (n) => fmtMoney(n, track);
+            const labels = (cashflow.meses || []).map(etiquetaPeriodo);
+            const esperado = (cashflow.esperado || []).map((x) => pickTrack(x, track));
+            const cobrado = (cashflow.cobrado || []).map((x) => pickTrack(x, track));
+            const acumulado = (cashflow.acumulado || []).map((x) => pickTrack(x, track));
+            const realizadoAnterior = pickTrack(cashflow.realizado_anterior, track);
             const periodoLabel = cfGranularidad === 'semana' ? 'semana' : cfGranularidad === 'adaptativo' ? 'período' : 'mes';
             return (
             <Box sx={{ mb: 3 }}>
@@ -211,6 +280,12 @@ const CobrosList = () => {
                   <ToggleButton value="grafico">Gráfico</ToggleButton>
                   <ToggleButton value="tabla">Tabla</ToggleButton>
                 </ToggleButtonGroup>
+                {usdPresent && (
+                  <ToggleButtonGroup value={track} exclusive size="small" onChange={(_, v) => v && setCfTrack(v)}>
+                    <ToggleButton value="ARS">Pesos</ToggleButton>
+                    <ToggleButton value="USD">Dólares</ToggleButton>
+                  </ToggleButtonGroup>
+                )}
                 <ToggleButton
                   value="hist"
                   selected={cfHistorico}
@@ -228,27 +303,32 @@ const CobrosList = () => {
                 <Typography variant="body2" color="text.secondary">Sin cobros proyectados en la ventana. Probá "Ver histórico".</Typography>
               ) : (
                 <Paper variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
-                  {!cfHistorico && cashflow.realizado_anterior > 0 && (
+                  {usdPresent && (
                     <Typography variant="caption" color="text.secondary" display="block" mb={1}>
-                      Realizado antes de la ventana: {money(cashflow.realizado_anterior)} (colapsado)
+                      Mostrando {track === 'USD' ? 'planes en dólares (US$)' : 'planes en pesos (indexados valuados a hoy)'}.
+                    </Typography>
+                  )}
+                  {!cfHistorico && realizadoAnterior > 0 && (
+                    <Typography variant="caption" color="text.secondary" display="block" mb={1}>
+                      Realizado antes de la ventana: {money(realizadoAnterior)} (colapsado)
                     </Typography>
                   )}
                   {cfVista === 'grafico' ? (
                     <Box sx={{ overflowX: 'auto' }}>
                       <BarChart
                         height={280}
-                        xAxis={[{ scaleType: 'band', data: cashflow.meses }]}
+                        xAxis={[{ scaleType: 'band', data: labels }]}
                         series={[
-                          { data: cashflow.esperado, label: 'Esperado', color: '#90A4D4' },
-                          { data: cashflow.cobrado, label: 'Cobrado', color: '#2E7D32' },
+                          { data: esperado, label: 'Esperado', color: '#90A4D4' },
+                          { data: cobrado, label: 'Cobrado', color: '#2E7D32' },
                         ]}
                       />
                       {/* Curva de saldo acumulado (#4) */}
                       <Typography variant="caption" color="text.secondary" sx={{ mt: 1 }}>Saldo acumulado proyectado</Typography>
                       <LineChart
                         height={200}
-                        xAxis={[{ scaleType: 'point', data: cashflow.meses }]}
-                        series={[{ data: cashflow.acumulado || [], label: 'Acumulado', color: '#1976D2', area: true, showMark: false }]}
+                        xAxis={[{ scaleType: 'point', data: labels }]}
+                        series={[{ data: acumulado, label: 'Acumulado', color: '#1976D2', area: true, showMark: false }]}
                       />
                     </Box>
                   ) : (
@@ -265,28 +345,156 @@ const CobrosList = () => {
                         </TableHead>
                         <TableBody>
                           {cashflow.meses.map((m, i) => {
-                            const esp = cashflow.esperado[i] || 0;
-                            const cob = cashflow.cobrado[i] || 0;
+                            const esp = esperado[i] || 0;
+                            const cob = cobrado[i] || 0;
                             return (
                               <TableRow key={m}>
-                                <TableCell>{m}</TableCell>
+                                <TableCell>{etiquetaPeriodo(m)}</TableCell>
                                 <TableCell align="right">{money(esp)}</TableCell>
                                 <TableCell align="right" sx={{ color: 'success.main' }}>{money(cob)}</TableCell>
                                 <TableCell align="right" sx={{ fontWeight: 700 }}>{money(esp + cob)}</TableCell>
-                                <TableCell align="right" sx={{ color: 'primary.main' }}>{money((cashflow.acumulado || [])[i])}</TableCell>
+                                <TableCell align="right" sx={{ color: 'primary.main' }}>{money(acumulado[i])}</TableCell>
                               </TableRow>
                             );
                           })}
                           <TableRow>
                             <TableCell sx={{ fontWeight: 700 }}>Total ventana</TableCell>
-                            <TableCell align="right" sx={{ fontWeight: 700 }}>{money((cashflow.esperado || []).reduce((a, b) => a + b, 0))}</TableCell>
-                            <TableCell align="right" sx={{ fontWeight: 700, color: 'success.main' }}>{money((cashflow.cobrado || []).reduce((a, b) => a + b, 0))}</TableCell>
+                            <TableCell align="right" sx={{ fontWeight: 700 }}>{money(esperado.reduce((a, b) => a + b, 0))}</TableCell>
+                            <TableCell align="right" sx={{ fontWeight: 700, color: 'success.main' }}>{money(cobrado.reduce((a, b) => a + b, 0))}</TableCell>
                             <TableCell colSpan={2} />
                           </TableRow>
                         </TableBody>
                       </Table>
                     </Box>
                   )}
+                </Paper>
+              )}
+            </Box>
+            );
+          })()}
+
+          {seccion === 'gestion' && (() => {
+            // A2: "a quién reclamar". Lista accionable por cuota, vencidos arriba,
+            // filtrable por mes y agrupable por obra.
+            const fechaCorta = (s) => { if (!s) return '—'; const [y, m, d] = s.split('-'); return `${Number(d)} ${MESES_CORTOS[Number(m) - 1]} ${y.slice(2)}`; };
+            const estadoChip = (e) => e === 'vencida'
+              ? <Chip size="small" label="Vencida" color="error" />
+              : e === 'cobrada_parcial'
+                ? <Chip size="small" label="Parcial" color="warning" />
+                : <Chip size="small" label="Pendiente" variant="outlined" />;
+            // El mes actual siempre figura como opción (aunque no tenga cuotas), porque es el filtro por default.
+            const mesActual = new Date().toISOString().slice(0, 7);
+            const mesesDisp = [...new Set([...(gestion || []).map((r) => (r.fecha_vencimiento || '').slice(0, 7)).filter(Boolean), mesActual])].sort();
+            const filtradas = (gestion || []).filter((r) => gestionMes === 'todos' || (r.fecha_vencimiento || '').slice(0, 7) === gestionMes);
+            // Vencidas primero, luego por vencimiento ascendente.
+            const ordenadas = [...filtradas].sort((a, b) => {
+              const va = a.estado === 'vencida' ? 0 : 1, vb = b.estado === 'vencida' ? 0 : 1;
+              if (va !== vb) return va - vb;
+              return (a.fecha_vencimiento || '9999').localeCompare(b.fecha_vencimiento || '9999');
+            });
+            const subtotal = (rows, track) => rows.reduce((a, r) => a + (r.track === track ? (r.saldo_a_hoy || 0) : 0), 0);
+            const grupos = gestionPorObra
+              ? [...ordenadas.reduce((map, r) => { const k = r.proyecto_nombre || 'Sin obra'; if (!map.has(k)) map.set(k, []); map.get(k).push(r); return map; }, new Map())]
+              : [['', ordenadas]];
+
+            // Paginación: en "todo junto" pagina cuotas; en "por obra" pagina obras (mantiene los grupos enteros).
+            const total = gestionPorObra ? grupos.length : ordenadas.length;
+            const start = gestionPage * gestionRpp;
+            const gruposPage = gestionPorObra
+              ? grupos.slice(start, start + gestionRpp)
+              : [['', ordenadas.slice(start, start + gestionRpp)]];
+
+            // Accordion por obra: colapsar/expandir sus cuotas.
+            const toggleObra = (obra) => setGestionColapsadas((prev) => { const n = new Set(prev); if (n.has(obra)) n.delete(obra); else n.add(obra); return n; });
+            const todasObras = grupos.map(([o]) => o);
+            const todasColapsadas = gestionPorObra && todasObras.length > 0 && todasObras.every((o) => gestionColapsadas.has(o));
+
+            const filaCuota = (r) => (
+              <TableRow key={r.cuota_id} sx={{ bgcolor: r.estado === 'vencida' ? '#FFF5F5' : 'inherit' }}>
+                <TableCell>{r.cliente_nombre || '—'}</TableCell>
+                {!gestionPorObra && <TableCell>{r.proyecto_nombre || '—'}</TableCell>}
+                <TableCell>{r.plan_nombre ? `${r.plan_nombre} · ` : ''}Cuota {r.numero}</TableCell>
+                <TableCell>{fechaCorta(r.fecha_vencimiento)}</TableCell>
+                <TableCell align="right" sx={{ fontWeight: 700 }}>{fmtMoney(r.saldo_a_hoy, r.track)}</TableCell>
+                <TableCell>{estadoChip(r.estado)}</TableCell>
+              </TableRow>
+            );
+            return (
+            <Box sx={{ mb: 3 }}>
+              <Stack direction="row" spacing={2} mb={2} flexWrap="wrap" alignItems="center" useFlexGap>
+                <FormControl size="small" sx={{ minWidth: 160 }}>
+                  <InputLabel>Mes de vencimiento</InputLabel>
+                  <Select value={gestionMes} label="Mes de vencimiento" onChange={(e) => setGestionMes(e.target.value)}>
+                    <MenuItem value="todos">Todos</MenuItem>
+                    {mesesDisp.map((m) => <MenuItem key={m} value={m}>{etiquetaPeriodo(m)}</MenuItem>)}
+                  </Select>
+                </FormControl>
+                <ToggleButtonGroup value={gestionPorObra ? 'obra' : 'todo'} exclusive size="small" onChange={(_, v) => v && setGestionPorObra(v === 'obra')}>
+                  <ToggleButton value="obra">Por obra</ToggleButton>
+                  <ToggleButton value="todo">Todo junto</ToggleButton>
+                </ToggleButtonGroup>
+                {gestionPorObra && (
+                  <Button size="small" onClick={() => setGestionColapsadas(todasColapsadas ? new Set() : new Set(todasObras))}>
+                    {todasColapsadas ? 'Expandir todo' : 'Contraer todo'}
+                  </Button>
+                )}
+                <Typography variant="caption" color="text.secondary">{ordenadas.length} cuota{ordenadas.length === 1 ? '' : 's'} a cobrar</Typography>
+              </Stack>
+
+              {ordenadas.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">No hay cuotas pendientes para reclamar en este filtro.</Typography>
+              ) : (
+                <Paper variant="outlined" sx={{ borderRadius: 2 }}>
+                  <Box sx={{ overflowX: 'auto' }}>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Cliente</TableCell>
+                        {!gestionPorObra && <TableCell>Obra</TableCell>}
+                        <TableCell>Cuota</TableCell>
+                        <TableCell>Vence</TableCell>
+                        <TableCell align="right">A cobrar (a hoy)</TableCell>
+                        <TableCell>Estado</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {gruposPage.map(([obra, rows]) => {
+                        const subARS = subtotal(rows, 'ARS'), subUSD = subtotal(rows, 'USD');
+                        const colapsada = gestionColapsadas.has(obra);
+                        return (
+                          <Fragment key={obra || 'todo'}>
+                            {gestionPorObra && (
+                              <TableRow hover onClick={() => toggleObra(obra)} sx={{ bgcolor: 'action.hover', cursor: 'pointer' }}>
+                                <TableCell colSpan={3} sx={{ fontWeight: 700 }}>
+                                  <Stack direction="row" alignItems="center" spacing={0.5}>
+                                    {colapsada ? <ChevronRightIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+                                    <span>{obra}</span>
+                                    <Typography component="span" variant="caption" color="text.secondary">({rows.length})</Typography>
+                                  </Stack>
+                                </TableCell>
+                                <TableCell align="right" sx={{ fontWeight: 700 }}>
+                                  {subARS ? fmtMoney(subARS, 'ARS') : ''}{subARS && subUSD ? ' · ' : ''}{subUSD ? fmtMoney(subUSD, 'USD') : ''}
+                                </TableCell>
+                                <TableCell />
+                              </TableRow>
+                            )}
+                            {!colapsada && rows.map(filaCuota)}
+                          </Fragment>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                  </Box>
+                  <TablePagination
+                    component="div"
+                    count={total}
+                    page={gestionPage}
+                    onPageChange={(_, p) => setGestionPage(p)}
+                    rowsPerPage={gestionRpp}
+                    onRowsPerPageChange={(e) => { setGestionRpp(parseInt(e.target.value, 10)); setGestionPage(0); }}
+                    rowsPerPageOptions={[10, 25, 50, 100]}
+                    labelRowsPerPage={gestionPorObra ? 'Obras por página' : 'Cuotas por página'}
+                  />
                 </Paper>
               )}
             </Box>

--- a/src/services/planCobroService.js
+++ b/src/services/planCobroService.js
@@ -64,9 +64,9 @@ const planCobroService = {
   agregarAnexo: (planId, data) =>
     api.post(`/cobros/${planId}/anexos`, data),
 
-  // Cashflow proyectado agregado (Fase G)
-  getCashflow: (empresaId, proyectoId = null, granularidad = 'mes', { incluirHistorico = false } = {}) =>
-    api.get('/cobros/cashflow', { params: { empresa_id: empresaId, proyecto_id: proyectoId || undefined, granularidad, incluir_historico: incluirHistorico || undefined } }),
+  // Cashflow proyectado agregado (Fase G). `detalle` trae la lista accionable por cuota (vista de gestión, A2).
+  getCashflow: (empresaId, proyectoId = null, granularidad = 'mes', { incluirHistorico = false, detalle = false } = {}) =>
+    api.get('/cobros/cashflow', { params: { empresa_id: empresaId, proyecto_id: proyectoId || undefined, granularidad, incluir_historico: incluirHistorico || undefined, detalle: detalle || undefined } }),
 };
 
 export default planCobroService;


### PR DESCRIPTION
## Épica
**Plan de Cobros: confiabilidad y lectura del Cash Flow** — TAR-574 (A1, `P0`), TAR-575 (A2, `P1`), TAR-576 (A3, `P3`).
Diseño técnico y cambios de backend: **sorby_bot_wa#274** (`docs/PLAN_DE_COBROS_CASHFLOW_TECNICO.md`).

## Qué cambia (frontend)
- **Cash Flow track-aware** (`cobros.js`): KPIs / gráfico / tabla leen los buckets `{ ARS, USD }`. Toggle **Pesos/Dólares** que aparece solo si hay planes en dólares. KPIs superiores muestran ARS y USD como **líneas de igual peso** (tracks distintos, no se suman).
- **Labels de semana legibles** (A3): `2026-W33` → `Sem 33 · 3–9 ago`, sin tocar la clave de orden.
- **Nueva pestaña "Gestión"** (A2): lista accionable por cuota ("a quién reclamar"), **vencidos arriba**, filtro por mes (default: **mes actual**), agrupación **por obra (default)** con accordion colapsable + subtotales, y **paginación**.
- **service**: `getCashflow` acepta `detalle` para traer la lista de gestión.

## Depende de
El backend debe estar deployado primero (nuevo shape de `getCashflow` con tracks + `detalle`): **sorby_bot_wa#274**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
