### PR TITLE
fix(reservas): el gasto se imputa a la reserva elegida, no a la primera de la obra

### DIFF
--- a/src/pages/movementForm.js
+++ b/src/pages/movementForm.js
@@ -316,23 +316,40 @@ const MovementFormPage = () => {
   const soloLectura = isEditMode && recorteObra.editar;
 
   // Reserva de Obra del proyecto: habilita marcar el egreso como gasto de la reserva.
-  const [reservaProyecto, setReservaProyecto] = useState(null);
+  // Una obra puede tener VARIAS reservas, así que se listan todas y el gasto se
+  // imputa a la elegida (nunca a "la primera").
+  const [reservasProyecto, setReservasProyecto] = useState([]);
+  const ridDe = (r) => String(r?._id || r?.id || '');
+  // Reserva objetivo: la que viene por query (botón "Registrar gasto" de una reserva)
+  // o, editando, la que ya tiene imputado el movimiento.
+  const reservaIdObjetivo = reservaId || (isEditMode ? movimiento?.reserva_id : null) || null;
   useEffect(() => {
     if (!empresa?.id || !effectiveProyectoId) {
-      setReservaProyecto(null);
+      setReservasProyecto([]);
       return undefined;
     }
     let cancelado = false;
     reservaObraService.obtenerPorProyecto(empresa.id, effectiveProyectoId)
-      .then((data) => {
-        if (!cancelado) setReservaProyecto(data?.reservas?.length ? data.reservas[0] : null);
+      .then(async (data) => {
+        let reservas = data?.reservas || [];
+        // Las ocultas de la caja (activa === false) no vienen en el listado: si el
+        // gasto apunta a una de esas, se trae puntualmente para no perder la imputación.
+        if (reservaIdObjetivo && !reservas.some((r) => ridDe(r) === String(reservaIdObjetivo))) {
+          try {
+            const suelta = await reservaObraService.obtener(reservaIdObjetivo);
+            if (suelta) reservas = [...reservas, suelta];
+          } catch (error) {
+            console.error('[MovementForm] Error cargando la reserva objetivo:', error);
+          }
+        }
+        if (!cancelado) setReservasProyecto(reservas);
       })
       .catch((error) => {
         console.error('[MovementForm] Error cargando reserva del proyecto:', error);
-        if (!cancelado) setReservaProyecto(null);
+        if (!cancelado) setReservasProyecto([]);
       });
     return () => { cancelado = true; };
-  }, [empresa?.id, effectiveProyectoId]);
+  }, [empresa?.id, effectiveProyectoId, reservaIdObjetivo]);
 
   // Control de Obra del proyecto: habilita imputar el egreso a una obra y sus sub-rubros.
   const [obrasProyecto, setObrasProyecto] = useState([]);
@@ -346,17 +363,17 @@ const MovementFormPage = () => {
   }, [empresa?.id, effectiveProyectoId]);
 
   // Si se llega con ?reservaId (ej. desde "Registrar gasto" de una reserva),
