### PR TITLE
TAR-632: cobrar una cuota por el importe real y confirmarla como saldada

### DIFF
--- a/src/components/planCobro/CobroCuotaDialog.js
+++ b/src/components/planCobro/CobroCuotaDialog.js
@@ -1,0 +1,315 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  FormControlLabel,
+  InputAdornment,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { formatCurrency, formatNumberInput, parseNumberInput } from 'src/utils/formatters';
+import planCobroService from 'src/services/planCobroService';
+import {
+  montoCalculadoDeCuota,
+  importeDelCobro,
+  diferenciaAceptadaPreview,
+  importeDifiereDelRestante,
+} from 'src/utils/planCobro/cobroCuota';
+
+const hoyISO = () => new Date().toISOString().split('T')[0];
+
+/**
+ * Diálogo de cobro de una cuota de Plan de Cobro. Compartido por el detalle del
+ * plan y por la pantalla de cobranzas de control de obra: el diálogo arma el
+ * payload y el que lo usa decide contra qué endpoint lo manda (`onConfirm`).
+ *
+ * @param {object}   cuota          cuota a cobrar (numero, monto_cobrado, fecha_vencimiento)
+ * @param {object}   plan           plan de la cuota (define moneda e indexación)
+ * @param {number}   montoCalculado monto ya conocido por el padre; se muestra mientras
+ *                                  el diálogo resuelve el índice de la fecha de cobro
+ * @param {function} onConfirm      recibe el payload del cobro; devuelve una promesa
+ */
+const CobroCuotaDialog = ({
+  open,
+  cuota,
+  plan = null,
+  montoCalculado = null,
+  empresaId,
+  onClose,
+  onConfirm,
+}) => {
+  // Un plan en 'CAC' se cobra en pesos: el índice es la unidad de cuenta, no la moneda.
+  const moneda = plan?.moneda === 'CAC' ? 'ARS' : (plan?.moneda || 'ARS');
+  const proyectoId = plan?.proyecto_id || null;
+  const [indice, setIndice] = useState({ cac: null, usd: null });
+  const [tipoCobro, setTipoCobro] = useState('total'); // 'total' | 'parcial'
+  const [montoParcial, setMontoParcial] = useState('');
+  const [modoCobro, setModoCobro] = useState('nuevo'); // 'nuevo' | 'vincular' | 'solo_estado'
+  // Fecha efectiva de cobro (TAR-442): default hoy, editable para cobros históricos.
+  const [fechaCobro, setFechaCobro] = useState(hoyISO());
+  const [movVinculables, setMovVinculables] = useState([]);
+  const [movSel, setMovSel] = useState(null);
+  const [cobroTotalConfirmado, setCobroTotalConfirmado] = useState(false);
+  const [enviando, setEnviando] = useState(false);
+
+  // Cada apertura arranca limpia y precarga los ingresos por si se elige "vincular".
+  useEffect(() => {
+    if (!open) return;
+    setTipoCobro('total');
+    setMontoParcial('');
+    setModoCobro('nuevo');
+    setFechaCobro(hoyISO());
+    setMovSel(null);
+    setCobroTotalConfirmado(false);
+    setEnviando(false);
+    if (!empresaId) { setMovVinculables([]); return; }
+    planCobroService.listarMovimientosVinculables(empresaId, proyectoId)
+      .then((res) => setMovVinculables(res?.data?.data || []))
+      .catch(() => setMovVinculables([]));
+  }, [open, empresaId, proyectoId, cuota?._id]);
+
+  // El monto calculado se toma al índice de la FECHA EFECTIVA de cobro, que es la
+  // que usa el backend para valuar la cuota y para el snapshot del cobro total.
+  useEffect(() => {
+    if (!open || !plan?.indexacion || !fechaCobro) { setIndice({ cac: null, usd: null }); return; }
+    let vigente = true;
+    const request = plan.indexacion === 'CAC'
+      ? planCobroService.previewCAC(fechaCobro, plan.cac_tipo || 'general')
+      : planCobroService.previewUSD(fechaCobro, plan.usd_fuente || plan.cotizacion_snapshot?.dolar_fuente || 'blue');
+    request
+      .then((res) => {
+        if (!vigente) return;
+        const data = res?.data?.data;
+        setIndice({ cac: data?.cac_indice || null, usd: data?.dolar_indice || null });
+      })
+      .catch(() => { if (vigente) setIndice({ cac: null, usd: null }); });
+    return () => { vigente = false; };
+  }, [open, fechaCobro, plan?.indexacion, plan?.cac_tipo, plan?.usd_fuente]);
+
+  const indiceResuelto = indice.cac != null || indice.usd != null;
+  const montoCuota = (!plan?.indexacion || indiceResuelto || montoCalculado == null)
+    ? montoCalculadoDeCuota({ cuota, plan, cacActual: indice.cac, usdActual: indice.usd })
+    : Number(montoCalculado) || 0;
+
+  const montoCobradoPrevio = cuota?.monto_cobrado || 0;
+  const restante = Math.max(0, montoCuota - montoCobradoPrevio);
+  const yaParcial = cuota?.estado === 'cobrada_parcial';
+
+  const importe = importeDelCobro({ modo: modoCobro, tipoCobro, montoParcial, movimiento: movSel, restante });
+  const difiere = importeDifiereDelRestante(importe, restante);
+  const diferencia = diferenciaAceptadaPreview({ montoCalculado: montoCuota, montoCobradoPrevio, importe });
+  const superaRestante = importe > restante + 0.01;
+
+  // El checkbox solo tiene sentido cuando el importe no coincide con el restante.
+  const mostrarCheckbox = difiere;
+  const totalConfirmado = mostrarCheckbox && cobroTotalConfirmado;
+
+  const faltaImporte = importe <= 0 || (modoCobro === 'vincular' && !movSel);
+  const bloqueadoPorTope = superaRestante && !totalConfirmado;
+
+  const handleConfirm = async () => {
+    if (faltaImporte || bloqueadoPorTope) return;
+    setEnviando(true);
+    try {
+      await onConfirm({
+        fecha_cobrado: fechaCobro || hoyISO(),
+        // En "vincular" el importe lo define el movimiento elegido.
+        monto_parcial: (modoCobro !== 'vincular' && tipoCobro === 'parcial') ? importe : undefined,
+        modo: modoCobro,
+        movimiento_id: modoCobro === 'vincular' ? movSel?._id : undefined,
+        cobro_total_confirmado: totalConfirmado || undefined,
+      });
+    } finally {
+      setEnviando(false);
+    }
+  };
+
+  const textoDiferencia = diferencia == null || diferencia === 0
+    ? null
+    : diferencia > 0
+      ? `Se acepta una diferencia de ${formatCurrency(diferencia, moneda)} a favor del cliente.`
+      : `Se cobra ${formatCurrency(Math.abs(diferencia), moneda)} por encima del monto calculado.`;
+
+  return (
+    <Dialog open={!!open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Registrar cobro</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 2 }}>
+          Cuota #{cuota?.numero} — Monto: <strong>{formatCurrency(montoCuota, moneda)}</strong>
+          {cuota?.fecha_vencimiento && (
+            <> (Vto: {new Date(cuota.fecha_vencimiento).toLocaleDateString('es-AR')})</>
+          )}
+          {yaParcial && (
+            <>
+              <br />
+              Ya cobrado: <strong>{formatCurrency(montoCobradoPrevio, moneda)}</strong>
+              {' '}— Restante: <strong>{formatCurrency(restante, moneda)}</strong>
+            </>
+          )}
+        </DialogContentText>
+
+        <ToggleButtonGroup
+          value={tipoCobro}
+          exclusive
+          onChange={(_, val) => {
+            if (val) { setTipoCobro(val); setMontoParcial(''); setCobroTotalConfirmado(false); }
+          }}
+          size="small"
+          sx={{ mb: 2 }}
+        >
+          <ToggleButton value="total">{yaParcial ? 'Cobrar todo el resto' : 'Cobro total'}</ToggleButton>
+          <ToggleButton value="parcial">Pago parcial</ToggleButton>
+        </ToggleButtonGroup>
+
+        {tipoCobro === 'parcial' && modoCobro !== 'vincular' && (
+          <TextField
+            label="Monto a cobrar"
+            value={formatNumberInput(montoParcial)}
+            onChange={(e) => setMontoParcial(parseNumberInput(e.target.value))}
+            fullWidth
+            size="small"
+            sx={{ mt: 1 }}
+            inputProps={{ inputMode: 'decimal' }}
+            InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+            error={bloqueadoPorTope}
+            helperText={
+              bloqueadoPorTope
+                ? 'Supera el restante de la cuota: marcá "La cuota queda totalmente pagada" o bajá el importe.'
+                : importe > 0
+                  ? `Resto después de este pago: ${formatCurrency(Math.max(0, restante - importe), moneda)}`
+                  : ''
+            }
+          />
+        )}
+
+        {/* Fecha efectiva de cobro (TAR-442): editable para registrar cobros históricos.
+            En modo "vincular" la fecha la define el movimiento ya cargado. */}
+        {modoCobro !== 'vincular' && (
+          <TextField
+            label="Fecha efectiva de cobro"
+            type="date"
+            value={fechaCobro}
+            onChange={(e) => setFechaCobro(e.target.value)}
+            fullWidth
+            size="small"
+            sx={{ mt: 2 }}
+            InputLabelProps={{ shrink: true }}
+            inputProps={{ max: hoyISO() }}
+            helperText="El ingreso en caja se registra con esta fecha. Podés indicar una fecha pasada."
+          />
+        )}
+
+        {/* Modo: crear ingreso, vincular uno existente, o solo estado */}
+        <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 2 }}>
+          ¿Cómo lo registramos?
+        </Typography>
+        <ToggleButtonGroup
+          value={modoCobro}
+          exclusive
+          onChange={(_, val) => { if (val) { setModoCobro(val); setMovSel(null); setCobroTotalConfirmado(false); } }}
+          size="small"
+          sx={{ mt: 0.5, flexWrap: 'wrap' }}
+        >
+          <ToggleButton value="nuevo">Nuevo ingreso</ToggleButton>
+          <ToggleButton value="vincular">Vincular pago existente</ToggleButton>
+          <ToggleButton value="solo_estado">Solo marcar</ToggleButton>
+        </ToggleButtonGroup>
+
+        {modoCobro === 'vincular' && (
+          <Box sx={{ mt: 1.5, maxHeight: 200, overflowY: 'auto', border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+            {movVinculables.length === 0 ? (
+              <Typography variant="body2" color="text.secondary" sx={{ p: 1.5 }}>
+                No hay ingresos sin vincular.
+              </Typography>
+            ) : movVinculables.map((m) => (
+              <Stack
+                key={m._id}
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+                onClick={() => { setMovSel(m); setCobroTotalConfirmado(false); }}
+                sx={{ px: 1.5, py: 1, cursor: 'pointer', bgcolor: movSel?._id === m._id ? 'primary.50' : 'transparent', borderBottom: '1px solid', borderColor: 'divider' }}
+              >
+                <Box>
+                  <Typography variant="body2" fontWeight={movSel?._id === m._id ? 700 : 500}>
+                    {m.codigo_operacion ? `#${m.codigo_operacion} · ` : ''}{formatCurrency(m.monto || 0, m.moneda || moneda)}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {m.fecha ? new Date(m.fecha).toLocaleDateString('es-AR') : 's/f'}{m.detalle ? ` · ${m.detalle}` : ''}
+                  </Typography>
+                </Box>
+                {movSel?._id === m._id && <CheckCircleIcon color="primary" fontSize="small" />}
+              </Stack>
+            ))}
+          </Box>
+        )}
+
+        {/* Cuota totalmente pagada: saldar la cuota con un importe distinto al calculado. */}
+        {mostrarCheckbox && (
+          <Box sx={{ mt: 2 }}>
+            <FormControlLabel
+              control={(
+                <Checkbox
+                  size="small"
+                  checked={cobroTotalConfirmado}
+                  onChange={(e) => setCobroTotalConfirmado(e.target.checked)}
+                />
+              )}
+              label="La cuota queda totalmente pagada"
+            />
+            <Typography variant="caption" color="text.secondary" display="block">
+              {cobroTotalConfirmado
+                ? textoDiferencia || 'La cuota se marcará como cobrada por el importe indicado.'
+                : 'Marcalo si este importe salda la cuota aunque no coincida con el monto calculado.'}
+            </Typography>
+          </Box>
+        )}
+
+        {/* En "vincular" no hay campo de monto donde avisar del tope. */}
+        {bloqueadoPorTope && modoCobro === 'vincular' && (
+          <Alert severity="warning" sx={{ mt: 1.5 }}>
+            El movimiento supera el restante de la cuota: marcá &quot;La cuota queda totalmente pagada&quot; para saldarla con ese importe.
+          </Alert>
+        )}
+
+        {totalConfirmado && (
+          <Alert severity="info" sx={{ mt: 1.5 }}>
+            La cuota quedará cobrada por {formatCurrency(montoCobradoPrevio + importe, moneda)} y no dejará saldo pendiente.
+          </Alert>
+        )}
+
+        <Typography variant="body2" color="text.secondary" mt={2}>
+          {modoCobro === 'nuevo'
+            ? 'Se registrará un movimiento de caja automáticamente.'
+            : modoCobro === 'vincular'
+              ? 'Se vinculará el pago ya cargado, sin duplicar el ingreso.'
+              : 'Se marcará como cobrada sin generar movimiento de caja.'}
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancelar</Button>
+        <Button
+          color="success"
+          variant="contained"
+          onClick={handleConfirm}
+          disabled={enviando || faltaImporte || bloqueadoPorTope}
+        >
+          {modoCobro === 'solo_estado' ? 'Marcar cobrada' : tipoCobro === 'parcial' ? 'Cobrar parcial' : 'Confirmar cobro'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CobroCuotaDialog;

--- a/src/pages/cobros/[id].js
+++ b/src/pages/cobros/[id].js
@@ -44,6 +44,12 @@ import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
 import { usePlanCobro } from 'src/hooks/usePlanCobro';
 import { formatCurrency, formatNumberInput, parseNumberInput } from 'src/utils/formatters';
 import planCobroService from 'src/services/planCobroService';
+import CobroCuotaDialog from 'src/components/planCobro/CobroCuotaDialog';
+import {
+  diferenciaAceptadaDeCuota,
+  mensajeCobroRegistrado,
+  montoCalculadoDeCuota,
+} from 'src/utils/planCobro/cobroCuota';
 
 const ESTADO_COLOR = { borrador: 'default', activo: 'primary', completado: 'success' };
 const ESTADO_LABEL = { borrador: 'Borrador', activo: 'Activo', completado: 'Completado' };
@@ -59,13 +65,6 @@ const DetallePlanPage = () => {
   const [confirmCobrar, setConfirmCobrar] = useState(null); // cuota object or null
   const [cobrandoId, setCobrandoId] = useState(null);
   const [reverting, setReverting] = useState(null);
-  const [tipoCobro, setTipoCobro] = useState('total'); // 'total' | 'parcial'
-  const [montoParcial, setMontoParcial] = useState('');
-  const [modoCobro, setModoCobro] = useState('nuevo'); // 'nuevo' | 'vincular' | 'solo_estado'
-  // Fecha efectiva de cobro (TAR-442): default hoy, editable para registrar cobros históricos.
-  const [fechaCobro, setFechaCobro] = useState(new Date().toISOString().split('T')[0]);
-  const [movVinculables, setMovVinculables] = useState([]);
-  const [movSel, setMovSel] = useState(null);
 
   // Edit cuota dialog
   const [editCuota, setEditCuota] = useState(null); // cuota object or null
@@ -145,16 +144,7 @@ const DetallePlanPage = () => {
   }, [plan?.indexacion, plan?.cac_tipo, plan?.usd_fuente, plan?.cotizacion_snapshot?.dolar_fuente]);
 
   // Para planes CAC con monto ajustable: valor actual en ARS = monto_cac × cac_actual
-  const getMontoCuota = (cuota) => {
-    if (!cuota) return 0;
-    if (plan?.indexacion === 'CAC' && cuota.monto_cac && cacActual) {
-      return Math.round(cuota.monto_cac * cacActual * 100) / 100;
-    }
-    if (plan?.indexacion === 'USD' && cuota.monto_usd && usdActual) {
-      return Math.round(cuota.monto_usd * usdActual * 100) / 100;
-    }
-    return cuota.monto || 0;
-  };
+  const getMontoCuota = (cuota) => montoCalculadoDeCuota({ cuota, plan, cacActual, usdActual });
 
   // A3 (TAR-466 pt.2): para cuotas ya cobradas mostramos el monto REAL cobrado,
   // no el valor ajustado al índice de hoy (que confunde: parece cobrado de más).
@@ -169,44 +159,17 @@ const DetallePlanPage = () => {
   const handleCobrarClick = (cuotaId) => {
     const cuota = (plan.cuotas || []).find((c) => c._id === cuotaId);
     setConfirmCobrar(cuota || { _id: cuotaId });
-    setTipoCobro('total');
-    setMontoParcial('');
-    setModoCobro('nuevo');
-    setMovSel(null);
-    setFechaCobro(new Date().toISOString().split('T')[0]);
-    // Precargar movimientos vinculables (por si el usuario elige "vincular")
-    planCobroService.listarMovimientosVinculables(empresaId, plan?.proyecto_id)
-      .then((res) => setMovVinculables(res?.data?.data || []))
-      .catch(() => setMovVinculables([]));
   };
 
-  const handleCobrarConfirm = async () => {
+  const handleCobrarConfirm = async (payload) => {
     if (!confirmCobrar) return;
     const cuotaId = confirmCobrar._id;
-    const parcial = tipoCobro === 'parcial' ? parseNumberInput(montoParcial) : null;
-    if (tipoCobro === 'parcial' && (!parcial || Number(parcial) <= 0)) return;
-    if (modoCobro === 'vincular' && !movSel) {
-      setAlert({ open: true, message: 'Elegí un movimiento para vincular', severity: 'warning' });
-      return;
-    }
     setConfirmCobrar(null);
     setCobrandoId(cuotaId);
     try {
-      await marcarCobrada(cuotaId, {
-        fecha_cobrado: fechaCobro || new Date().toISOString().split('T')[0],
-        monto_parcial: parcial ? Number(parcial) : undefined,
-        modo: modoCobro,
-        movimiento_id: modoCobro === 'vincular' ? movSel?._id : undefined,
-      });
+      await marcarCobrada(cuotaId, payload);
       await refresh();
-      const msg = modoCobro === 'vincular'
-        ? 'Cuota cobrada vinculando el movimiento existente.'
-        : modoCobro === 'solo_estado'
-          ? 'Cuota marcada como cobrada (sin movimiento de caja).'
-          : tipoCobro === 'parcial'
-            ? 'Pago parcial registrado.'
-            : 'Cuota cobrada. Movimiento de caja registrado.';
-      setAlert({ open: true, message: msg, severity: 'success' });
+      setAlert({ open: true, message: mensajeCobroRegistrado(payload), severity: 'success' });
     } catch (err) {
       setAlert({ open: true, message: err?.response?.data?.error || err.message || 'Error al marcar cuota', severity: 'error' });
     } finally {
@@ -1147,6 +1110,18 @@ const DetallePlanPage = () => {
                               </Tooltip>
                             ) : montoTxt;
                           })()}
+                          {(() => {
+                            // Cuota saldada manualmente con un importe distinto al calculado.
+                            const diferencia = diferenciaAceptadaDeCuota(cuota);
+                            if (diferencia == null) return null;
+                            return (
+                              <Tooltip title={`Monto calculado al día del cobro: ${formatCurrency(cuota.monto_calculado_snapshot, monedaDisplay)}`}>
+                                <Typography variant="caption" color="text.secondary">
+                                  Diferencia aceptada: {formatCurrency(Math.abs(diferencia), monedaDisplay)} {diferencia > 0 ? 'de menos' : 'de más'}
+                                </Typography>
+                              </Tooltip>
+                            );
+                          })()}
                           {plan.estado === 'activo' && (
                             <Stack direction="row" spacing={1} flexWrap="wrap" justifyContent={{ sm: 'flex-end' }}>
                               {esCobrada || esParcial ? (
@@ -1191,151 +1166,16 @@ const DetallePlanPage = () => {
         </Container>
       </Box>
 
-      {/* Diálogo confirmar cobrar (total o parcial) */}
-      <Dialog open={!!confirmCobrar} onClose={() => setConfirmCobrar(null)} maxWidth="xs" fullWidth>
-        <DialogTitle>Registrar cobro</DialogTitle>
-        <DialogContent>
-          {(() => {
-            const montoActual = getMontoCuota(confirmCobrar);
-            const montoRestante = montoActual - (confirmCobrar?.monto_cobrado || 0);
-            const yaParcial = confirmCobrar?.estado === 'cobrada_parcial';
-            return (
-              <>
-                <DialogContentText sx={{ mb: 2 }}>
-                  Cuota #{confirmCobrar?.numero} — Monto: <strong>{formatCurrency(montoActual, monedaDisplay)}</strong>
-                  {confirmCobrar?.fecha_vencimiento && (
-                    <> (Vto: {new Date(confirmCobrar.fecha_vencimiento).toLocaleDateString('es-AR')})</>
-                  )}
-                  {yaParcial && (
-                    <>
-                      <br />
-                      Ya cobrado: <strong>{formatCurrency(confirmCobrar?.monto_cobrado || 0, monedaDisplay)}</strong>
-                      {' '}— Restante: <strong>{formatCurrency(montoRestante, monedaDisplay)}</strong>
-                    </>
-                  )}
-                </DialogContentText>
-
-                <ToggleButtonGroup
-                  value={tipoCobro}
-                  exclusive
-                  onChange={(_, val) => {
-                    if (val) { setTipoCobro(val); setMontoParcial(''); }
-                  }}
-                  size="small"
-                  sx={{ mb: 2 }}
-                >
-                  <ToggleButton value="total">{yaParcial ? 'Cobrar todo el resto' : 'Cobro total'}</ToggleButton>
-                  <ToggleButton value="parcial">Pago parcial</ToggleButton>
-                </ToggleButtonGroup>
-
-                {tipoCobro === 'parcial' && (
-                  <TextField
-                    label="Monto a cobrar"
-                    value={formatNumberInput(montoParcial)}
-                    onChange={(e) => setMontoParcial(parseNumberInput(e.target.value))}
-                    fullWidth
-                    size="small"
-                    sx={{ mt: 1 }}
-                    inputProps={{ inputMode: 'decimal' }}
-                    InputProps={{
-                      startAdornment: <InputAdornment position="start">$</InputAdornment>,
-                    }}
-                    helperText={
-                      montoParcial && montoRestante
-                        ? `Resto después de este pago: ${formatCurrency(Math.max(0, montoRestante - (Number(montoParcial) || 0)), monedaDisplay)}`
-                        : ''
-                    }
-                  />
-                )}
-
-                {/* Fecha efectiva de cobro (TAR-442): editable para registrar cobros históricos.
-                    En modo "vincular" la fecha la define el movimiento ya cargado. */}
-                {modoCobro !== 'vincular' && (
-                  <TextField
-                    label="Fecha efectiva de cobro"
-                    type="date"
-                    value={fechaCobro}
-                    onChange={(e) => setFechaCobro(e.target.value)}
-                    fullWidth
-                    size="small"
-                    sx={{ mt: 2 }}
-                    InputLabelProps={{ shrink: true }}
-                    inputProps={{ max: new Date().toISOString().split('T')[0] }}
-                    helperText="El ingreso en caja se registra con esta fecha. Podés indicar una fecha pasada."
-                  />
-                )}
-
-                {/* Modo: crear ingreso, vincular uno existente, o solo estado */}
-                <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 2 }}>
-                  ¿Cómo lo registramos?
-                </Typography>
-                <ToggleButtonGroup
-                  value={modoCobro}
-                  exclusive
-                  onChange={(_, val) => { if (val) { setModoCobro(val); setMovSel(null); } }}
-                  size="small"
-                  sx={{ mt: 0.5, flexWrap: 'wrap' }}
-                >
-                  <ToggleButton value="nuevo">Nuevo ingreso</ToggleButton>
-                  <ToggleButton value="vincular">Vincular pago existente</ToggleButton>
-                  <ToggleButton value="solo_estado">Solo marcar</ToggleButton>
-                </ToggleButtonGroup>
-
-                {modoCobro === 'vincular' && (
-                  <Box sx={{ mt: 1.5, maxHeight: 200, overflowY: 'auto', border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
-                    {movVinculables.length === 0 ? (
-                      <Typography variant="body2" color="text.secondary" sx={{ p: 1.5 }}>
-                        No hay ingresos sin vincular.
-                      </Typography>
-                    ) : movVinculables.map((m) => (
-                      <Stack
-                        key={m._id}
-                        direction="row"
-                        justifyContent="space-between"
-                        alignItems="center"
-                        onClick={() => setMovSel(m)}
-                        sx={{ px: 1.5, py: 1, cursor: 'pointer', bgcolor: movSel?._id === m._id ? 'primary.50' : 'transparent', borderBottom: '1px solid', borderColor: 'divider' }}
-                      >
-                        <Box>
-                          <Typography variant="body2" fontWeight={movSel?._id === m._id ? 700 : 500}>
-                            {m.codigo_operacion ? `#${m.codigo_operacion} · ` : ''}{formatCurrency(m.monto || 0, m.moneda || monedaDisplay)}
-                          </Typography>
-                          <Typography variant="caption" color="text.secondary">
-                            {m.fecha ? new Date(m.fecha).toLocaleDateString('es-AR') : 's/f'}{m.detalle ? ` · ${m.detalle}` : ''}
-                          </Typography>
-                        </Box>
-                        {movSel?._id === m._id && <CheckCircleIcon color="primary" fontSize="small" />}
-                      </Stack>
-                    ))}
-                  </Box>
-                )}
-
-                <Typography variant="body2" color="text.secondary" mt={2}>
-                  {modoCobro === 'nuevo'
-                    ? 'Se registrará un movimiento de caja automáticamente.'
-                    : modoCobro === 'vincular'
-                      ? 'Se vinculará el pago ya cargado, sin duplicar el ingreso.'
-                      : 'Se marcará como cobrada sin generar movimiento de caja.'}
-                </Typography>
-              </>
-            );
-          })()}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setConfirmCobrar(null)}>Cancelar</Button>
-          <Button
-            color="success"
-            variant="contained"
-            onClick={handleCobrarConfirm}
-            disabled={
-              (tipoCobro === 'parcial' && (!montoParcial || Number(montoParcial) <= 0)) ||
-              (modoCobro === 'vincular' && !movSel)
-            }
-          >
-            {modoCobro === 'solo_estado' ? 'Marcar cobrada' : tipoCobro === 'parcial' ? 'Cobrar parcial' : 'Confirmar cobro'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      {/* Diálogo de cobro compartido con la pantalla de cobranzas de control de obra */}
+      <CobroCuotaDialog
+        open={!!confirmCobrar}
+        cuota={confirmCobrar}
+        plan={plan}
+        montoCalculado={getMontoCuota(confirmCobrar)}
+        empresaId={empresaId}
+        onClose={() => setConfirmCobrar(null)}
+        onConfirm={handleCobrarConfirm}
+      />
 
       <Dialog open={showAdelantarCuota} onClose={() => setShowAdelantarCuota(false)} maxWidth="sm" fullWidth>
         <DialogTitle>Adelantar cuota</DialogTitle>

--- a/src/pages/control-obra/cobranzas.js
+++ b/src/pages/control-obra/cobranzas.js
@@ -2,13 +2,16 @@ import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
-  Box, Button, Card, CardContent, Chip, Container, LinearProgress, Stack,
+  Alert, Box, Button, Card, CardContent, Chip, Container, LinearProgress, Snackbar, Stack,
   Table, TableBody, TableCell, TableHead, TableRow, TableSortLabel, TextField, MenuItem, Typography,
 } from '@mui/material';
 import { Layout as DashboardLayout } from 'src/layouts/dashboard/layout';
 import { useAuthContext } from 'src/contexts/auth-context';
 import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
 import ControlObraService from 'src/services/controlObra/controlObraService';
+import planCobroService from 'src/services/planCobroService';
+import CobroCuotaDialog from 'src/components/planCobro/CobroCuotaDialog';
+import { mensajeCobroRegistrado } from 'src/utils/planCobro/cobroCuota';
 import CarteraNav from 'src/components/controlObra/CarteraNav';
 import SinPermisoControlObra, { puedeVerControlObra } from 'src/components/controlObra/AccesoControlObra';
 import { KpiCard, fmt } from 'src/components/controlObra/ui';
@@ -35,6 +38,9 @@ function CobranzasPage() {
   const [hasta, setHasta] = useState('');
   const [orderBy, setOrderBy] = useState('fecha_vencimiento');
   const [order, setOrder] = useState('asc');
+  // Cobro de cuota de plan: { item, plan, cuota } con el plan ya cargado.
+  const [cobroSel, setCobroSel] = useState(null);
+  const [snack, setSnack] = useState({ open: false, message: '', severity: 'success' });
 
   useEffect(() => {
     if (!user) return;
@@ -47,7 +53,40 @@ function CobranzasPage() {
     enabled: !!empresaId,
   });
   const refresh = () => qc.invalidateQueries({ queryKey: ['control-obra'] });
-  const accion = useMutation({ mutationFn: ({ fn }) => fn(), onSuccess: refresh });
+  const accion = useMutation({
+    mutationFn: ({ fn }) => fn(),
+    onSuccess: (_data, vars) => {
+      refresh();
+      if (vars?.mensajeExito) setSnack({ open: true, message: vars.mensajeExito, severity: 'success' });
+    },
+    onError: (err) => setSnack({
+      open: true,
+      message: err?.response?.data?.error || err?.message || 'No se pudo registrar el cobro',
+      severity: 'error',
+    }),
+  });
+
+  // El cobro de cuotas abre el mismo diálogo que el detalle del plan, así que
+  // necesita el plan (moneda e indexación definen el monto calculado del día).
+  const abrirCobroCuota = async (item) => {
+    try {
+      const res = await planCobroService.getPlan(item.plan_id, empresaId);
+      const plan = res?.data?.data;
+      const cuota = (plan?.cuotas || []).find((c) => String(c._id) === String(item.cuota_id));
+      setCobroSel({ item, plan, cuota: cuota || { _id: item.cuota_id, monto: item.monto, monto_cobrado: item.monto_cobrado, estado: item.estado, fecha_vencimiento: item.fecha_vencimiento } });
+    } catch (err) {
+      setSnack({ open: true, message: 'No se pudo cargar el plan de la cuota', severity: 'error' });
+    }
+  };
+
+  const confirmarCobroCuota = async (payload) => {
+    const { item } = cobroSel;
+    setCobroSel(null);
+    accion.mutate({
+      fn: () => ControlObraService.cobrarCuota(item.obra_id, item.cuota_id, empresaId, payload),
+      mensajeExito: mensajeCobroRegistrado(payload),
+    });
+  };
 
   const rows = q.data || [];
   const obras = useMemo(() => obrasDeItems(rows), [rows]);
@@ -120,9 +159,18 @@ function CobranzasPage() {
                       <TableCell align="right">{fmt(i.pendiente)}</TableCell>
                       <TableCell align="right">
                         <Stack direction="row" spacing={1} justifyContent="flex-end">
-                          <Button size="small" variant="contained" onClick={() => accion.mutate({ fn: () => (i.tipo === 'certificado'
-                            ? ControlObraService.cobrarCertificado(i.certificado_id, empresaId)
-                            : ControlObraService.cobrarCuota(i.obra_id, i.cuota_id, empresaId)) })}>Cobrar</Button>
+                          <Button
+                            size="small"
+                            variant="contained"
+                            onClick={() => (i.tipo === 'certificado'
+                              ? accion.mutate({
+                                fn: () => ControlObraService.cobrarCertificado(i.certificado_id, empresaId),
+                                mensajeExito: 'Certificado cobrado.',
+                              })
+                              : abrirCobroCuota(i))}
+                          >
+                            Cobrar
+                          </Button>
                           <Button size="small" onClick={() => router.push(`/control-obra/${i.obra_id}`)}>Ver obra</Button>
                         </Stack>
                       </TableCell>
@@ -136,6 +184,26 @@ function CobranzasPage() {
             </Box>
           </CardContent>
         </Card>
+
+        <CobroCuotaDialog
+          open={!!cobroSel}
+          cuota={cobroSel?.cuota}
+          plan={cobroSel?.plan}
+          empresaId={empresaId}
+          onClose={() => setCobroSel(null)}
+          onConfirm={confirmarCobroCuota}
+        />
+
+        <Snackbar
+          open={snack.open}
+          autoHideDuration={4000}
+          onClose={() => setSnack((s) => ({ ...s, open: false }))}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        >
+          <Alert severity={snack.severity} onClose={() => setSnack((s) => ({ ...s, open: false }))} variant="filled">
+            {snack.message}
+          </Alert>
+        </Snackbar>
       </Container>
     </DashboardLayout>
   );

--- a/src/services/controlObra/controlObraService.js
+++ b/src/services/controlObra/controlObraService.js
@@ -106,7 +106,10 @@ const ControlObraService = {
     return Array.isArray(res.data?.items) ? res.data.items : [];
   },
 
-  cobrarCuota: async (obraId, cuotaId, empresa_id) => unwrap(await api.post(`${BASE}/${obraId}/cuotas/${cuotaId}/cobrar`, { empresa_id })),
+  // `cobro` acepta lo que arma el diálogo de cobro: monto_parcial, fecha_cobrado,
+  // modo, movimiento_id y cobro_total_confirmado (cuota totalmente pagada).
+  cobrarCuota: async (obraId, cuotaId, empresa_id, cobro = {}) =>
+    unwrap(await api.post(`${BASE}/${obraId}/cuotas/${cuotaId}/cobrar`, { empresa_id, ...cobro })),
 
   /* ---------- Costo y margen (Fase 2) ---------- */
   ejecucion: async (obraId, empresa_id) => {

--- a/src/utils/planCobro/__tests__/cobroCuota.test.js
+++ b/src/utils/planCobro/__tests__/cobroCuota.test.js
@@ -1,0 +1,134 @@
+import {
+  montoCalculadoDeCuota,
+  importeDelCobro,
+  importeDifiereDelRestante,
+  mensajeCobroRegistrado,
+  diferenciaAceptadaPreview,
+  diferenciaAceptadaDeCuota,
+} from '../cobroCuota';
+
+describe('montoCalculadoDeCuota', () => {
+  const cuota = { monto: 500000, monto_cac: 1000, monto_usd: 500 };
+
+  it('plan CAC: unidades CAC por el índice de hoy', () => {
+    expect(montoCalculadoDeCuota({ cuota, plan: { indexacion: 'CAC' }, cacActual: 600 })).toBe(600000);
+  });
+
+  it('plan USD: unidades USD por la cotización de hoy', () => {
+    expect(montoCalculadoDeCuota({ cuota, plan: { indexacion: 'USD' }, usdActual: 1200 })).toBe(600000);
+  });
+
+  it('sin índice disponible cae al monto pactado', () => {
+    expect(montoCalculadoDeCuota({ cuota, plan: { indexacion: 'CAC' }, cacActual: null })).toBe(500000);
+  });
+
+  it('plan no indexado: monto nominal', () => {
+    expect(montoCalculadoDeCuota({ cuota, plan: { indexacion: null }, cacActual: 600 })).toBe(500000);
+  });
+});
+
+describe('importeDelCobro', () => {
+  const restante = 600000;
+
+  it('cobro total: el importe es el restante de la cuota', () => {
+    expect(importeDelCobro({ modo: 'nuevo', tipoCobro: 'total', montoParcial: '', restante })).toBe(600000);
+  });
+
+  it('cobro parcial: el importe es el monto tipeado', () => {
+    expect(importeDelCobro({ modo: 'nuevo', tipoCobro: 'parcial', montoParcial: '500000', restante })).toBe(500000);
+  });
+
+  it('parcial sin monto tipeado: 0', () => {
+    expect(importeDelCobro({ modo: 'nuevo', tipoCobro: 'parcial', montoParcial: '', restante })).toBe(0);
+  });
+
+  it('vincular: el importe lo define el movimiento elegido, no el tipo de cobro', () => {
+    expect(importeDelCobro({ modo: 'vincular', tipoCobro: 'total', movimiento: { monto: 420000 }, restante })).toBe(420000);
+    expect(importeDelCobro({ modo: 'vincular', tipoCobro: 'total', movimiento: null, restante })).toBe(0);
+  });
+
+  it('solo marcar: se comporta como un cobro normal', () => {
+    expect(importeDelCobro({ modo: 'solo_estado', tipoCobro: 'total', restante })).toBe(600000);
+    expect(importeDelCobro({ modo: 'solo_estado', tipoCobro: 'parcial', montoParcial: '300000', restante })).toBe(300000);
+  });
+});
+
+describe('importeDifiereDelRestante', () => {
+  it('coincidir con el restante no es diferencia', () => {
+    expect(importeDifiereDelRestante(600000, 600000)).toBe(false);
+  });
+
+  it('cobrar de menos o de más sí lo es', () => {
+    expect(importeDifiereDelRestante(500000, 600000)).toBe(true);
+    expect(importeDifiereDelRestante(700000, 600000)).toBe(true);
+  });
+
+  it('sin importe todavía no hay diferencia que decidir', () => {
+    expect(importeDifiereDelRestante(0, 600000)).toBe(false);
+  });
+
+  it('ignora el ruido de redondeo del índice', () => {
+    expect(importeDifiereDelRestante(600000.005, 600000)).toBe(false);
+  });
+});
+
+describe('mensajeCobroRegistrado', () => {
+  it('el cobro total confirmado manda sobre el modo', () => {
+    expect(mensajeCobroRegistrado({ modo: 'vincular', cobro_total_confirmado: true }))
+      .toBe('Cuota saldada por el importe cobrado.');
+  });
+
+  it('distingue vincular, solo marcar, parcial y cobro completo', () => {
+    expect(mensajeCobroRegistrado({ modo: 'vincular' })).toMatch(/vinculando/);
+    expect(mensajeCobroRegistrado({ modo: 'solo_estado' })).toMatch(/sin movimiento de caja/);
+    expect(mensajeCobroRegistrado({ modo: 'nuevo', monto_parcial: 100 })).toBe('Pago parcial registrado.');
+    expect(mensajeCobroRegistrado({ modo: 'nuevo' })).toMatch(/Movimiento de caja registrado/);
+  });
+});
+
+describe('diferenciaAceptadaPreview', () => {
+  it('positiva cuando se cobra menos que el monto calculado', () => {
+    expect(diferenciaAceptadaPreview({ montoCalculado: 600000, montoCobradoPrevio: 0, importe: 500000 })).toBe(100000);
+  });
+
+  it('negativa cuando se cobra de más', () => {
+    expect(diferenciaAceptadaPreview({ montoCalculado: 600000, montoCobradoPrevio: 0, importe: 700000 })).toBe(-100000);
+  });
+
+  it('suma los pagos parciales previos', () => {
+    expect(diferenciaAceptadaPreview({ montoCalculado: 600000, montoCobradoPrevio: 200000, importe: 250000 })).toBe(150000);
+  });
+
+  it('sin monto calculado no hay diferencia que mostrar', () => {
+    expect(diferenciaAceptadaPreview({ montoCalculado: 0, montoCobradoPrevio: 0, importe: 500000 })).toBeNull();
+  });
+});
+
+describe('diferenciaAceptadaDeCuota', () => {
+  it('deriva la diferencia del snapshot y lo cobrado', () => {
+    expect(diferenciaAceptadaDeCuota({
+      cobro_total_confirmado: true, monto_calculado_snapshot: 600000, monto_cobrado: 500000,
+    })).toBe(100000);
+  });
+
+  it('es negativa si se cobró de más', () => {
+    expect(diferenciaAceptadaDeCuota({
+      cobro_total_confirmado: true, monto_calculado_snapshot: 600000, monto_cobrado: 700000,
+    })).toBe(-100000);
+  });
+
+  it('null si la cuota no se saldó con cobro total confirmado', () => {
+    expect(diferenciaAceptadaDeCuota({ monto_calculado_snapshot: 600000, monto_cobrado: 500000 })).toBeNull();
+    expect(diferenciaAceptadaDeCuota(null)).toBeNull();
+  });
+
+  it('null si no hay snapshot persistido (cobros previos a la funcionalidad)', () => {
+    expect(diferenciaAceptadaDeCuota({ cobro_total_confirmado: true, monto_cobrado: 500000 })).toBeNull();
+  });
+
+  it('ignora diferencias por redondeo', () => {
+    expect(diferenciaAceptadaDeCuota({
+      cobro_total_confirmado: true, monto_calculado_snapshot: 600000, monto_cobrado: 599999.995,
+    })).toBeNull();
+  });
+});

--- a/src/utils/planCobro/cobroCuota.js
+++ b/src/utils/planCobro/cobroCuota.js
@@ -1,0 +1,74 @@
+/**
+ * Lógica pura del cobro de una cuota de Plan de Cobro (TAR-632).
+ *
+ * "Monto calculado" es el valor de la cuota ajustado por el índice al día del cobro;
+ * la "diferencia aceptada" es lo que separa a ese monto de lo efectivamente cobrado
+ * cuando el usuario confirma que la cuota queda totalmente pagada.
+ */
+
+// Diferencias por debajo de un peso son ruido de redondeo del índice.
+const EPSILON = 0.01;
+
+/**
+ * Monto calculado de la cuota: el valor ajustado por el índice del día. Sin índice
+ * disponible (o plan no indexado) cae al monto nominal pactado, que es lo que el
+ * backend también cobra en ese caso.
+ */
+export function montoCalculadoDeCuota({ cuota, plan, cacActual, usdActual }) {
+  if (!cuota) return 0;
+  if (plan?.indexacion === 'CAC' && cuota.monto_cac && cacActual) {
+    return Math.round(Number(cuota.monto_cac) * Number(cacActual) * 100) / 100;
+  }
+  if (plan?.indexacion === 'USD' && cuota.monto_usd && usdActual) {
+    return Math.round(Number(cuota.monto_usd) * Number(usdActual) * 100) / 100;
+  }
+  return Number(cuota.monto) || 0;
+}
+
+/** Importe que se va a registrar según cómo esté armado el diálogo de cobro. */
+export function importeDelCobro({ modo, tipoCobro, montoParcial, movimiento, restante }) {
+  if (modo === 'vincular') return Number(movimiento?.monto) || 0;
+  if (tipoCobro === 'parcial') return Number(montoParcial) || 0;
+  return Number(restante) || 0;
+}
+
+/**
+ * Diferencia aceptada que resultaría de confirmar este cobro. Positiva = se cobra
+ * menos que el monto calculado; negativa = se cobra de más. Null si no hay monto
+ * calculado contra el cual comparar.
+ */
+export function diferenciaAceptadaPreview({ montoCalculado, montoCobradoPrevio = 0, importe }) {
+  const calculado = Number(montoCalculado) || 0;
+  if (calculado <= 0) return null;
+  const cobradoTotal = (Number(montoCobradoPrevio) || 0) + (Number(importe) || 0);
+  return Math.round((calculado - cobradoTotal) * 100) / 100;
+}
+
+/**
+ * Diferencia aceptada ya persistida de una cuota saldada con cobro total confirmado.
+ * Null si la cuota no se saldó así, si no tiene snapshot (cobros anteriores a la
+ * funcionalidad) o si la diferencia es puro redondeo.
+ */
+export function diferenciaAceptadaDeCuota(cuota) {
+  if (!cuota?.cobro_total_confirmado) return null;
+  const calculado = Number(cuota.monto_calculado_snapshot) || 0;
+  if (calculado <= 0) return null;
+  const diferencia = calculado - (Number(cuota.monto_cobrado) || 0);
+  return Math.abs(diferencia) < EPSILON ? null : Math.round(diferencia * 100) / 100;
+}
+
+/** Mensaje de confirmación de un cobro ya registrado, según cómo se registró. */
+export function mensajeCobroRegistrado(payload = {}) {
+  if (payload.cobro_total_confirmado) return 'Cuota saldada por el importe cobrado.';
+  if (payload.modo === 'vincular') return 'Cuota cobrada vinculando el movimiento existente.';
+  if (payload.modo === 'solo_estado') return 'Cuota marcada como cobrada (sin movimiento de caja).';
+  if (payload.monto_parcial != null) return 'Pago parcial registrado.';
+  return 'Cuota cobrada. Movimiento de caja registrado.';
+}
+
+/** ¿El importe a registrar difiere del restante de la cuota? */
+export function importeDifiereDelRestante(importe, restante) {
+  const imp = Number(importe) || 0;
+  if (imp <= 0) return false;
+  return Math.abs(imp - (Number(restante) || 0)) > EPSILON;
+}


### PR DESCRIPTION
## Qué resuelve

Al cobrar una cuota de un Plan de Cobro indexado, el importe recibido puede diferir del monto calculado del día (acuerdo comercial, descuento, o pago al valor pactado original). El diálogo de cobro no dejaba registrar ese importe y dar la cuota por saldada: quedaba como pago parcial con saldo pendiente ficticio.

Además, en cobranzas de control de obra el botón "Cobrar" era un click directo al valor calculado, sin poder indicar el monto real, la fecha ni el modo, y sin confirmación visible de que el cobro se registró.

## Cómo

**Checkbox "La cuota queda totalmente pagada"**, visible en "Pago parcial" y en "Vincular pago existente" cuando el importe no coincide con el restante. Con el checkbox activo se muestra la diferencia que se está aceptando antes de confirmar, se libera la validación de tope contra el restante y se manda `cobro_total_confirmado` al backend. El detalle del plan muestra la diferencia aceptada en cada cuota saldada así, con el monto calculado del día del cobro en el tooltip.

**Diálogo compartido.** El diálogo de cobro salió de `pages/cobros/[id].js` a `components/planCobro/CobroCuotaDialog.js` y ahora lo usan tanto el detalle del plan como la pantalla de cobranzas de control de obra, que dejó de cobrar de un click y confirma con snackbar (el cobro de certificados no cambia).

**Lógica pura en un util.** `utils/planCobro/cobroCuota.js` concentra monto calculado, importe del cobro, diferencia aceptada (preview y persistida) y los mensajes de confirmación, con 24 tests. De paso deduplica el cálculo del monto indexado, que estaba inline en la página.

## Un detalle que vale la pena mirar

El diálogo resuelve el índice de la **fecha efectiva de cobro**, no la de hoy. El backend snapshotea el índice de `fecha_cobrado`, así que pedir el de hoy hacía que en un cobro retroactivo la diferencia mostrada no fuera la que se persiste ni la que después se ve en el detalle. Cambiar la fecha en el diálogo vuelve a pedir el índice.

## Tests

24 tests puros del util (`npx jest src/utils/planCobro`), en el estilo de los tests puros que ya hay en el repo. Sin tests de componentes: no hay infraestructura de DOM. `next lint` limpio en los archivos tocados y `next build` completo en verde.

## Notas

- Contraparte del backend: fedemaidan/sorby_bot_wa#294 (ahí vive la lógica de negocio y el contrato).
- Ticket de origen: TAR-632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)