### PR TITLE
TAR-635: marcar (vos) en la columna Creador de la preview de import

### DIFF
--- a/src/sections/importMovimientos/PasoValidarMovimientosImport.js
+++ b/src/sections/importMovimientos/PasoValidarMovimientosImport.js
@@ -683,7 +683,10 @@ const PasoValidarMovimientosImport = forwardRef(
                       <Typography variant="body2" noWrap sx={{ maxWidth: 120 }}>
                         {(() => {
                           const p = perfiles.find((pp) => pp.phone === d.user_phone);
-                          if (p) return `${p.firstName || ''} ${p.lastName || ''}`.trim() || p.phone;
+                          if (p) {
+                            const nombre = `${p.firstName || ''} ${p.lastName || ''}`.trim() || p.phone;
+                            return p.id === user?.id ? `${nombre} (vos)` : nombre;
+                          }
                           return d.user_phone || '—';
                         })()}
                       </Typography>


### PR DESCRIPTION
Ticket: [TAR-635 — Carga masiva: la vista previa no refleja correctamente los valores que finalmente se crean](https://app.notion.com/p/3a750a1e534180b8beb6dfdc4917f65e)

PR gemelo del backend: fedemaidan/sorby_bot_wa#283 (deployar el backend primero).

Cambio mínimo de UI en el paso de validación de la carga masiva tabular (`PasoValidarMovimientosImport.js`): cuando el creador resuelto de la fila es el usuario logueado, la columna Creador agrega el sufijo "(vos)". El backend ahora completa siempre `user_phone` en la preview (fila con match tolerante > usuario logueado), así que la columna deja de mostrar "—" y esta marca aclara el caso más común.

## TL;DR

Sufijo "(vos)" en la columna Creador cuando el movimiento quedará a nombre del usuario logueado; sin otros cambios de UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
