### PR TITLE
TAR-567: la columna Tipo muestra la categoría del proveedor

### DIFF
--- a/src/components/ProveedorDrawer.js
+++ b/src/components/ProveedorDrawer.js
@@ -1409,11 +1409,11 @@ function ProveedorDrawer({ open, onClose, proveedorId, proveedorNombreHint, empr
                 <Typography variant="h6" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
                   {proveedor.nombre}
                 </Typography>
-                <Chip
-                  label={proveedor.tipo === 'mano_de_obra' ? 'Mano de obra' : 'Materiales'}
-                  size="small"
-                  variant="outlined"
-                />
+                {/* Sólo si es contratista: el default 'materiales' no distingue
+                    configurado de nunca tocado, y las categorías están en Datos. */}
+                {proveedor.tipo === 'mano_de_obra' && (
+                  <Chip label="Mano de obra" size="small" variant="outlined" />
+                )}
                 {proveedor.archivado && (
                   <Chip label="Archivado" size="small" color="default" />
                 )}

--- a/src/pages/proveedores.js
+++ b/src/pages/proveedores.js
@@ -57,6 +57,40 @@ const TABS = [
   { key: 'archivados', label: 'Archivados' },
 ];
 
+// El tipo que le sirve al usuario son las categorías configuradas del proveedor.
+// `tipo` sólo distingue contratistas: su default 'materiales' no permite saber si
+// alguien lo eligió o nunca se tocó, así que no se muestra como si fuera un dato.
+const etiquetasTipo = (prov) => {
+  const categorias = (prov.categorias || []).filter(Boolean);
+  return prov.tipo === 'mano_de_obra' ? ['Mano de obra', ...categorias] : categorias;
+};
+
+const CeldaTipo = ({ prov }) => {
+  const etiquetas = etiquetasTipo(prov);
+  if (!etiquetas.length) return <Typography variant="body2" color="text.disabled">—</Typography>;
+
+  const visibles = etiquetas.slice(0, 2);
+  const ocultas = etiquetas.length - visibles.length;
+  const esManoDeObra = prov.tipo === 'mano_de_obra';
+
+  return (
+    <Tooltip title={etiquetas.join(' · ')}>
+      <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+        {visibles.map((etiqueta, i) => (
+          <Chip
+            key={etiqueta}
+            label={etiqueta}
+            size="small"
+            variant="outlined"
+            color={i === 0 && esManoDeObra ? 'primary' : 'default'}
+          />
+        ))}
+        {ocultas > 0 && <Chip label={`+${ocultas}`} size="small" variant="outlined" />}
+      </Stack>
+    </Tooltip>
+  );
+};
+
 const renderEstadoCC = (resumen) => {
   if (!resumen) return <Chip size="small" label="—" variant="outlined" />;
   const saldo = resumen.saldo || 0;
@@ -94,7 +128,7 @@ function ProveedoresContent({ empresa, refreshKey }) {
   // Selección múltiple (sólo activa en tab Con deuda para ajuste de cuentas)
   const [seleccionados, setSeleccionados] = useState(() => new Set());
   const [ajusteDialogOpen, setAjusteDialogOpen] = useState(false);
-  const [filtroTipo, setFiltroTipo] = useState('todos'); // 'todos' | 'materiales' | 'mano_de_obra'
+  const [filtroTipo, setFiltroTipo] = useState('todos'); // 'todos' | 'mano_de_obra' | `cat:<categoria>`
 
   // Paginación de la lista (client-side) para no renderizar cientos de filas a la vez.
   const [page, setPage] = useState(0);
@@ -155,8 +189,13 @@ function ProveedoresContent({ empresa, refreshKey }) {
       if (tab === 'todos'      && archivado) return false;
       if (tab === 'archivados' && !archivado) return false;
 
-      // Filtro tipo
-      if (filtroTipo !== 'todos' && p.tipo !== filtroTipo) return false;
+      // Filtro tipo: contratistas o una categoría (que matchea también sus subcategorías)
+      if (filtroTipo === 'mano_de_obra' && p.tipo !== 'mano_de_obra') return false;
+      if (filtroTipo.startsWith('cat:')) {
+        const categoria = filtroTipo.slice(4);
+        const match = (p.categorias || []).some((c) => c === categoria || c.startsWith(`${categoria} - `));
+        if (!match) return false;
+      }
 
       // Búsqueda
       if (q) {
@@ -412,12 +451,14 @@ function ProveedoresContent({ empresa, refreshKey }) {
             InputProps={{ startAdornment: <InputAdornment position="start"><SearchIcon fontSize="small" /></InputAdornment> }}
             sx={{ flex: 1 }}
           />
-          <FormControl size="small" sx={{ minWidth: 160 }}>
+          <FormControl size="small" sx={{ minWidth: 200 }}>
             <InputLabel>Tipo</InputLabel>
             <Select value={filtroTipo} label="Tipo" onChange={(e) => setFiltroTipo(e.target.value)}>
               <MenuItem value="todos">Todos</MenuItem>
-              <MenuItem value="materiales">Materiales</MenuItem>
               <MenuItem value="mano_de_obra">Mano de obra</MenuItem>
+              {(empresa?.categorias || []).map((cat) => (
+                <MenuItem key={cat.name} value={`cat:${cat.name}`}>{cat.name}</MenuItem>
+              ))}
             </Select>
           </FormControl>
         </Stack>
@@ -580,14 +621,7 @@ function ProveedoresContent({ empresa, refreshKey }) {
                         <Typography variant="caption" color="text.secondary">{prov.alias.join(', ')}</Typography>
                       )}
                     </TableCell>
-                    <TableCell>
-                      <Chip
-                        label={prov.tipo === 'mano_de_obra' ? 'Mano de obra' : 'Materiales'}
-                        size="small"
-                        variant="outlined"
-                        color={prov.tipo === 'mano_de_obra' ? 'primary' : 'default'}
-                      />
-                    </TableCell>
+                    <TableCell><CeldaTipo prov={prov} /></TableCell>
                     <TableCell align="right">
                       {(() => {
                         const saldo = r?.saldo || 0;


### PR DESCRIPTION
La columna Tipo mostraba "Materiales" para todos los proveedores; ahora muestra la categoría configurada. Ticket: https://app.notion.com/p/39e50a1e53418026ac48dd3cd8d4dc88 — PR hermano (backend): https://github.com/fedemaidan/sorby_bot_wa/pull/277

---

## TAR-567 — El tipo de proveedor no refleja la categoría configurada

**Causa raíz / Problema:** en `/proveedores` la columna Tipo decía "Materiales" para los 60 proveedores de la empresa, incluidos ABL, AGIP, Aguas Argentinas o Autónomos, que claramente no lo son. La columna renderizaba `proveedor.tipo`, un enum binario interno (`materiales` | `mano_de_obra`) con default `'materiales'` que en la práctica nunca se setea: los proveedores se crean solos al cargar un movimiento (`ensureExiste`), y ese camino pasa `categorias` pero nunca `tipo`. El render, además, colapsaba el default y el `undefined` en un chip "Materiales" con pinta de dato configurado, cuando en realidad no hay forma de distinguir "es de materiales" de "nunca se configuró". El dato que el usuario sí configura —y que el sistema sí puebla, desde la categoría de cada movimiento— son las `categorias` del proveedor.

**Cómo lo hicimos (funcional):** la columna Tipo ahora muestra la categoría de cada proveedor: ABL aparece como Servicios, AGIP como Impuestos, y así. Si un proveedor tiene varias categorías se ven las dos primeras y un `+N` con el detalle al pasar el mouse. Si todavía no tiene ninguna, muestra un guion en vez de inventar "Materiales". Los contratistas siguen distinguiéndose: si el proveedor está marcado como mano de obra, esa etiqueta va primera y resaltada. El filtro de arriba, que antes ofrecía "Materiales" (y devolvía absolutamente todo) y "Mano de obra", ahora deja filtrar por cualquiera de las categorías de la empresa, además de por mano de obra.

**Decisiones y por qué:**
• Mostrar `categorias` en vez de `tipo` en la columna → es el único dato de clasificación que realmente refleja la configuración del proveedor. `tipo` no es rescatable: su default se escribe en toda alta automática, así que el 100% de los proveedores lo tiene en `'materiales'` sin que nadie lo haya elegido.
• Mostrar `—` cuando no hay categorías, en vez de un fallback → la raíz del ticket es exactamente eso: un default disfrazado de dato. Un guion comunica "no hay info" y es honesto; "Materiales" es información falsa.
• Conservar "Mano de obra" como primera etiqueta cuando aplica, en lugar de reemplazar la columna por "Categorías" a secas → `tipo === 'mano_de_obra'` sí se configura explícitamente y tiene consecuencias funcionales (habilita presupuesto vigente y pretendidos en la cuenta corriente, y contratistas en control de pagos). Sacarlo de la lista habría sido una regresión para las empresas que lo usan.
• Cambiar el filtro además de la columna → el ticket menciona la confusión al filtrar, y dejar un filtro que opera sobre un flag invisible mientras la columna muestra otra cosa sería incoherente. Se descartó poner dos selects (uno de tipo y otro de categoría) para no recargar la barra de filtros.
• Sacar la opción "Materiales" del filtro → filtraba por el default, o sea devolvía la lista completa; no había nada que preservar.
• Tope de 2 chips + `+N` → un proveedor puede acumular varias categorías a lo largo de sus movimientos y la columna crecería sin control; el tooltip da el detalle completo sin abrir la ficha.

**Cómo lo implementamos (técnico):**
• `src/pages/proveedores.js` → nuevo helper `etiquetasTipo(prov)` y componente `CeldaTipo` a nivel de módulo. `etiquetasTipo` devuelve `['Mano de obra', ...categorias]` si el proveedor es contratista y `categorias` en caso contrario; `CeldaTipo` renderiza los dos primeros chips, el `+N` y el `Tooltip` con el listado completo, o `—` si el array queda vacío.
• Filtro: `filtroTipo` pasa de `'todos' | 'materiales' | 'mano_de_obra'` a `'todos' | 'mano_de_obra' | 'cat:<categoria>'`. Las opciones del `Select` salen de `empresa.categorias` (mismo origen que el Autocomplete de la ficha). El match de categoría es `c === categoria || c.startsWith(\`${categoria} - \`)`, para que filtrar por una categoría padre incluya a sus subcategorías — el separador `' - '` es el mismo que arma `categoriasFromMovimiento` en el backend al persistir `"Categoria - Subcategoria"`.
• `src/components/ProveedorDrawer.js` → el chip del header de la ficha tenía el mismo fallback mentiroso; ahora sólo se renderiza cuando el proveedor es mano de obra. Las categorías ya están en la tab Datos, así que no se duplican en el header.
• No se tocó el export a CSV: sigue exportando `tipo` y `categorias` como campos crudos.

**Producción / compatibilidad:** cambio sólo de presentación y filtrado en el cliente, sin migración ni backfill. Los proveedores existentes se ven correctos apenas se deploya, porque `categorias` siempre se guardó bien. Único caso que puede quedar en blanco: proveedores dados de alta a mano y sin ningún movimiento cargado todavía, que no tienen categorías — muestran `—` hasta que se les asigne una desde la ficha o llegue su primer movimiento.

**Orden de deploy:** después del PR del backend. Al revés no rompe nada visible, pero el alta con "Mano de obra" del diálogo Nuevo proveedor sigue perdiéndose.

**Verificación:** ESLint limpio sobre los dos archivos. **No se validó en browser.** Checklist manual pendiente:
1. `/proveedores` → la columna Tipo muestra categorías reales y `—` para los que no tienen, ya no "Materiales" para todos.
2. Un proveedor marcado como mano de obra muestra ese chip primero y resaltado, y también en el header de la ficha.
3. Filtro Tipo → elegir una categoría filtra por ella e incluye sus subcategorías; "Mano de obra" trae sólo contratistas.
4. Proveedor con 3+ categorías → se ven 2 chips + `+N` y el tooltip lista todas.
5. Con el backend deployado: crear un proveedor con tipo "Mano de obra" y confirmar que persiste.

**Notas al código:**
• `proveedores.js:etiquetasTipo` → el comentario del código dice lo mínimo; el racional completo es que `tipo` tiene default `'materiales'` a nivel schema y se escribe en toda alta automática por movimiento, así que un valor `'materiales'` es indistinguible de "campo nunca tocado". Por eso la función nunca emite "Materiales" como etiqueta: sólo "Mano de obra", que sí requiere una acción explícita del usuario.
• `proveedores.js` filtro → el prefijo `cat:` en el value del `Select` es para meter dos dimensiones (el flag `tipo` y las categorías) en un solo control sin recargar la barra de filtros. Alternativa descartada: dos selects separados.
• `proveedores.js` match de categoría → el `startsWith(\`${categoria} - \`)` incluye el separador con espacios a propósito; sin él, filtrar por "Obra" también matchearía "Obrador" o cualquier categoría con el mismo prefijo.

---

## TL;DR
• La columna Tipo de `/proveedores` pasa de mostrar "Materiales" para todos a mostrar la categoría configurada de cada proveedor (2 chips + `+N` con tooltip), con `—` cuando no hay ninguna en vez de un valor inventado. "Mano de obra" sigue visible y primero para los contratistas.
• El filtro Tipo pasa de `Materiales | Mano de obra` —donde "Materiales" devolvía la lista entera— a `Mano de obra` + las categorías de la empresa; una categoría padre matchea también sus subcategorías.
• En la ficha del proveedor, el chip del header sólo aparece si es mano de obra (antes decía "Materiales" siempre).
• Archivos: `src/pages/proveedores.js` (helper `etiquetasTipo` + componente `CeldaTipo` + filtro) y `src/components/ProveedorDrawer.js` (chip del header).
• Sin cambios de modelo de datos, sin migración, sin backfill: `categorias` siempre estuvo bien poblada. Deploy después del PR del backend.
• Verificado con ESLint; falta la validación en browser (checklist de 5 puntos arriba).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
