### PR TITLE
TAR-571 — Pasar el pedido del usuario al corrector con visión de plantillas

### DIFF
--- a/src/components/plantillasPdf/PdfPlantillaChatDialog.js
+++ b/src/components/plantillasPdf/PdfPlantillaChatDialog.js
@@ -189,9 +189,9 @@ export default function PdfPlantillaChatDialog({
   }, []);
 
   // ── Corrector con visión (se dispara cuando hay imagen renderizada) ────────
-  const runCorrection = useCallback(async (code, imageSrc) => {
+  const runCorrection = useCallback(async (code, imageSrc, userRequest) => {
     setCorrecting(true);
-    const improved = await pdfPlantillaService.aiCorrect({ code, empresaId, documentType, previewImageDataUrl: imageSrc });
+    const improved = await pdfPlantillaService.aiCorrect({ code, empresaId, documentType, previewImageDataUrl: imageSrc, lastUserRequest: userRequest });
     setCorrecting(false);
     if (improved && improved !== code) {
       setCurrentCode(improved);
@@ -201,10 +201,10 @@ export default function PdfPlantillaChatDialog({
 
   const handlePreviewImageReady = useCallback((src) => {
     previewImageRef.current = src;
-    const codeToCorrect = awaitingCorrectionRef.current;
-    if (codeToCorrect) {
+    const pending = awaitingCorrectionRef.current;
+    if (pending) {
       awaitingCorrectionRef.current = null;
-      runCorrection(codeToCorrect, src);
+      runCorrection(pending.code, src, pending.userRequest);
     }
   }, [runCorrection]);
 
@@ -244,7 +244,7 @@ export default function PdfPlantillaChatDialog({
       // La IA puede sugerir el modo de moneda (nominal/cac/usd); movemos el selector.
       if (result.modo && sampleDataModes.includes(result.modo)) setModo(result.modo);
       if (result.code) {
-        awaitingCorrectionRef.current = result.code; // disparará el corrector al renderizar
+        awaitingCorrectionRef.current = { code: result.code, userRequest: text }; // disparará el corrector al renderizar
         setCurrentCode(result.code);
         await handleCompile(result.code);
       }

--- a/src/services/pdfPlantillaService.js
+++ b/src/services/pdfPlantillaService.js
@@ -78,13 +78,14 @@ const pdfPlantillaService = {
   },
 
   // Corrector con visión (pasada 2): { code }
-  aiCorrect: async ({ code, empresaId, documentType, previewImageDataUrl }) => {
+  aiCorrect: async ({ code, empresaId, documentType, previewImageDataUrl, lastUserRequest }) => {
     try {
       const res = await api.post('pdf-plantillas/ai-correct', {
         code,
         empresaId,
         documentType,
         previewImageDataUrl,
+        lastUserRequest: lastUserRequest || null,
       });
       return res.status === 200 ? res.data?.code || null : null;
     } catch (e) {


### PR DESCRIPTION
Lado frontend del fix de TAR-571: el diálogo de plantillas ahora le manda al corrector con visión el pedido que originó el cambio. Ticket: https://app.notion.com/p/La-vista-previa-de-Plantillas-vuelve-al-estado-anterior-mientras-se-genera-el-resultado-39e50a1e53418013a9e8dc908f88c770 · PR hermano (backend): https://github.com/fedemaidan/sorby_bot_wa/pull/281

---

## TAR-571 — La vista previa de Plantillas vuelve al estado anterior mientras se genera el resultado

**Causa raíz / Problema:** El corrector con visión ("Puliendo el diseño…") recibía solo código + imagen, sin saber qué había pedido el usuario, y revertía cambios de contenido recién aplicados (ej. el título). El detalle completo de la causa y el fix del prompt están en el PR hermano del backend.

**Cómo lo hicimos (funcional):** El cambio que el usuario pide en el chat se mantiene en la vista previa durante todo el proceso y en el resultado final; el pulido solo retoca lo visual.

**Decisiones y por qué:**
- Guardar el texto del pedido **junto al código pendiente de corrección** (`awaitingCorrectionRef` pasa de guardar el código a guardar `{ code, userRequest }`) → el corrector se dispara después, cuando el preview termina de renderizar; si el pedido se leyera de un estado suelto podría quedar desfasado del código al que corresponde.

**Cómo lo implementamos (técnico):**
- `src/components/plantillasPdf/PdfPlantillaChatDialog.js` → `handleSend` guarda `{ code, userRequest: text }` en `awaitingCorrectionRef`; `handlePreviewImageReady` lo destructura y `runCorrection` lo pasa al servicio.
- `src/services/pdfPlantillaService.js` → `aiCorrect` envía `lastUserRequest` (o `null`) en el POST a `pdf-plantillas/ai-correct`.

**Producción / compatibilidad:** Sin migración. El backend acepta `lastUserRequest` como campo opcional, así que no hay orden de deploy estricto; para que el fix completo esté activo conviene deployar el backend primero (con backend viejo el campo extra se ignora en el destructuring del body).

**Verificación:** Validado en browser local (backend :3003 + frontend :3000): pedir "cambiá el título por CERTIFICADO DE AVANCE" sobre la plantilla de control de presupuesto; el título se mantiene durante "Puliendo el diseño…" y en el resultado final, y el request a `ai-correct` lleva `lastUserRequest`. ESLint limpio en los dos archivos.

---

## TL;DR
- El chat de plantillas PDF conserva el cambio pedido: se envía el último pedido del usuario al corrector con visión para que no lo revierta.
- Cambios: `PdfPlantillaChatDialog.js` (ref de corrección pasa a `{ code, userRequest }`) y `pdfPlantillaService.js` (`aiCorrect` manda `lastUserRequest`).
- Sin migración; backend acepta el campo como opcional (PR hermano sorby_bot_wa#281, deployar primero).
- Verificado en browser local con el flujo completo generador → pulido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)