-  // marcar el egreso como gasto de esa reserva una vez cargada.
+  // marcar el egreso como gasto de ESA reserva (no de otra de la misma obra).
   useEffect(() => {
-    if (isEditMode || !reservaId || !reservaProyecto) return;
-    const rid = reservaProyecto._id || reservaProyecto.id;
-    if (rid && !formik.values.reserva_id) {
-      formik.setFieldValue('reserva_id', rid);
+    if (isEditMode || !reservaId || !reservasProyecto.length) return;
+    const target = reservasProyecto.find((r) => ridDe(r) === String(reservaId));
+    if (target && !formik.values.reserva_id) {
+      formik.setFieldValue('reserva_id', ridDe(target));
       formik.setFieldValue('reserva_decidida', true); // viene explícito desde la reserva
       if (formik.values.type !== 'egreso') formik.setFieldValue('type', 'egreso');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reservaId, reservaProyecto, isEditMode]);
+  }, [reservaId, reservasProyecto, isEditMode]);
 
   // Setear breadcrumbs
   useEffect(() => {
@@ -866,7 +883,7 @@ const createdAtStr = (() => {
       if (fieldName === 'reserva') {
         // reserva_id null es una respuesta válida ("No"); se exige que el usuario haya
         // decidido explícitamente, solo cuando la obra tiene reserva y es un egreso nuevo.
-        const aplica = !isEditMode && values?.type === 'egreso' && !!reservaProyecto;
+        const aplica = !isEditMode && values?.type === 'egreso' && reservasProyecto.length > 0;
         if (aplica && !values?.reserva_decidida) {
           errors.reserva = 'Indicá si el gasto sale de la reserva';
         }
@@ -2122,21 +2139,31 @@ const createdAtStr = (() => {
                   </StitchBlock>
                   <StitchBlock step={2} title="Clasificación">
                     <MovementFields {...sharedFieldProps} block="classification" />
-                    {reservaProyecto && formik.values.type === 'egreso' && (
-                      requiredFieldNames.includes('reserva') && !isEditMode ? (
-                        // Obligatorio: pregunta Sí/No sin opción por defecto (bloquea el submit).
+                    {reservasProyecto.length > 0 && formik.values.type === 'egreso' && (() => {
+                      const nombreDe = (r) => r.nombre || `Reserva de Obra · ${r.proyecto_nombre || 'la obra'}`;
+                      // Con varias reservas en la obra hay que elegir a CUÁL se imputa:
+                      // el default (la del query o la primera) solo aplica al tildar el check.
+                      const ridDefault = ridDe(
+                        reservasProyecto.find((r) => ridDe(r) === String(reservaIdObjetivo)) || reservasProyecto[0],
+                      );
+                      const opciones = reservasProyecto.map((r) => ({
+                        key: ridDe(r),
+                        label: reservasProyecto.length > 1 ? nombreDe(r) : 'Sí, de la reserva',
+                        rid: ridDe(r),
+                      }));
+                      return requiredFieldNames.includes('reserva') && !isEditMode ? (
+                        // Obligatorio: pregunta sin opción por defecto (bloquea el submit).
                         <div className="mt-2 rounded-lg border border-warning-main/40 bg-warning-main/5 px-2.5 py-2">
-                          <span className="block text-xs font-medium text-neutral-800">¿Este gasto sale de la Reserva de Obra?</span>
+                          <span className="block text-xs font-medium text-neutral-800">¿Este gasto sale de una Reserva de Obra?</span>
                           <span className="mb-1.5 block text-[11px] text-neutral-500">
-                            Reserva interna de {reservaProyecto.proyecto_nombre || 'la obra'}. Elegí una opción para continuar.
+                            Reserva interna de {reservasProyecto[0].proyecto_nombre || 'la obra'}. Elegí una opción para continuar.
                           </span>
-                          <div className="flex gap-2">
-                            {[
-                              { key: 'si', label: 'Sí, de la reserva', rid: (reservaProyecto._id || reservaProyecto.id) },
-                              { key: 'no', label: 'No, saldo general', rid: null },
-                            ].map((opt) => {
+                          <div className="flex flex-wrap gap-2">
+                            {[...opciones, { key: 'no', label: 'No, saldo general', rid: null }].map((opt) => {
                               const selected = formik.values.reserva_decidida
-                                && (opt.key === 'si' ? !!formik.values.reserva_id : !formik.values.reserva_id);
+                                && (opt.rid
+                                  ? String(formik.values.reserva_id) === opt.rid
+                                  : !formik.values.reserva_id);
                               return (
                                 <button
                                   type="button"
@@ -2146,7 +2173,7 @@ const createdAtStr = (() => {
                                     formik.setFieldValue('reserva_decidida', true);
                                     formik.setFieldTouched('reserva', true, false);
                                   }}
-                                  className={`flex-1 rounded-md border px-2 py-1.5 text-xs font-medium transition ${selected ? 'border-warning-main bg-warning-main/20 text-neutral-900' : 'border-neutral-300 bg-white text-neutral-600 hover:border-warning-main/60'}`}
+                                  className={`min-w-[120px] flex-1 rounded-md border px-2 py-1.5 text-xs font-medium transition ${selected ? 'border-warning-main bg-warning-main/20 text-neutral-900' : 'border-neutral-300 bg-white text-neutral-600 hover:border-warning-main/60'}`}
                                 >
                                   {opt.label}
                                 </button>
@@ -2163,19 +2190,30 @@ const createdAtStr = (() => {
                             <span className="min-w-0">
                               <span className="block text-xs font-medium text-neutral-800">Gasto de Reserva de Obra</span>
                               <span className="block text-[11px] text-neutral-500">
-                                Consume la reserva interna de {reservaProyecto.proyecto_nombre || 'la obra'} (es un egreso real de la obra)
+                                Consume la reserva interna de {reservasProyecto[0].proyecto_nombre || 'la obra'} (es un egreso real de la obra)
                               </span>
                             </span>
                             <input
                               type="checkbox"
                               className="h-4 w-4 shrink-0 accent-warning-main"
                               checked={!!formik.values.reserva_id}
-                              onChange={(e) => formik.setFieldValue('reserva_id', e.target.checked ? (reservaProyecto._id || reservaProyecto.id) : null)}
+                              onChange={(e) => formik.setFieldValue('reserva_id', e.target.checked ? ridDefault : null)}
                             />
                           </label>
+                          {!!formik.values.reserva_id && reservasProyecto.length > 1 && (
+                            <select
+                              className="mt-2 w-full rounded border border-divider px-2 py-1 text-xs"
+                              value={String(formik.values.reserva_id)}
+                              onChange={(e) => formik.setFieldValue('reserva_id', e.target.value)}
+                            >
+                              {reservasProyecto.map((r) => (
+                                <option key={ridDe(r)} value={ridDe(r)}>{nombreDe(r)}</option>
+                              ))}
+                            </select>
+                          )}
                         </div>
-                      )
-                    )}
+                      );
+                    })()}
                     {obrasProyecto.length > 0 && formik.values.type === 'egreso' && (() => {
                       const obraSel = obrasProyecto.find((o) => o._id === formik.values.control_obra_id) || null;
                       const subs = obraSel ? (obraSel.rubros || []).flatMap((r) => (r.subrubros || []).map((s) => ({ uid: s.uid, nombre: `${r.nombre} · ${s.nombre}` }))) : [];


### PR DESCRIPTION
Fix salido de probar la épica **Reserva de Obra unificada**. Tickets de contexto: [Épica Reserva de Obra unificada](https://app.notion.com/p/39d50a1e534181ed8a3dcda2513fd385) · [TAR-564 — Visualizar reservas en negativo](https://app.notion.com/p/39d50a1e534181d09ad5dd106106b5b4). Sin PR hermano: el backend no necesitó cambios.

---

## Gasto de Reserva de Obra imputado a la reserva equivocada

**Causa raíz / Problema:** al tocar **Registrar gasto** dentro de una reserva, el movimiento se creaba bien pero la reserva seguía mostrando **$0 de gastos**. El botón le pasaba al formulario de movimientos el id de *esa* reserva (`?reservaId=`), pero el formulario lo usaba solo como señal de "vengo de una reserva" y después imputaba el gasto a **la primera reserva de la obra**. En una obra con una sola reserva coincidía por casualidad; en una obra con dos o más, el gasto caía en la reserva incorrecta, sin ningún aviso.

Caso real que lo destapó: la obra Tigre tiene dos reservas (`Reserva de Obra · Tigre`, de junio, y `reserva prueba tigre`, de julio). Cuatro egresos cargados desde la segunda (códigos 5293 a 5296, 729.000 ARS) quedaron descontando de la primera.

**Cómo lo hicimos (funcional):**
- El gasto ahora descuenta de **la reserva desde la que se tocó "Registrar gasto"**, siempre.
- Si la obra tiene **varias reservas** y el usuario carga un egreso desde la caja (sin venir de una reserva), el formulario muestra las reservas por nombre y le pide elegir a cuál se imputa (o "No, saldo general"). Antes solo podía decir sí/no a una reserva que el sistema elegía por él.
- **Editando** un egreso también aparece el selector, así se puede corregir un gasto que quedó en la reserva equivocada sin borrarlo ni recargarlo.
- Con una sola reserva en la obra, la pantalla se ve exactamente igual que antes.

**Decisiones y por qué:**
- **La reserva la manda el `reservaId` de la URL, no el orden del listado** → es el único dato que expresa la intención del usuario; `reservas[0]` era una coincidencia heredada de cuando existía una sola reserva por obra.
- **Si la reserva objetivo está oculta de la caja (`activa: false`) se trae por id aparte** → `GET /reservas/proyecto/:id` filtra las ocultas a propósito (no deben sumar al reservado de la caja), pero eso no debería impedir imputarle un gasto si el usuario entró justo a esa reserva. Alternativa descartada: dejar de filtrarlas en el endpoint, que rompería el desglose de la caja.
- **Selector solo cuando hay más de una reserva** → con una sola, un desplegable de un ítem es ruido; se mantiene el checkbox / los botones Sí-No de siempre.
- **Se habilita el cambio de reserva en edición** → es la vía para reparar los movimientos ya mal imputados desde la propia UI, sin script de migración.
- **Sin cambios en el backend** → `reserva_id` ya viajaba entero de punta a punta y `recalcularSaldos` ya recalcula las dos reservas afectadas al editar. El bug era del lado del formulario.

**Cómo lo implementamos (técnico):** todo en `factudata-react/src/pages/movementForm.js`.
- `reservaProyecto` (una sola reserva) pasa a ser `reservasProyecto` (array). El efecto que llama a `reservaObraService.obtenerPorProyecto` ahora guarda `data.reservas` completo y, si `reservaIdObjetivo` no está en esa lista, la busca con `reservaObraService.obtener(id)` y la agrega.
- `reservaIdObjetivo = reservaId (query) || movimiento.reserva_id (modo edición)`: un solo concepto de "cuál es la reserva de este gasto", que sirve tanto al alta como a la edición.
- El efecto de prefill matchea `ridDe(r) === String(reservaId)` en vez de tomar `reservasProyecto[0]`, y solo setea `reserva_decidida` si encontró la reserva.
- `validateMovementForm` pasa de `!!reservaProyecto` a `reservasProyecto.length > 0` para la pregunta obligatoria.
- El bloque de UI se envuelve en un IIFE que arma las opciones: en el modo obligatorio, un botón por reserva (con su nombre cuando hay más de una) más "No, saldo general"; en el modo checkbox, el check de siempre más un `<select>` de reservas que aparece únicamente si hay varias.

**Producción / compatibilidad:** no hay migración ni cambios de modelo de datos ni de API. Los movimientos ya cargados quedan intactos — incluidos los mal imputados, que siguen descontando de la reserva equivocada hasta que se los reasigne a mano (el selector en edición hace exactamente eso y dispara `recalcularSaldos` de ambas reservas en el backend). Obras con una sola reserva: comportamiento idéntico al actual.

**Verificación:** causa raíz confirmada contra la base que usaba el entorno (solo lectura): la obra tiene dos reservas y los cuatro egresos web quedaron con el `reserva_id` de la primera. `npx eslint src/pages/movementForm.js` limpio. **Pendiente de prueba manual en browser** (no se validó en Chrome):
1. Entrar a la reserva B de una obra con dos reservas → Registrar gasto → guardar → el gasto aparece en B y sube "Gastos registrados" de B.
2. Repetir desde la reserva A → cae en A.
3. Cargar un egreso desde la caja de esa obra → aparecen las dos reservas, ninguna preseleccionada.
4. Obra con una sola reserva → la pantalla no cambió.
5. Editar uno de los egresos mal imputados → cambiar de reserva en el selector → los saldos de ambas reservas se actualizan.

**Notas al código:**
- `movementForm.js` → efecto de carga de reservas: el fetch extra por id existe solo para el caso de reserva oculta de la caja; se hace dentro del `.then` (y no en un efecto aparte) para que `reservasProyecto` quede seteado una sola vez y el efecto de prefill no corra con una lista incompleta.
- `movementForm.js` → `ridDe(r)`: las reservas llegan con `_id` (Mongo) desde el listado y podrían llegar con `id` según el caller, y el `reservaId` de la query siempre es string; el helper normaliza para que la comparación sea siempre string contra string.
- `movementForm.js` → efecto de prefill: si la reserva del query no aparece en la lista no se setea nada, en vez de caer a la primera. Preferimos un gasto sin reserva (visible, corregible) antes que un gasto silenciosamente descontado de la reserva de otro.
- `movementForm.js` → `ridDefault` en el modo checkbox: al tildar el check se usa la reserva del query si existe, y recién si no hay ninguna, la primera. Ese fallback ya no es una imputación a ciegas porque al lado queda el selector para cambiarla.

---

## TL;DR
- **Para el usuario:** el gasto cargado desde una reserva ahora descuenta de *esa* reserva. En obras con más de una reserva, el formulario de movimientos deja elegir a cuál se imputa (antes elegía el sistema, mal). Editando un egreso también se puede cambiar de reserva.
- **Archivos:** un solo archivo, `factudata-react/src/pages/movementForm.js`. Backend sin cambios.
- **Qué se sacó:** el estado `reservaProyecto` (una reserva por obra) y el `reservas[0]` implícito; pasan a `reservasProyecto` + match por id.
- **Modelo de datos:** sin cambios, sin migración, sin breaking changes.
- **Verificación:** causa raíz confirmada en base (dos reservas en la obra, 4 egresos en la equivocada), eslint limpio, prueba manual en browser pendiente.
- **Pendiente aparte:** reasignar a mano los movimientos ya mal imputados (códigos 5293-5296).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
