### PR TITLE
TAR-640: export a Excel de Control de Presupuestos incluye columnas USD/CAC según chips activos

### DIFF
--- a/src/components/PresupuestoDrawer.js
+++ b/src/components/PresupuestoDrawer.js
@@ -2743,6 +2743,9 @@ const PresupuestoDrawer = ({
                           cacIndiceActual: cacActualEfectivo || cacEfectivo,
                           tipoCambioActual: dolarEfectivo,
                           tipo: esIngreso ? 'ingresos' : 'gastos',
+                          cacModo,
+                          equivUsd: equivToggles.usd,
+                          equivCac: equivToggles.cac,
                         });
                       };
                       return (

--- a/src/pages/control-presupuestos.js
+++ b/src/pages/control-presupuestos.js
@@ -2549,6 +2549,8 @@ const ControlPresupuestosPage = () => {
                   presupuestadoNativo: presupuestado,
                   tipo: movDrawer.tipo === 'ingreso' ? 'ingresos' : 'gastos',
                   cacModo,
+                  equivUsd: movDrawerEquiv.usd,
+                  equivCac: movDrawerEquiv.cac,
                 });
               };
               return (

--- a/src/utils/controlPresupuesto/__tests__/buildControlPresupuestoData.test.js
+++ b/src/utils/controlPresupuesto/__tests__/buildControlPresupuestoData.test.js
@@ -183,6 +183,67 @@ describe('buildControlPresupuestoData', () => {
     expect(data.saldo).toBe(300000);
   });
 
+  // TAR-640: columnas de equivalencia USD/CAC según los chips activos en la grilla.
+  describe('equivalencias por chip (equivUsd / equivCac)', () => {
+    const movimientos = [
+      mov(100, 300000, 'ARS', { ars: 300000, cac: 600, usd_blue: 250 }),
+      mov(200, 200, 'USD', { ars: 250000, cac: 500, usd_blue: 200 }),
+    ];
+
+    test('sin chips (default) → sin columnas de equivalencia', () => {
+      const data = buildControlPresupuestoData({ movimientos });
+      expect(data.mostrar_equiv_usd).toBe(false);
+      expect(data.mostrar_equiv_cac).toBe(false);
+      expect(data.movimientos[0].equiv_usd).toBe(null);
+      expect(data.movimientos[0].equiv_cac).toBe(null);
+    });
+
+    test('nominal + ambos chips → mismos valores que la grilla', () => {
+      const data = buildControlPresupuestoData({ movimientos, equivUsd: true, equivCac: true });
+      expect(data.mostrar_equiv_usd).toBe(true);
+      expect(data.mostrar_equiv_cac).toBe(true);
+      expect(data.equiv_cac_label).toBe('CAC');
+      // Mov ARS: usd_blue y cac guardados.
+      expect(data.movimientos[0]).toMatchObject({ moneda_mov: 'ARS', equiv_usd: 250, equiv_cac: 600 });
+      // Mov USD: la columna USD muestra el equivalente en pesos (eq.ars), como la grilla.
+      expect(data.movimientos[1]).toMatchObject({ moneda_mov: 'USD', equiv_usd: 250000, equiv_cac: 500 });
+    });
+
+    test("modo 'usd' + chip USD → se omite (el monto ya está en USD)", () => {
+      const data = buildControlPresupuestoData({ movimientos, modo: 'usd', equivUsd: true, equivCac: true });
+      expect(data.mostrar_equiv_usd).toBe(false);
+      expect(data.mostrar_equiv_cac).toBe(true);
+    });
+
+    test("modo 'cac' + chip CAC → se omite (ya hay columna CAC), chip USD se mantiene", () => {
+      const data = buildControlPresupuestoData({
+        movimientos, modo: 'cac', indexacion: 'CAC', cacIndiceActual: 500,
+        equivUsd: true, equivCac: true,
+      });
+      expect(data.mostrar_equiv).toBe(true);
+      expect(data.mostrar_equiv_cac).toBe(false);
+      expect(data.mostrar_equiv_usd).toBe(true);
+    });
+
+    test('respeta cacTipo y cacModo (variantes del shape nuevo)', () => {
+      const data = buildControlPresupuestoData({
+        movimientos: [mov(100, 1000, 'ARS', { ars: 1000, cac_mano_obra: { legacy: 2, estimado: 3 } })],
+        cacTipo: 'mano_obra', cacModo: 'estimado', equivCac: true,
+      });
+      expect(data.equiv_cac_label).toBe('CAC MO');
+      expect(data.movimientos[0].equiv_cac).toBe(3);
+    });
+
+    test('sin equivalencia guardada → null (la celda queda vacía)', () => {
+      const data = buildControlPresupuestoData({
+        movimientos: [mov(100, 1000, 'ARS', { ars: 1000 })],
+        equivUsd: true, equivCac: true,
+      });
+      expect(data.movimientos[0].equiv_usd).toBe(null);
+      expect(data.movimientos[0].equiv_cac).toBe(null);
+    });
+  });
+
   // Bug fix: con fechas de Mongo (Date / ISO) el sort cronológico debe ordenar del
   // más viejo al más nuevo y acumular en ese orden (antes fechaSecs solo entendía el
   // shape de Firestore → no ordenaba y el acumulado salía al revés).

--- a/src/utils/controlPresupuesto/buildControlPresupuestoData.js
+++ b/src/utils/controlPresupuesto/buildControlPresupuestoData.js
@@ -62,6 +62,8 @@ const MODO_LABEL = { nominal: 'Nominal', cac: 'CAC a hoy', usd: 'USD' };
  * @param {number} [opts.montoIngresado]     Pesos originales (fallback para nominal/derivados).
  * @param {number} [opts.cacIndiceActual]    Índice CAC de hoy (según cacTipo).
  * @param {number} [opts.tipoCambioActual]   Dólar de hoy.
+ * @param {boolean} [opts.equivUsd]          Chip USD activo en la grilla → columna equivalencia USD.
+ * @param {boolean} [opts.equivCac]          Chip CAC activo en la grilla → columna equivalencia CAC.
  */
 export function buildControlPresupuestoData({
   movimientos = [],
@@ -84,6 +86,8 @@ export function buildControlPresupuestoData({
   cacIndiceActual = null,
   tipoCambioActual = null,
   cacModo = 'legacy',
+  equivUsd = false,
+  equivCac = false,
 } = {}) {
   const orden = [...movimientos].sort((a, b) => fechaSecs(a) - fechaSecs(b));
   const campo = baseCalculo === 'subtotal' ? 'subtotal' : 'total';
@@ -129,6 +133,12 @@ export function buildControlPresupuestoData({
     };
   }
 
+  // Columnas de equivalencia por chip (espejan la grilla). Se omiten cuando el modo
+  // ya expresa esa unidad (en 'usd' el monto YA es USD; en 'cac' ya hay columna CAC).
+  const modoCacActivo = modo === 'cac' && indexacion === 'CAC' && cotizCac > 0;
+  const incluirEquivUsd = !!equivUsd && modo !== 'usd';
+  const incluirEquivCac = !!equivCac && !modoCacActivo;
+
   let acumPrimary = 0;
   let acumEquiv = 0;
   const movs = orden.map((m, i) => {
@@ -136,16 +146,27 @@ export function buildControlPresupuestoData({
     const montoEquiv = equivOf ? equivOf(m) : null;
     acumPrimary += monto;
     if (equivOf) acumEquiv += montoEquiv;
+    const eq = eqOf(m);
+    const monedaMov = m.moneda || 'ARS';
     return {
       numero: i + 1,
       fecha: fechaStr(m),
       detalle: m.nombre_proveedor || m.categoria || m.observacion || 'Movimiento',
       proveedor: m.nombre_proveedor || '',
       categoria: m.categoria || '',
+      moneda_mov: monedaMov,
       monto,
       acumulado: acumPrimary,
       monto_equiv: equivOf ? montoEquiv : null,
       acumulado_equiv: equivOf ? acumEquiv : null,
+      // Mismos valores que las celdas de los chips: para movs en USD la columna USD
+      // muestra el equivalente en pesos (eq.ars); para el resto, el usd_blue guardado.
+      equiv_usd: incluirEquivUsd
+        ? (monedaMov === 'USD' ? num(eq.ars) : (eq.usd_blue != null ? num(eq.usd_blue) : null))
+        : null,
+      equiv_cac: incluirEquivCac
+        ? (() => { const v = equivalenciaCac(eq, cacTipo, cacModo); return v != null ? num(v) : null; })()
+        : null,
     };
   });
 
@@ -196,6 +217,9 @@ export function buildControlPresupuestoData({
     indexacion: modo === 'cac' ? indexacion : null,
     mostrar_equiv: !!equivOf,
     equiv_label: equivLabel,
+    mostrar_equiv_usd: incluirEquivUsd,
+    mostrar_equiv_cac: incluirEquivCac,
+    equiv_cac_label: cacLabel(cacTipo),
     presupuestado: presupuestadoPrimary,
     ejecutado,
     saldo,

--- a/src/utils/controlPresupuesto/exportControlPresupuestoXLSX.js
+++ b/src/utils/controlPresupuesto/exportControlPresupuestoXLSX.js
@@ -3,8 +3,10 @@ import * as XLSX from 'xlsx';
 /**
  * Exporta a Excel SOLO la tabla de movimientos del control de presupuesto, con las
  * mismas columnas que el recibo PDF (PdfControlPresupuestoDocument) según el modo
- * elegido (nominal / CAC / USD). No incluye encabezado, resumen ni plantilla: solo
- * la tabla, una fila por movimiento. Los importes van como números (Excel los suma).
+ * elegido (nominal / CAC / USD), más las columnas de equivalencia USD/CAC cuando los
+ * chips correspondientes estaban activos en la grilla (mostrar_equiv_usd/_cac del
+ * data). No incluye encabezado, resumen ni plantilla: solo la tabla, una fila por
+ * movimiento. Los importes van como números (Excel los suma).
  *
  * Recibe el mismo `data` que produce buildControlPresupuestoData.
  */
@@ -17,14 +19,20 @@ export function exportControlPresupuestoXLSX(data, fileName = 'control-presupues
   const d = data || {};
   const movs = Array.isArray(d.movimientos) ? d.movimientos : [];
   const mostrarEquiv = !!d.mostrar_equiv;
+  const mostrarEquivUsd = !!d.mostrar_equiv_usd;
+  const mostrarEquivCac = !!d.mostrar_equiv_cac;
   const moneda = d.moneda || 'ARS';
   const equivLabel = d.equiv_label || '';
+  const equivCacLabel = d.equiv_cac_label || 'CAC';
   const montoHeader = moneda === 'USD' ? 'MONTO USD' : 'MONTO $';
 
-  // Mismas columnas que el PDF: N° · Fecha · Detalle · Monto · [equiv] · Acumulado.
+  // Mismas columnas que el PDF: N° · Fecha · Detalle · Monto · [equiv] · Acumulado,
+  // más las equivalencias USD/CAC si los chips estaban activos en la grilla.
   const header = ['N°', 'FECHA', 'DETALLE', montoHeader];
   if (mostrarEquiv) header.push(equivLabel || 'EQUIV.');
   header.push('ACUMULADO');
+  if (mostrarEquivUsd) header.push('USD');
+  if (mostrarEquivCac) header.push(equivCacLabel);
 
   const rows = movs.map((m, i) => {
     const row = [
@@ -35,6 +43,8 @@ export function exportControlPresupuestoXLSX(data, fileName = 'control-presupues
     ];
     if (mostrarEquiv) row.push(num(m.monto_equiv));
     row.push(mostrarEquiv ? num(m.acumulado_equiv) : num(m.acumulado));
+    if (mostrarEquivUsd) row.push(m.equiv_usd != null ? num(m.equiv_usd) : '');
+    if (mostrarEquivCac) row.push(m.equiv_cac != null ? num(m.equiv_cac) : '');
     return row;
   });
 
@@ -45,6 +55,8 @@ export function exportControlPresupuestoXLSX(data, fileName = 'control-presupues
   const cols = [{}, {}, { wpx: 250 }, { wpx: 150 }];
   if (mostrarEquiv) cols.push({});
   cols.push({ wpx: 150 });
+  if (mostrarEquivUsd) cols.push({ wpx: 110 });
+  if (mostrarEquivCac) cols.push({ wpx: 110 });
   ws['!cols'] = cols;
 
   // Formato de número: signo de moneda + sin decimales (el valor real se mantiene
@@ -54,12 +66,21 @@ export function exportControlPresupuestoXLSX(data, fileName = 'control-presupues
   const fmtEquivU = `#,##0" ${equivLabel || 'CAC'}"`;
   const idxMonto = 3;
   const idxAcum = mostrarEquiv ? 5 : 4;
+  const idxEquivUsd = mostrarEquivUsd ? idxAcum + 1 : null;
+  const idxEquivCac = mostrarEquivCac ? idxAcum + 1 + (mostrarEquivUsd ? 1 : 0) : null;
   const formatos = { [idxMonto]: fmtMoneda, [idxAcum]: mostrarEquiv ? fmtEquivU : fmtMoneda };
   if (mostrarEquiv) formatos[4] = fmtEquivU;
+  if (idxEquivCac != null) formatos[idxEquivCac] = `#,##0.00" ${equivCacLabel}"`;
   for (let r = 1; r <= rows.length; r++) {
     for (const c of Object.keys(formatos)) {
       const ref = XLSX.utils.encode_cell({ r, c: Number(c) });
       if (ws[ref]) ws[ref].z = formatos[c];
+    }
+    // La columna USD espeja la grilla: en movs nativos en USD el valor es su
+    // equivalente en pesos → formato $; en el resto es el usd_blue → formato USD.
+    if (idxEquivUsd != null) {
+      const ref = XLSX.utils.encode_cell({ r, c: idxEquivUsd });
+      if (ws[ref]) ws[ref].z = movs[r - 1]?.moneda_mov === 'USD' ? '"$ "#,##0' : '"USD "#,##0.00';
     }
   }
 


### PR DESCRIPTION
# TAR-640 — Export a Excel de Control de Presupuestos incluye las columnas USD y CAC

La exportación a Excel ahora refleja las columnas de equivalencia que el usuario tiene activas en la grilla. Ticket: [TAR-640](https://app.notion.com/p/Exportaci-n-a-Excel-de-Control-de-Presupuestos-no-incluye-las-columnas-de-USD-y-CAC-3aa50a1e5341808a8fd2de3a54eacf7b)

---

## TAR-640 — Columnas USD/CAC en el Excel exportado

**Causa raíz / Problema:** en Control de Presupuestos, los chips USD y CAC agregan columnas de equivalencia a la tabla de movimientos en pantalla, pero el export a Excel armaba los datos sin enterarse del estado de esos chips: el archivo salía siempre sin esas columnas, y no coincidía con lo que el usuario estaba viendo.

**Cómo lo hicimos (funcional):** al exportar a Excel con el chip USD y/o CAC activo, el archivo incluye esas columnas al final de la tabla, con los mismos valores que muestra la pantalla. Con los chips apagados, el Excel sale igual que antes. Aplica en los dos lugares donde existe esta grilla: el detalle de movimientos del proyecto (pantalla Control de Presupuestos) y la pestaña Movimientos del detalle de un presupuesto.

**Decisiones y por qué:**
- Las columnas se agregan **solo si el chip está activo** → es lo que pide el ticket: el Excel debe espejar las columnas visibles en la grilla, ni más ni menos.
- Si el modo de export elegido ya expresa esa unidad, la columna del chip se omite → en modo "USD" el monto ya está en dólares y en modo "CAC a hoy" ya existe la columna CAC del modo; duplicarlas ensuciaría el archivo sin agregar información.
- Los valores replican **exactamente** las celdas de la grilla (incluido que para un movimiento nativo en USD la columna USD muestra su equivalente en pesos) → el criterio del ticket es "la información exportada debe coincidir con la mostrada"; no inventamos una semántica nueva para el Excel.
- El estado de los chips viaja por `buildControlPresupuestoData` (el `buildData` compartido) y no por el componente de export → un solo punto arma los datos para PDF y Excel; el PDF ignora los campos nuevos y queda igual.

**Cómo lo implementamos (técnico):**
- `buildControlPresupuestoData.js`: nuevas opciones `equivUsd`/`equivCac`. Cada fila suma `moneda_mov`, `equiv_usd` (para movs USD: `eq.ars`; para el resto: `eq.usd_blue`) y `equiv_cac` (vía `equivalenciaCac` respetando `cac_tipo` y `cacModo`). El `data` devuelto expone `mostrar_equiv_usd`, `mostrar_equiv_cac` y `equiv_cac_label` (`CAC`/`CAC MO`/`CAC MAT`).
- `exportControlPresupuestoXLSX.js`: agrega los headers `USD`/`CAC` después de ACUMULADO cuando los flags están activos, con valores numéricos (Excel los suma) y formato por celda.
- `control-presupuestos.js` (drawer de movimientos del proyecto) y `PresupuestoDrawer.js` (tab Movimientos): pasan `equivUsd`/`equivCac` desde el estado de sus chips (`movDrawerEquiv` / `equivToggles`) al `buildData` compartido.
- `PresupuestoDrawer.js` además ahora pasa `cacModo` a `buildControlPresupuestoData`: antes caía al default `legacy`, con lo cual la equivalencia CAC exportada podía no coincidir con la que muestra la grilla (que sí usa el modo CAC de la empresa).

**Producción / compatibilidad:** sin migración ni breaking changes. Las opciones nuevas son opcionales con default `false` (chips apagados → mismo Excel que hoy), los campos nuevos del `data` son aditivos y las plantillas PDF (default y custom) los ignoran. Los chips `$ act.` y `Δ` del PresupuestoDrawer quedan fuera de alcance (el ticket pide USD y CAC).

**Verificación:** 23/23 tests de `buildControlPresupuestoData` pasan; 6 nuevos cubren chips apagados (default), ambos chips en nominal (valores idénticos a la grilla, incluido el caso mov USD → pesos), supresión de duplicados en modos `usd`/`cac`, selección de `cacTipo`+`cacModo` en el shape nuevo `{legacy,estimado,automatico}`, y equivalencias faltantes → celda vacía. ESLint limpio. Pendiente validación manual en browser: exportar desde ambas grillas con cada combinación de chips.

**Notas al código:**
- `buildControlPresupuestoData` → `incluirEquivUsd = equivUsd && modo !== 'usd'` e `incluirEquivCac = equivCac && !modoCacActivo`: la supresión vive acá y no en el export para que cualquier consumidor del `data` (PDF custom incluido) reciba flags ya resueltos y no tenga que conocer la regla.
- `exportControlPresupuestoXLSX` → el formato de la columna USD se decide por fila (`moneda_mov === 'USD'` → formato `$`): la misma columna mezcla equivalente en pesos (movs nativos USD) y `usd_blue` (resto), igual que la grilla, así que un formato único por columna mostraría mal uno de los dos casos.
- `equiv_usd`/`equiv_cac` en `null` viajan como celda vacía (no `0`): un `0` en el Excel se sumaría como dato real cuando en realidad el movimiento no tiene la equivalencia guardada (la grilla muestra `—`).

---

## TL;DR
- El Excel de Control de Presupuestos ahora incluye las columnas USD y/o CAC cuando el chip correspondiente está activo en la grilla (y solo en ese caso), con los mismos valores que la pantalla; se omiten si el modo de export ya expresa esa unidad.
- Aplica a las dos grillas con chips: drawer de movimientos del proyecto (`src/pages/control-presupuestos.js`) y tab Movimientos del presupuesto (`src/components/PresupuestoDrawer.js`); la lógica vive en `buildControlPresupuestoData.js` (opts `equivUsd`/`equivCac` + campos por fila) y `exportControlPresupuestoXLSX.js` (columnas y formatos).
- Fix relacionado: el PresupuestoDrawer ahora pasa `cacModo` al build, así la equivalencia CAC exportada coincide con la de la grilla.
- Sin migración ni cambios de modelo de datos; todo aditivo con defaults que preservan el comportamiento actual. 23/23 tests pasan (6 nuevos); falta validación manual en browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
