### PR TITLE
Plan de Cobros: Cash Flow desglosable y accionable (frontend)

### DIFF
--- a/src/components/planCobro/DesgloseCuotas.js
+++ b/src/components/planCobro/DesgloseCuotas.js
@@ -1,0 +1,83 @@
+import { Box, Button, Chip, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import { totalPorTrack, claveDeFila } from 'src/utils/planCobro/cashflowDetalle';
+
+// 'YYYY-MM-DD' → '3 ago 26'. Sin `new Date()`: el string ya viene normalizado del
+// backend y parsearlo como UTC retrocedería un día en AR.
+const MESES_CORTOS = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+const fechaCorta = (s) => { if (!s) return '—'; const [y, m, d] = s.split('-'); return `${Number(d)} ${MESES_CORTOS[Number(m) - 1]} ${y.slice(2)}`; };
+const fmtMoney = (n, track = 'ARS') => (n || 0).toLocaleString('es-AR', { style: 'currency', currency: track === 'USD' ? 'USD' : 'ARS', maximumFractionDigits: 0 });
+
+const estadoChip = (e) => (e === 'vencida' ? <Chip size="small" label="Vencida" color="error" />
+  : e === 'cobrada' ? <Chip size="small" label="Cobrada" color="success" />
+    : e === 'cobrada_parcial' ? <Chip size="small" label="Parcial" color="warning" />
+      : <Chip size="small" label="Pendiente" variant="outlined" />);
+
+/**
+ * Las cuotas que componen un número del Cash Flow. El total del pie es la suma de
+ * las filas que se están mostrando, así que coincide con la celda de la que se abrió
+ * (el backend las etiquetó con el mismo bucket que usó para el agregado).
+ *
+ * @param {Array}    filas    filas del `detalle` ya filtradas por quien lo usa
+ * @param {string}   tipo     'esperado' | 'cobrado' — decide si se muestra la fecha de cobro
+ * @param {string}   track    'ARS' | 'USD' — el track del que se muestra el total
+ * @param {string}   titulo   qué se está desglosando
+ * @param {function} onCobrar recibe la fila; si no se pasa, no hay columna de acciones
+ */
+export default function DesgloseCuotas({ filas, tipo, track, titulo, onCobrar }) {
+  const total = totalPorTrack(filas);
+  const conFechaCobro = tipo === 'cobrado';
+  const conAcciones = typeof onCobrar === 'function';
+
+  return (
+    <Box sx={{ px: 2, py: 1.5 }}>
+      <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>
+        {titulo} · {filas.length} cuota{filas.length === 1 ? '' : 's'}
+      </Typography>
+      {filas.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">Sin cuotas en este período.</Typography>
+      ) : (
+        <Box sx={{ overflowX: 'auto' }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Obra</TableCell>
+                <TableCell>Cliente</TableCell>
+                <TableCell>Cuota</TableCell>
+                <TableCell>Vence</TableCell>
+                {conFechaCobro && <TableCell>Cobrada</TableCell>}
+                <TableCell align="right">Monto</TableCell>
+                <TableCell>Estado</TableCell>
+                {conAcciones && <TableCell align="right">Acciones</TableCell>}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filas.map((r) => (
+                <TableRow key={claveDeFila(r)}>
+                  <TableCell>{r.proyecto_nombre || '—'}</TableCell>
+                  <TableCell>{r.cliente_nombre || '—'}</TableCell>
+                  <TableCell>{r.plan_nombre ? `${r.plan_nombre} · ` : ''}Cuota {r.numero}</TableCell>
+                  <TableCell>{fechaCorta(r.fecha_vencimiento)}</TableCell>
+                  {conFechaCobro && <TableCell>{fechaCorta(r.fecha_cobrado)}</TableCell>}
+                  <TableCell align="right" sx={{ fontWeight: 700 }}>{fmtMoney(r.monto, r.track)}</TableCell>
+                  <TableCell>{estadoChip(r.estado)}</TableCell>
+                  {conAcciones && (
+                    <TableCell align="right">
+                      {r.estado !== 'cobrada' && (
+                        <Button size="small" variant="contained" onClick={() => onCobrar(r)}>Cobrar</Button>
+                      )}
+                    </TableCell>
+                  )}
+                </TableRow>
+              ))}
+              <TableRow>
+                <TableCell colSpan={conFechaCobro ? 5 : 4} sx={{ fontWeight: 700 }}>Total del desglose</TableCell>
+                <TableCell align="right" sx={{ fontWeight: 700 }}>{fmtMoney(total[track], track)}</TableCell>
+                <TableCell colSpan={conAcciones ? 2 : 1} />
+              </TableRow>
+            </TableBody>
+          </Table>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/pages/cobros.js
+++ b/src/pages/cobros.js
@@ -137,7 +137,7 @@ const CobrosList = () => {
   const [cfVista, setCfVista] = useState('tabla'); // 'grafico' | 'tabla'
   const [cfHistorico, setCfHistorico] = useState(false);
   const [cfTrack, setCfTrack] = useState('ARS'); // 'ARS' | 'USD' — track visible (sólo se ofrece si hay USD)
-  const [cfCelda, setCfCelda] = useState(null); // celda expandida: `${bucket_key}|${tipo}` (una a la vez)
+  const [cfCelda, setCfCelda] = useState(null); // período expandido: su `bucket_key` (uno a la vez)
   const [detalle, setDetalle] = useState([]); // lista accionable por cuota (Cash Flow + Gestión)
   const [cobroSel, setCobroSel] = useState(null); // { fila, plan, cuota } con el plan ya cargado
   const [recargas, setRecargas] = useState(0); // bump tras cobrar: recarga agregado y desglose
@@ -248,9 +248,10 @@ const CobrosList = () => {
     }
     if (busqueda.trim()) {
       const q = busqueda.toLowerCase();
-      result = result.filter(
-        (p) => (p.nombre || '').toLowerCase().includes(q) || (p.codigo || '').toLowerCase().includes(q)
-      );
+      // `String(...)`: el código de un plan puede venir numérico y sin esto la
+      // búsqueda revienta apenas se escribe la primera letra.
+      const contiene = (v) => String(v ?? '').toLowerCase().includes(q);
+      result = result.filter((p) => contiene(p.nombre) || contiene(p.codigo));
     }
     return sortPlanes(result, sortBy);
   }, [planes, filtroProyecto, busqueda, sortBy]);
@@ -332,41 +333,42 @@ const CobrosList = () => {
             const realizadoAnterior = pickTrack(cashflow.realizado_anterior, track);
             const periodoLabel = cfGranularidad === 'semana' ? 'semana' : cfGranularidad === 'adaptativo' ? 'período' : 'mes';
 
-            // ── Desglose por celda ──
-            // El backend etiquetó cada cuota con el mismo bucket que usó para el
+            // ── Desglose del período ──
+            // Un solo desglose por fila, con lo esperado y lo cobrado uno debajo del
+            // otro. El backend etiquetó cada cuota con el mismo bucket que usó para el
             // agregado, así que acá sólo se filtra: la suma cierra por construcción.
-            const celdaKey = (bucket, tipo) => `${bucket}|${tipo}`;
-            const toggleCelda = (bucket, tipo) => setCfCelda((k) => (k === celdaKey(bucket, tipo) ? null : celdaKey(bucket, tipo)));
+            const toggleFila = (bucket) => setCfCelda((k) => (k === bucket ? null : bucket));
 
-            // Celda clickeable del agregado: abre/cierra las cuotas que la componen.
-            const celdaExpandible = (bucket, tipo, valor, sx) => (
-              <TableCell
-                align="right"
-                onClick={valor ? () => toggleCelda(bucket, tipo) : undefined}
-                sx={{ ...sx, cursor: valor ? 'pointer' : 'default', '&:hover': valor ? { bgcolor: 'action.hover' } : undefined }}
-              >
-                <Stack direction="row" spacing={0.5} alignItems="center" justifyContent="flex-end">
-                  <span>{money(valor)}</span>
-                  {!!valor && (cfCelda === celdaKey(bucket, tipo)
-                    ? <ExpandMoreIcon fontSize="small" color="action" />
-                    : <ChevronRightIcon fontSize="small" color="disabled" />)}
-                </Stack>
-              </TableCell>
-            );
-
-            const filaDesglose = (bucket, tipo) => (
-              <TableRow>
-                <TableCell colSpan={5} sx={{ p: 0, bgcolor: 'action.hover', borderBottom: '2px solid', borderColor: 'divider' }}>
-                  <DesgloseCuotas
-                    filas={filasDeCelda(detalle, { bucketKey: bucket, track, tipo })}
-                    tipo={tipo}
-                    track={track}
-                    titulo={`${tipo === 'esperado' ? 'Cuotas a cobrar' : 'Cobros registrados'} en ${etiquetaPeriodo(bucket)}`}
-                    onCobrar={abrirCobro}
-                  />
-                </TableCell>
-              </TableRow>
-            );
+            const filaDesglose = (bucket) => {
+              const esperadas = filasDeCelda(detalle, { bucketKey: bucket, track, tipo: 'esperado' });
+              const cobradas = filasDeCelda(detalle, { bucketKey: bucket, track, tipo: 'cobrado' });
+              return (
+                <TableRow>
+                  <TableCell colSpan={5} sx={{ p: 0, bgcolor: 'action.hover', borderBottom: '2px solid', borderColor: 'divider' }}>
+                    {esperadas.length > 0 && (
+                      <DesgloseCuotas
+                        filas={esperadas}
+                        tipo="esperado"
+                        track={track}
+                        titulo={`Cuotas a cobrar en ${etiquetaPeriodo(bucket)}`}
+                        onCobrar={abrirCobro}
+                      />
+                    )}
+                    {/* Lo ya cobrado va sin `onCobrar`: no queda nada que cobrar ahí. */}
+                    {cobradas.length > 0 && (
+                      <Box sx={esperadas.length > 0 ? { borderTop: '1px dashed', borderColor: 'divider' } : undefined}>
+                        <DesgloseCuotas
+                          filas={cobradas}
+                          tipo="cobrado"
+                          track={track}
+                          titulo={`Cobros registrados en ${etiquetaPeriodo(bucket)}`}
+                        />
+                      </Box>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            };
             return (
             <Box sx={{ mb: 3 }}>
               <Stack direction="row" spacing={2} mb={2} flexWrap="wrap" alignItems="center" useFlexGap>
@@ -453,7 +455,7 @@ const CobrosList = () => {
                   ) : (
                     <Box sx={{ overflowX: 'auto' }}>
                       <Typography variant="caption" color="text.secondary" display="block" mb={1}>
-                        Tocá un importe de Esperado o Cobrado para ver qué cuotas lo componen.
+                        Tocá un período para ver las cuotas que lo componen.
                       </Typography>
                       <Table size="small">
                         <TableHead>
@@ -469,17 +471,29 @@ const CobrosList = () => {
                           {cashflow.meses.map((m, i) => {
                             const esp = esperado[i] || 0;
                             const cob = cobrado[i] || 0;
+                            const abierta = cfCelda === m;
+                            const tieneDesglose = !!esp || !!cob;
                             return (
                               <Fragment key={m}>
-                                <TableRow>
-                                  <TableCell>{etiquetaPeriodo(m)}</TableCell>
-                                  {celdaExpandible(m, 'esperado', esp)}
-                                  {celdaExpandible(m, 'cobrado', cob, { color: 'success.main' })}
+                                <TableRow
+                                  hover={tieneDesglose}
+                                  onClick={tieneDesglose ? () => toggleFila(m) : undefined}
+                                  sx={{ cursor: tieneDesglose ? 'pointer' : 'default' }}
+                                >
+                                  <TableCell>
+                                    <Stack direction="row" spacing={0.5} alignItems="center">
+                                      {tieneDesglose && (abierta
+                                        ? <ExpandMoreIcon fontSize="small" color="action" />
+                                        : <ChevronRightIcon fontSize="small" color="disabled" />)}
+                                      <span>{etiquetaPeriodo(m)}</span>
+                                    </Stack>
+                                  </TableCell>
+                                  <TableCell align="right">{money(esp)}</TableCell>
+                                  <TableCell align="right" sx={{ color: 'success.main' }}>{money(cob)}</TableCell>
                                   <TableCell align="right" sx={{ fontWeight: 700 }}>{money(esp + cob)}</TableCell>
                                   <TableCell align="right" sx={{ color: 'primary.main' }}>{money(acumulado[i])}</TableCell>
                                 </TableRow>
-                                {cfCelda === celdaKey(m, 'esperado') && filaDesglose(m, 'esperado')}
-                                {cfCelda === celdaKey(m, 'cobrado') && filaDesglose(m, 'cobrado')}
+                                {abierta && filaDesglose(m)}
                               </Fragment>
                             );
                           })}

--- a/src/pages/cobros.js
+++ b/src/pages/cobros.js
@@ -47,7 +47,14 @@ import { getEmpresaDetailsFromUser } from 'src/services/empresaService';
 import { getProyectosFromUser } from 'src/services/proyectosService';
 import { usePlanesCobroList } from 'src/hooks/usePlanCobro';
 import PlanCobroCard from 'src/components/planCobro/PlanCobroCard';
+import CobroCuotaDialog from 'src/components/planCobro/CobroCuotaDialog';
 import planCobroService from 'src/services/planCobroService';
+import DesgloseCuotas from 'src/components/planCobro/DesgloseCuotas';
+import { mensajeCobroRegistrado } from 'src/utils/planCobro/cobroCuota';
+import { filasDeCelda, filasDeGestion, filasRealizadoAnterior, totalPorTrack, claveDeFila } from 'src/utils/planCobro/cashflowDetalle';
+
+// Clave de "celda expandida" para el bloque de realizado anterior, que no es un período.
+const REALIZADO_ANTERIOR = 'realizado-anterior';
 
 const SORT_OPTIONS = [
   { value: 'reciente', label: 'Más recientes' },
@@ -90,6 +97,15 @@ const rangoSemanaISO = (year, week) => {
   sunday.setUTCDate(monday.getUTCDate() + 6);
   return [monday, sunday];
 };
+// 'YYYY-MM-DD' → '3 ago 26'. Sin `new Date()`: el string ya viene normalizado del
+// backend y parsearlo como UTC retrocedería un día en AR.
+const fechaCorta = (s) => { if (!s) return '—'; const [y, m, d] = s.split('-'); return `${Number(d)} ${MESES_CORTOS[Number(m) - 1]} ${y.slice(2)}`; };
+
+const estadoChip = (e) => (e === 'vencida' ? <Chip size="small" label="Vencida" color="error" />
+  : e === 'cobrada' ? <Chip size="small" label="Cobrada" color="success" />
+    : e === 'cobrada_parcial' ? <Chip size="small" label="Parcial" color="warning" />
+      : <Chip size="small" label="Pendiente" variant="outlined" />);
+
 const etiquetaPeriodo = (key) => {
   const mes = String(key || '').match(/^(\d{4})-(\d{2})$/);
   if (mes) return `${MESES_CORTOS[Number(mes[2]) - 1]} ${mes[1].slice(2)}`;
@@ -116,10 +132,15 @@ const CobrosList = () => {
   const [seccion, setSeccion] = useState('planes'); // 'planes' | 'cashflow' | 'gestion'
   const [cashflow, setCashflow] = useState({ meses: [], esperado: [], cobrado: [], acumulado: [], kpis: {}, vencido: { ARS: 0, USD: 0, cuotas: 0 }, realizado_anterior: { ARS: 0, USD: 0 } });
   const [cfGranularidad, setCfGranularidad] = useState('adaptativo'); // 'mes' | 'semana' | 'adaptativo'
-  const [cfVista, setCfVista] = useState('grafico'); // 'grafico' | 'tabla'
+  // Abre en tabla: el desglose por período vive en la tabla, así que es la vista
+  // desde la que se puede accionar sin tener que cambiar de modo primero.
+  const [cfVista, setCfVista] = useState('tabla'); // 'grafico' | 'tabla'
   const [cfHistorico, setCfHistorico] = useState(false);
   const [cfTrack, setCfTrack] = useState('ARS'); // 'ARS' | 'USD' — track visible (sólo se ofrece si hay USD)
-  const [gestion, setGestion] = useState([]); // A2: lista accionable por cuota (detalle)
+  const [cfCelda, setCfCelda] = useState(null); // celda expandida: `${bucket_key}|${tipo}` (una a la vez)
+  const [detalle, setDetalle] = useState([]); // lista accionable por cuota (Cash Flow + Gestión)
+  const [cobroSel, setCobroSel] = useState(null); // { fila, plan, cuota } con el plan ya cargado
+  const [recargas, setRecargas] = useState(0); // bump tras cobrar: recarga agregado y desglose
   const [gestionMes, setGestionMes] = useState(() => new Date().toISOString().slice(0, 7)); // filtro por mes (default: mes actual)
   const [gestionPorObra, setGestionPorObra] = useState(true); // toggle "por obra ↔ todo junto" (default: por obra)
   const [gestionColapsadas, setGestionColapsadas] = useState(() => new Set()); // obras colapsadas (accordion)
@@ -142,19 +163,29 @@ const CobrosList = () => {
     planCobroService.getCashflow(empresaId, filtroProyecto || null, cfGranularidad, { incluirHistorico: cfHistorico })
       .then((res) => setCashflow(res?.data?.data || {}))
       .catch(() => setCashflow({ meses: [], esperado: [], cobrado: [] }));
-  }, [empresaId, filtroProyecto, cfGranularidad, cfHistorico]);
+  }, [empresaId, filtroProyecto, cfGranularidad, cfHistorico, recargas]);
 
-  // Vista de gestión (A2): lista accionable por cuota. Se pide sólo al entrar a la pestaña.
-  // El detalle son las cuotas pendientes/vencidas (no depende de la ventana), así que no pasamos histórico.
+  // Lista accionable por cuota. La consumen el desglose del Cash Flow (que filtra
+  // por `bucket_key`) y la vista de Gestión. En Cash Flow se pide con la MISMA
+  // granularidad y ventana que el gráfico: si no, los buckets no se corresponden.
   useEffect(() => {
-    if (!empresaId || seccion !== 'gestion') return;
-    planCobroService.getCashflow(empresaId, filtroProyecto || null, 'mes', { detalle: true })
-      .then((res) => setGestion(res?.data?.data?.detalle || []))
-      .catch(() => setGestion([]));
-  }, [empresaId, filtroProyecto, seccion]);
+    if (!empresaId || (seccion !== 'gestion' && seccion !== 'cashflow')) return;
+    const enCashflow = seccion === 'cashflow';
+    planCobroService.getCashflow(
+      empresaId,
+      filtroProyecto || null,
+      enCashflow ? cfGranularidad : 'mes',
+      { detalle: true, ...(enCashflow ? { incluirHistorico: cfHistorico } : {}) },
+    )
+      .then((res) => setDetalle(res?.data?.data?.detalle || []))
+      .catch(() => setDetalle([]));
+  }, [empresaId, filtroProyecto, seccion, cfGranularidad, cfHistorico, recargas]);
+
+  // Una celda expandida deja de tener sentido si cambian los buckets debajo.
+  useEffect(() => { setCfCelda(null); }, [cfGranularidad, cfHistorico, filtroProyecto, cfTrack]);
 
   // Reset de paginación al cambiar filtro/modo/datos de la vista de gestión.
-  useEffect(() => { setGestionPage(0); }, [gestionMes, gestionPorObra, gestion]);
+  useEffect(() => { setGestionPage(0); }, [gestionMes, gestionPorObra, detalle]);
 
   const filterParams = filtroEstado ? { estado: filtroEstado } : {};
   const { planes, loading, error, refresh } = usePlanesCobroList(empresaId, filterParams);
@@ -177,6 +208,38 @@ const CobrosList = () => {
   useEffect(() => {
     if (error) setAlert({ open: true, message: 'Error al cargar planes de cobro', severity: 'error' });
   }, [error]);
+
+  // ── Cobrar una cuota sin salir de esta pantalla ──
+  // Las filas del detalle no traen el plan completo, y el diálogo lo necesita para
+  // resolver el monto al índice del día. Se carga igual que en cobranzas de obra.
+  const abrirCobro = async (fila) => {
+    try {
+      const res = await planCobroService.getPlan(fila.plan_id, empresaId);
+      const plan = res?.data?.data;
+      const cuota = (plan?.cuotas || []).find((c) => String(c._id) === String(fila.cuota_id));
+      if (!cuota) throw new Error('La cuota ya no existe en el plan');
+      setCobroSel({ fila, plan, cuota });
+    } catch (err) {
+      setAlert({ open: true, message: err.message || 'No se pudo cargar el plan de la cuota', severity: 'error' });
+    }
+  };
+
+  // Sin actualización optimista: en planes indexados el monto que se registra lo
+  // resuelve el backend con el índice del día del cobro, y un optimista mostraría
+  // un número distinto al persistido. Se recargan agregado y desglose.
+  const confirmarCobro = async (payload) => {
+    const { fila } = cobroSel;
+    setCobroSel(null);
+    try {
+      const res = await planCobroService.marcarCuotaCobrada(fila.plan_id, fila.cuota_id, { empresa_id: empresaId, ...payload });
+      if (!res?.data?.ok) throw new Error(res?.data?.error || 'No se pudo registrar el cobro');
+      setAlert({ open: true, message: mensajeCobroRegistrado(payload), severity: 'success' });
+      setRecargas((n) => n + 1);
+      refresh();
+    } catch (err) {
+      setAlert({ open: true, message: err?.response?.data?.error || err.message || 'No se pudo registrar el cobro', severity: 'error' });
+    }
+  };
 
   const planesFiltrados = useMemo(() => {
     let result = planes;
@@ -268,6 +331,42 @@ const CobrosList = () => {
             const acumulado = (cashflow.acumulado || []).map((x) => pickTrack(x, track));
             const realizadoAnterior = pickTrack(cashflow.realizado_anterior, track);
             const periodoLabel = cfGranularidad === 'semana' ? 'semana' : cfGranularidad === 'adaptativo' ? 'período' : 'mes';
+
+            // ── Desglose por celda ──
+            // El backend etiquetó cada cuota con el mismo bucket que usó para el
+            // agregado, así que acá sólo se filtra: la suma cierra por construcción.
+            const celdaKey = (bucket, tipo) => `${bucket}|${tipo}`;
+            const toggleCelda = (bucket, tipo) => setCfCelda((k) => (k === celdaKey(bucket, tipo) ? null : celdaKey(bucket, tipo)));
+
+            // Celda clickeable del agregado: abre/cierra las cuotas que la componen.
+            const celdaExpandible = (bucket, tipo, valor, sx) => (
+              <TableCell
+                align="right"
+                onClick={valor ? () => toggleCelda(bucket, tipo) : undefined}
+                sx={{ ...sx, cursor: valor ? 'pointer' : 'default', '&:hover': valor ? { bgcolor: 'action.hover' } : undefined }}
+              >
+                <Stack direction="row" spacing={0.5} alignItems="center" justifyContent="flex-end">
+                  <span>{money(valor)}</span>
+                  {!!valor && (cfCelda === celdaKey(bucket, tipo)
+                    ? <ExpandMoreIcon fontSize="small" color="action" />
+                    : <ChevronRightIcon fontSize="small" color="disabled" />)}
+                </Stack>
+              </TableCell>
+            );
+
+            const filaDesglose = (bucket, tipo) => (
+              <TableRow>
+                <TableCell colSpan={5} sx={{ p: 0, bgcolor: 'action.hover', borderBottom: '2px solid', borderColor: 'divider' }}>
+                  <DesgloseCuotas
+                    filas={filasDeCelda(detalle, { bucketKey: bucket, track, tipo })}
+                    tipo={tipo}
+                    track={track}
+                    titulo={`${tipo === 'esperado' ? 'Cuotas a cobrar' : 'Cobros registrados'} en ${etiquetaPeriodo(bucket)}`}
+                    onCobrar={abrirCobro}
+                  />
+                </TableCell>
+              </TableRow>
+            );
             return (
             <Box sx={{ mb: 3 }}>
               <Stack direction="row" spacing={2} mb={2} flexWrap="wrap" alignItems="center" useFlexGap>
@@ -308,10 +407,30 @@ const CobrosList = () => {
                       Mostrando {track === 'USD' ? 'planes en dólares (US$)' : 'planes en pesos (indexados valuados a hoy)'}.
                     </Typography>
                   )}
+                  {/* Los cobros previos a la ventana no tienen fila propia: el agregado
+                      los colapsa acá. Se pueden abrir para entender de qué se trata. */}
                   {!cfHistorico && realizadoAnterior > 0 && (
-                    <Typography variant="caption" color="text.secondary" display="block" mb={1}>
-                      Realizado antes de la ventana: {money(realizadoAnterior)} (colapsado)
-                    </Typography>
+                    <Box mb={1}>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        onClick={() => setCfCelda((k) => (k === REALIZADO_ANTERIOR ? null : REALIZADO_ANTERIOR))}
+                        sx={{ display: 'inline-flex', alignItems: 'center', cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                      >
+                        Realizado antes de la ventana: {money(realizadoAnterior)} (colapsado)
+                        {cfCelda === REALIZADO_ANTERIOR ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+                      </Typography>
+                      {cfCelda === REALIZADO_ANTERIOR && (
+                        <Box sx={{ bgcolor: 'action.hover', borderRadius: 1, mt: 0.5 }}>
+                          <DesgloseCuotas
+                            filas={filasRealizadoAnterior(detalle, track)}
+                            tipo="cobrado"
+                            track={track}
+                            titulo="Cobros anteriores a la ventana"
+                          />
+                        </Box>
+                      )}
+                    </Box>
                   )}
                   {cfVista === 'grafico' ? (
                     <Box sx={{ overflowX: 'auto' }}>
@@ -333,6 +452,9 @@ const CobrosList = () => {
                     </Box>
                   ) : (
                     <Box sx={{ overflowX: 'auto' }}>
+                      <Typography variant="caption" color="text.secondary" display="block" mb={1}>
+                        Tocá un importe de Esperado o Cobrado para ver qué cuotas lo componen.
+                      </Typography>
                       <Table size="small">
                         <TableHead>
                           <TableRow>
@@ -348,13 +470,17 @@ const CobrosList = () => {
                             const esp = esperado[i] || 0;
                             const cob = cobrado[i] || 0;
                             return (
-                              <TableRow key={m}>
-                                <TableCell>{etiquetaPeriodo(m)}</TableCell>
-                                <TableCell align="right">{money(esp)}</TableCell>
-                                <TableCell align="right" sx={{ color: 'success.main' }}>{money(cob)}</TableCell>
-                                <TableCell align="right" sx={{ fontWeight: 700 }}>{money(esp + cob)}</TableCell>
-                                <TableCell align="right" sx={{ color: 'primary.main' }}>{money(acumulado[i])}</TableCell>
-                              </TableRow>
+                              <Fragment key={m}>
+                                <TableRow>
+                                  <TableCell>{etiquetaPeriodo(m)}</TableCell>
+                                  {celdaExpandible(m, 'esperado', esp)}
+                                  {celdaExpandible(m, 'cobrado', cob, { color: 'success.main' })}
+                                  <TableCell align="right" sx={{ fontWeight: 700 }}>{money(esp + cob)}</TableCell>
+                                  <TableCell align="right" sx={{ color: 'primary.main' }}>{money(acumulado[i])}</TableCell>
+                                </TableRow>
+                                {cfCelda === celdaKey(m, 'esperado') && filaDesglose(m, 'esperado')}
+                                {cfCelda === celdaKey(m, 'cobrado') && filaDesglose(m, 'cobrado')}
+                              </Fragment>
                             );
                           })}
                           <TableRow>
@@ -376,23 +502,23 @@ const CobrosList = () => {
           {seccion === 'gestion' && (() => {
             // A2: "a quién reclamar". Lista accionable por cuota, vencidos arriba,
             // filtrable por mes y agrupable por obra.
-            const fechaCorta = (s) => { if (!s) return '—'; const [y, m, d] = s.split('-'); return `${Number(d)} ${MESES_CORTOS[Number(m) - 1]} ${y.slice(2)}`; };
-            const estadoChip = (e) => e === 'vencida'
-              ? <Chip size="small" label="Vencida" color="error" />
-              : e === 'cobrada_parcial'
-                ? <Chip size="small" label="Parcial" color="warning" />
-                : <Chip size="small" label="Pendiente" variant="outlined" />;
             // El mes actual siempre figura como opción (aunque no tenga cuotas), porque es el filtro por default.
             const mesActual = new Date().toISOString().slice(0, 7);
-            const mesesDisp = [...new Set([...(gestion || []).map((r) => (r.fecha_vencimiento || '').slice(0, 7)).filter(Boolean), mesActual])].sort();
-            const filtradas = (gestion || []).filter((r) => gestionMes === 'todos' || (r.fecha_vencimiento || '').slice(0, 7) === gestionMes);
+            // Sólo lo que hay que reclamar: las filas de cobrado del detalle son
+            // historial y viven en el desglose del Cash Flow.
+            const gestion = filasDeGestion(detalle);
+            const mesesDisp = [...new Set([...gestion.map((r) => (r.fecha_vencimiento || '').slice(0, 7)).filter(Boolean), mesActual])].sort();
+            const filtradas = gestion.filter((r) => gestionMes === 'todos' || (r.fecha_vencimiento || '').slice(0, 7) === gestionMes);
             // Vencidas primero, luego por vencimiento ascendente.
             const ordenadas = [...filtradas].sort((a, b) => {
               const va = a.estado === 'vencida' ? 0 : 1, vb = b.estado === 'vencida' ? 0 : 1;
               if (va !== vb) return va - vb;
               return (a.fecha_vencimiento || '9999').localeCompare(b.fecha_vencimiento || '9999');
             });
-            const subtotal = (rows, track) => rows.reduce((a, r) => a + (r.track === track ? (r.saldo_a_hoy || 0) : 0), 0);
+            const subtotal = (rows, track) => rows.reduce((a, r) => a + (r.track === track ? (r.monto || 0) : 0), 0);
+            // Total del mes filtrado: sobre TODAS las cuotas del filtro, antes de
+            // paginar, para que el número no dependa de dónde esté el paginador.
+            const totalMes = totalPorTrack(filtradas);
             const grupos = gestionPorObra
               ? [...ordenadas.reduce((map, r) => { const k = r.proyecto_nombre || 'Sin obra'; if (!map.has(k)) map.set(k, []); map.get(k).push(r); return map; }, new Map())]
               : [['', ordenadas]];
@@ -410,13 +536,16 @@ const CobrosList = () => {
             const todasColapsadas = gestionPorObra && todasObras.length > 0 && todasObras.every((o) => gestionColapsadas.has(o));
 
             const filaCuota = (r) => (
-              <TableRow key={r.cuota_id} sx={{ bgcolor: r.estado === 'vencida' ? '#FFF5F5' : 'inherit' }}>
+              <TableRow key={claveDeFila(r)} sx={{ bgcolor: r.estado === 'vencida' ? '#FFF5F5' : 'inherit' }}>
                 <TableCell>{r.cliente_nombre || '—'}</TableCell>
                 {!gestionPorObra && <TableCell>{r.proyecto_nombre || '—'}</TableCell>}
                 <TableCell>{r.plan_nombre ? `${r.plan_nombre} · ` : ''}Cuota {r.numero}</TableCell>
                 <TableCell>{fechaCorta(r.fecha_vencimiento)}</TableCell>
-                <TableCell align="right" sx={{ fontWeight: 700 }}>{fmtMoney(r.saldo_a_hoy, r.track)}</TableCell>
+                <TableCell align="right" sx={{ fontWeight: 700 }}>{fmtMoney(r.monto, r.track)}</TableCell>
                 <TableCell>{estadoChip(r.estado)}</TableCell>
+                <TableCell align="right">
+                  <Button size="small" variant="contained" onClick={() => abrirCobro(r)}>Cobrar</Button>
+                </TableCell>
               </TableRow>
             );
             return (
@@ -455,6 +584,7 @@ const CobrosList = () => {
                         <TableCell>Vence</TableCell>
                         <TableCell align="right">A cobrar (a hoy)</TableCell>
                         <TableCell>Estado</TableCell>
+                        <TableCell align="right">Acciones</TableCell>
                       </TableRow>
                     </TableHead>
                     <TableBody>
@@ -475,7 +605,7 @@ const CobrosList = () => {
                                 <TableCell align="right" sx={{ fontWeight: 700 }}>
                                   {subARS ? fmtMoney(subARS, 'ARS') : ''}{subARS && subUSD ? ' · ' : ''}{subUSD ? fmtMoney(subUSD, 'USD') : ''}
                                 </TableCell>
-                                <TableCell />
+                                <TableCell colSpan={2} />
                               </TableRow>
                             )}
                             {!colapsada && rows.map(filaCuota)}
@@ -485,6 +615,33 @@ const CobrosList = () => {
                     </TableBody>
                   </Table>
                   </Box>
+
+                  {/* Total del mes filtrado: fijo sobre el paginador, así que sigue
+                      visible al cambiar de página o colapsar obras. Pesos y dólares
+                      en líneas separadas: son tracks distintos, no se suman. */}
+                  <Box sx={{
+                    position: 'sticky', bottom: 0, zIndex: 2,
+                    px: 2, py: 1.25, bgcolor: 'background.paper',
+                    borderTop: '2px solid', borderColor: 'divider',
+                  }}>
+                    <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2}>
+                      <Box>
+                        <Typography variant="overline" color="text.secondary" display="block" lineHeight={1.4}>
+                          Total {gestionMes === 'todos' ? 'del filtro' : etiquetaPeriodo(gestionMes)}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {totalMes.cuotas} cuota{totalMes.cuotas === 1 ? '' : 's'} a cobrar
+                        </Typography>
+                      </Box>
+                      <Stack alignItems="flex-end">
+                        <Typography variant="h6" fontWeight={700} lineHeight={1.3}>{fmtMoney(totalMes.ARS, 'ARS')}</Typography>
+                        {totalMes.USD !== 0 && (
+                          <Typography variant="h6" fontWeight={700} lineHeight={1.3}>{fmtMoney(totalMes.USD, 'USD')}</Typography>
+                        )}
+                      </Stack>
+                    </Stack>
+                  </Box>
+
                   <TablePagination
                     component="div"
                     count={total}
@@ -694,6 +851,17 @@ const CobrosList = () => {
           {alert.message}
         </Alert>
       </Snackbar>
+
+      {/* Mismo diálogo de cobro que el detalle del plan y cobranzas de control de
+          obra: no hay flujo nuevo, sólo se monta en una pantalla más. */}
+      <CobroCuotaDialog
+        open={!!cobroSel}
+        cuota={cobroSel?.cuota}
+        plan={cobroSel?.plan}
+        empresaId={empresaId}
+        onClose={() => setCobroSel(null)}
+        onConfirm={confirmarCobro}
+      />
 
       {/* Diálogo confirmar eliminación */}
       <Dialog open={!!confirmEliminar} onClose={() => setConfirmEliminar(null)}>

--- a/src/pages/cobros/[id].js
+++ b/src/pages/cobros/[id].js
@@ -21,6 +21,11 @@ import {
   Snackbar,
   Alert,
   Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
@@ -496,13 +501,18 @@ const DetallePlanPage = () => {
       (plan.indexacion !== 'USD' && !!cacActual)
     );
   // Pendiente = lo que resta cobrar de cuotas no saldadas, a valor actualizado.
-  const pendienteAjustado = hasIndiceActual
+  // El backend ya lo calcula en el resumen (y el PDF dibuja ESE mismo número);
+  // el cálculo local queda como fallback contra un backend viejo.
+  const pendienteLocal = hasIndiceActual
     ? allCuotas
         .filter((c) => c.estado !== 'cobrada')
         .reduce((acc, c) => acc + Math.max(0, getMontoCuota(c) - (c.monto_cobrado || 0)), 0)
     : null;
+  const pendienteAjustado = resumen.pendiente_a_hoy != null ? resumen.pendiente_a_hoy : pendienteLocal;
   // Total = cobrado REAL + pendiente actualizado (no reajusta lo ya cobrado a valor de hoy).
-  const totalAjustado = hasIndiceActual ? (resumen.cobrado || 0) + pendienteAjustado : null;
+  const totalAjustado = resumen.total_a_hoy != null
+    ? resumen.total_a_hoy
+    : (hasIndiceActual ? (resumen.cobrado || 0) + pendienteLocal : null);
 
   return (
     <>
@@ -806,6 +816,56 @@ const DetallePlanPage = () => {
                   </Button>
                 </Stack>
               </Stack>
+            </Paper>
+          )}
+
+          {/* Composición del plan: cuánto era el presupuesto firmado y cuánto es
+              alcance agregado. Los "adicionales" son los anexos del plan. Los
+              números los calcula el backend (mismo resumen que consume el PDF),
+              así que pantalla y PDF no pueden divergir. */}
+          {resumen.tiene_adicionales && (
+            <Paper variant="outlined" sx={{ p: 2, mb: 3, borderRadius: 2 }}>
+              <Typography variant="subtitle2" fontWeight={700} mb={0.5}>Composición del plan</Typography>
+              <Typography variant="caption" color="text.secondary" display="block" mb={1.5}>
+                Valuado al {new Date(`${resumen.fecha_valuacion}T12:00:00`).toLocaleDateString('es-AR')}
+                {resumen.indice_usado?.valor ? ` · ${resumen.indice_usado.tipo} = ${Number(resumen.indice_usado.valor).toLocaleString('es-AR')}` : ''}
+              </Typography>
+              <Box sx={{ overflowX: 'auto' }}>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Concepto</TableCell>
+                      <TableCell align="right">Total</TableCell>
+                      <TableCell align="right">Cobrado</TableCell>
+                      <TableCell align="right">Resta cobrar</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    <TableRow>
+                      <TableCell>Presupuesto base</TableCell>
+                      <TableCell align="right">{formatCurrency(resumen.base, monedaDisplay)}</TableCell>
+                      <TableCell align="right" sx={{ color: 'success.main' }}>{formatCurrency(resumen.cobrado_base, monedaDisplay)}</TableCell>
+                      <TableCell align="right">{formatCurrency(resumen.pendiente_base, monedaDisplay)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>Adicionales ({(plan.anexos || []).length} anexo{(plan.anexos || []).length === 1 ? '' : 's'})</TableCell>
+                      <TableCell align="right">{formatCurrency(resumen.adicionales, monedaDisplay)}</TableCell>
+                      <TableCell align="right" sx={{ color: 'success.main' }}>{formatCurrency(resumen.cobrado_adicionales, monedaDisplay)}</TableCell>
+                      <TableCell align="right">{formatCurrency(resumen.pendiente_adicionales, monedaDisplay)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell sx={{ fontWeight: 700 }}>Total del plan</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 700 }}>{formatCurrency(resumen.total_a_hoy, monedaDisplay)}</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 700, color: 'success.main' }}>{formatCurrency(resumen.cobrado_a_hoy, monedaDisplay)}</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 700 }}>{formatCurrency(resumen.pendiente_a_hoy, monedaDisplay)}</TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </Box>
+              <Typography variant="caption" color="text.secondary" display="block" mt={1}>
+                Nominal pactado: {formatCurrency(resumen.nominal_pactado, monedaDisplay)}.
+                {' '}Los anexos cargados como cuota nueva se atribuyen exacto; los prorrateados, proporcional a cada cuota.
+              </Typography>
             </Paper>
           )}
 

--- a/src/pages/cobros/[id].js
+++ b/src/pages/cobros/[id].js
@@ -91,6 +91,7 @@ const DetallePlanPage = () => {
   const [usdActual, setUsdActual] = useState(null);
   // A2 (TAR-466 pt.1): desplegar el detalle de cuotas que componen el total cobrado
   const [showCobradoDetail, setShowCobradoDetail] = useState(false);
+  const [showComposicion, setShowComposicion] = useState(false);
   // Fase 4 — edición de total y saldo sin asignar
   const [showEditTotal, setShowEditTotal] = useState(false);
   const [editTotalValue, setEditTotalValue] = useState('');
@@ -644,6 +645,11 @@ const DetallePlanPage = () => {
                 subtitle: showCAC && cacIndiceBase
                   ? `${Math.round((resumen.total || 0) / cacIndiceBase).toLocaleString('es-AR')} CAC al crear`
                   : null,
+                // Sin anexos no hay nada que descomponer: base sería el total entero.
+                expandable: resumen.tiene_adicionales,
+                expanded: showComposicion,
+                onToggle: () => setShowComposicion((v) => !v),
+                detailColor: 'primary.main',
               },
               {
                 label: 'COBRADO',
@@ -651,6 +657,9 @@ const DetallePlanPage = () => {
                 borderColor: '#2E7D32',
                 subtitle: `${cuotasCobradas} de ${totalCuotas} cuotas`,
                 expandable: cuotasCobradas > 0,
+                expanded: showCobradoDetail,
+                onToggle: () => setShowCobradoDetail((v) => !v),
+                detailColor: 'success.main',
               },
               {
                 label: 'PENDIENTE',
@@ -662,7 +671,7 @@ const DetallePlanPage = () => {
               <Grid item xs={12} sm={4} key={m.label}>
                 <Paper
                   variant="outlined"
-                  onClick={m.expandable ? () => setShowCobradoDetail((v) => !v) : undefined}
+                  onClick={m.expandable ? m.onToggle : undefined}
                   sx={{
                     p: 2,
                     textAlign: 'center',
@@ -684,15 +693,15 @@ const DetallePlanPage = () => {
                   )}
                   {m.expandable && (
                     <Stack direction="row" spacing={0.5} justifyContent="center" alignItems="center" mt={0.5}>
-                      <Typography variant="caption" color="success.main" fontWeight={600}>
-                        {showCobradoDetail ? 'Ocultar detalle' : 'Ver detalle'}
+                      <Typography variant="caption" color={m.detailColor} fontWeight={600}>
+                        {m.expanded ? 'Ocultar detalle' : 'Ver detalle'}
                       </Typography>
                       <KeyboardArrowDownIcon
                         sx={{
                           fontSize: 16,
-                          color: 'success.main',
+                          color: m.detailColor,
                           transition: 'transform 0.2s',
-                          transform: showCobradoDetail ? 'rotate(180deg)' : 'none',
+                          transform: m.expanded ? 'rotate(180deg)' : 'none',
                         }}
                       />
                     </Stack>
@@ -701,6 +710,57 @@ const DetallePlanPage = () => {
               </Grid>
             ))}
           </Grid>
+
+          {/* Composición del plan: cuánto era el presupuesto firmado y cuánto es
+              alcance agregado. Los "adicionales" son los anexos del plan. Los
+              números los calcula el backend (mismo resumen que consume el PDF),
+              así que pantalla y PDF no pueden divergir. Va plegado dentro de la
+              card del total: es el desglose de ese número, no una sección aparte. */}
+          <Collapse in={showComposicion && !!resumen.tiene_adicionales} unmountOnExit>
+            <Paper variant="outlined" sx={{ p: 2, mb: 3, borderRadius: 2 }}>
+              <Typography variant="subtitle2" fontWeight={700} mb={0.5}>Composición del plan</Typography>
+              <Typography variant="caption" color="text.secondary" display="block" mb={1.5}>
+                Valuado al {new Date(`${resumen.fecha_valuacion}T12:00:00`).toLocaleDateString('es-AR')}
+                {resumen.indice_usado?.valor ? ` · ${resumen.indice_usado.tipo} = ${Number(resumen.indice_usado.valor).toLocaleString('es-AR')}` : ''}
+              </Typography>
+              <Box sx={{ overflowX: 'auto' }}>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Concepto</TableCell>
+                      <TableCell align="right">Total</TableCell>
+                      <TableCell align="right">Cobrado</TableCell>
+                      <TableCell align="right">Resta cobrar</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    <TableRow>
+                      <TableCell>Presupuesto base</TableCell>
+                      <TableCell align="right">{formatCurrency(resumen.base, monedaDisplay)}</TableCell>
+                      <TableCell align="right" sx={{ color: 'success.main' }}>{formatCurrency(resumen.cobrado_base, monedaDisplay)}</TableCell>
+                      <TableCell align="right">{formatCurrency(resumen.pendiente_base, monedaDisplay)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>Adicionales ({(plan.anexos || []).length} anexo{(plan.anexos || []).length === 1 ? '' : 's'})</TableCell>
+                      <TableCell align="right">{formatCurrency(resumen.adicionales, monedaDisplay)}</TableCell>
+                      <TableCell align="right" sx={{ color: 'success.main' }}>{formatCurrency(resumen.cobrado_adicionales, monedaDisplay)}</TableCell>
+                      <TableCell align="right">{formatCurrency(resumen.pendiente_adicionales, monedaDisplay)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell sx={{ fontWeight: 700 }}>Total del plan</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 700 }}>{formatCurrency(resumen.total_a_hoy, monedaDisplay)}</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 700, color: 'success.main' }}>{formatCurrency(resumen.cobrado_a_hoy, monedaDisplay)}</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 700 }}>{formatCurrency(resumen.pendiente_a_hoy, monedaDisplay)}</TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </Box>
+              <Typography variant="caption" color="text.secondary" display="block" mt={1}>
+                Nominal pactado: {formatCurrency(resumen.nominal_pactado, monedaDisplay)}.
+                {' '}Los anexos cargados como cuota nueva se atribuyen exacto; los prorrateados, proporcional a cada cuota.
+              </Typography>
+            </Paper>
+          </Collapse>
 
           {/* A2: detalle de cuotas cobradas que componen el total */}
           <Collapse in={showCobradoDetail} unmountOnExit>
@@ -816,56 +876,6 @@ const DetallePlanPage = () => {
                   </Button>
                 </Stack>
               </Stack>
-            </Paper>
-          )}
-
-          {/* Composición del plan: cuánto era el presupuesto firmado y cuánto es
-              alcance agregado. Los "adicionales" son los anexos del plan. Los
-              números los calcula el backend (mismo resumen que consume el PDF),
-              así que pantalla y PDF no pueden divergir. */}
-          {resumen.tiene_adicionales && (
-            <Paper variant="outlined" sx={{ p: 2, mb: 3, borderRadius: 2 }}>
-              <Typography variant="subtitle2" fontWeight={700} mb={0.5}>Composición del plan</Typography>
-              <Typography variant="caption" color="text.secondary" display="block" mb={1.5}>
-                Valuado al {new Date(`${resumen.fecha_valuacion}T12:00:00`).toLocaleDateString('es-AR')}
-                {resumen.indice_usado?.valor ? ` · ${resumen.indice_usado.tipo} = ${Number(resumen.indice_usado.valor).toLocaleString('es-AR')}` : ''}
-              </Typography>
-              <Box sx={{ overflowX: 'auto' }}>
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>Concepto</TableCell>
-                      <TableCell align="right">Total</TableCell>
-                      <TableCell align="right">Cobrado</TableCell>
-                      <TableCell align="right">Resta cobrar</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    <TableRow>
-                      <TableCell>Presupuesto base</TableCell>
-                      <TableCell align="right">{formatCurrency(resumen.base, monedaDisplay)}</TableCell>
-                      <TableCell align="right" sx={{ color: 'success.main' }}>{formatCurrency(resumen.cobrado_base, monedaDisplay)}</TableCell>
-                      <TableCell align="right">{formatCurrency(resumen.pendiente_base, monedaDisplay)}</TableCell>
-                    </TableRow>
-                    <TableRow>
-                      <TableCell>Adicionales ({(plan.anexos || []).length} anexo{(plan.anexos || []).length === 1 ? '' : 's'})</TableCell>
-                      <TableCell align="right">{formatCurrency(resumen.adicionales, monedaDisplay)}</TableCell>
-                      <TableCell align="right" sx={{ color: 'success.main' }}>{formatCurrency(resumen.cobrado_adicionales, monedaDisplay)}</TableCell>
-                      <TableCell align="right">{formatCurrency(resumen.pendiente_adicionales, monedaDisplay)}</TableCell>
-                    </TableRow>
-                    <TableRow>
-                      <TableCell sx={{ fontWeight: 700 }}>Total del plan</TableCell>
-                      <TableCell align="right" sx={{ fontWeight: 700 }}>{formatCurrency(resumen.total_a_hoy, monedaDisplay)}</TableCell>
-                      <TableCell align="right" sx={{ fontWeight: 700, color: 'success.main' }}>{formatCurrency(resumen.cobrado_a_hoy, monedaDisplay)}</TableCell>
-                      <TableCell align="right" sx={{ fontWeight: 700 }}>{formatCurrency(resumen.pendiente_a_hoy, monedaDisplay)}</TableCell>
-                    </TableRow>
-                  </TableBody>
-                </Table>
-              </Box>
-              <Typography variant="caption" color="text.secondary" display="block" mt={1}>
-                Nominal pactado: {formatCurrency(resumen.nominal_pactado, monedaDisplay)}.
-                {' '}Los anexos cargados como cuota nueva se atribuyen exacto; los prorrateados, proporcional a cada cuota.
-              </Typography>
             </Paper>
           )}
 

--- a/src/pages/cobros/[id].js
+++ b/src/pages/cobros/[id].js
@@ -462,6 +462,10 @@ const DetallePlanPage = () => {
   const usdFuenteLabel = (plan.usd_fuente || plan.cotizacion_snapshot?.dolar_fuente) === 'oficial' ? 'Oficial' : 'Blue';
   const indexacionLabel = plan.indexacion === 'CAC' ? `CAC ${cacTipoLabel}` : plan.indexacion === 'USD' ? `Dólar ${usdFuenteLabel}` : '';
   const allCuotas = plan.cuotas || [];
+  // Lo que se pliega bajo "Ver detalle" del total: de dónde sale el número
+  // (base vs. adicionales) y qué anexos lo movieron.
+  const anexos = plan.anexos || [];
+  const hayComposicion = !!resumen.tiene_adicionales || anexos.length > 0;
   const totalCuotas = allCuotas.length;
   const cuotasCobradas = allCuotas.filter((c) => c.estado === 'cobrada').length;
   const proximaCuota = allCuotas.find((c) => c.estado === 'pendiente' || c.estado === 'cobrada_parcial' || c.estado_ui === 'vencida' || c.estado_ui === 'cobrada_parcial_vencida');
@@ -646,7 +650,7 @@ const DetallePlanPage = () => {
                   ? `${Math.round((resumen.total || 0) / cacIndiceBase).toLocaleString('es-AR')} CAC al crear`
                   : null,
                 // Sin anexos no hay nada que descomponer: base sería el total entero.
-                expandable: resumen.tiene_adicionales,
+                expandable: hayComposicion,
                 expanded: showComposicion,
                 onToggle: () => setShowComposicion((v) => !v),
                 detailColor: 'primary.main',
@@ -716,7 +720,7 @@ const DetallePlanPage = () => {
               números los calcula el backend (mismo resumen que consume el PDF),
               así que pantalla y PDF no pueden divergir. Va plegado dentro de la
               card del total: es el desglose de ese número, no una sección aparte. */}
-          <Collapse in={showComposicion && !!resumen.tiene_adicionales} unmountOnExit>
+          <Collapse in={showComposicion && hayComposicion} unmountOnExit>
             <Paper variant="outlined" sx={{ p: 2, mb: 3, borderRadius: 2 }}>
               <Typography variant="subtitle2" fontWeight={700} mb={0.5}>Composición del plan</Typography>
               <Typography variant="caption" color="text.secondary" display="block" mb={1.5}>
@@ -755,7 +759,32 @@ const DetallePlanPage = () => {
                   </TableBody>
                 </Table>
               </Box>
-              <Typography variant="caption" color="text.secondary" display="block" mt={1}>
+              {/* Qué anexos componen la fila de adicionales. */}
+              {anexos.length > 0 && (
+                <Box mt={2}>
+                  <Typography variant="caption" color="text.secondary" fontWeight={700} display="block" mb={0.5}>
+                    ANEXOS
+                  </Typography>
+                  <Stack spacing={0.5}>
+                    {anexos.map((a) => (
+                      <Stack key={a.id} direction="row" justifyContent="space-between" alignItems="center"
+                        sx={{ py: 0.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+                        <Box>
+                          <Typography variant="body2">{a.motivo || 'Anexo'}</Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {a.fecha ? new Date(a.fecha).toLocaleDateString('es-AR') : ''} · {a.modo === 'nueva_cuota' ? 'cuota nueva' : 'prorrateado'}
+                            {a.monto_cac ? ` · ${Math.round(a.monto_cac * 100) / 100} CAC${a.cac_indice_ref ? ` @ ${a.cac_indice_ref.toLocaleString('es-AR')}` : ''}` : ''}
+                          </Typography>
+                        </Box>
+                        <Typography variant="body2" fontWeight={700} color={a.monto >= 0 ? 'success.main' : 'error.main'}>
+                          {a.monto >= 0 ? '+' : ''}{formatCurrency(a.monto, monedaDisplay)}
+                        </Typography>
+                      </Stack>
+                    ))}
+                  </Stack>
+                </Box>
+              )}
+              <Typography variant="caption" color="text.secondary" display="block" mt={1.5}>
                 Nominal pactado: {formatCurrency(resumen.nominal_pactado, monedaDisplay)}.
                 {' '}Los anexos cargados como cuota nueva se atribuyen exacto; los prorrateados, proporcional a cada cuota.
               </Typography>
@@ -875,30 +904,6 @@ const DetallePlanPage = () => {
                     Achicar plan al distribuido
                   </Button>
                 </Stack>
-              </Stack>
-            </Paper>
-          )}
-
-          {/* Historial de anexos */}
-          {(plan.anexos || []).length > 0 && (
-            <Paper variant="outlined" sx={{ p: 2, mb: 3, borderRadius: 2 }}>
-              <Typography variant="subtitle2" fontWeight={700} mb={1}>Anexos</Typography>
-              <Stack spacing={0.5}>
-                {(plan.anexos || []).map((a) => (
-                  <Stack key={a.id} direction="row" justifyContent="space-between" alignItems="center"
-                    sx={{ py: 0.5, borderBottom: '1px solid', borderColor: 'divider' }}>
-                    <Box>
-                      <Typography variant="body2">{a.motivo || 'Anexo'}</Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        {a.fecha ? new Date(a.fecha).toLocaleDateString('es-AR') : ''} · {a.modo === 'nueva_cuota' ? 'cuota nueva' : 'prorrateado'}
-                        {a.monto_cac ? ` · ${Math.round(a.monto_cac * 100) / 100} CAC${a.cac_indice_ref ? ` @ ${a.cac_indice_ref.toLocaleString('es-AR')}` : ''}` : ''}
-                      </Typography>
-                    </Box>
-                    <Typography variant="body2" fontWeight={700} color={a.monto >= 0 ? 'success.main' : 'error.main'}>
-                      {a.monto >= 0 ? '+' : ''}{formatCurrency(a.monto, monedaDisplay)}
-                    </Typography>
-                  </Stack>
-                ))}
               </Stack>
             </Paper>
           )}

--- a/src/utils/planCobro/__tests__/cashflowDetalle.test.js
+++ b/src/utils/planCobro/__tests__/cashflowDetalle.test.js
@@ -1,0 +1,113 @@
+import {
+  filasDeCelda,
+  totalPorTrack,
+  filasDeGestion,
+  filasRealizadoAnterior,
+  claveDeFila,
+} from '../cashflowDetalle';
+
+const fila = (over = {}) => ({
+  cuota_id: 'c1', tipo: 'esperado', bucket_key: '2026-08', track: 'ARS',
+  monto: 100, fecha: '2026-08-05', vencida: false, realizado_anterior: false,
+  ...over,
+});
+
+describe('filasDeCelda', () => {
+  const detalle = [
+    fila({ cuota_id: 'a', monto: 100, fecha: '2026-08-20' }),
+    fila({ cuota_id: 'b', monto: 250, fecha: '2026-08-03' }),
+    fila({ cuota_id: 'c', bucket_key: '2026-09' }),
+    fila({ cuota_id: 'd', track: 'USD' }),
+    fila({ cuota_id: 'e', tipo: 'cobrado' }),
+    fila({ cuota_id: 'f', bucket_key: null, vencida: true }),
+  ];
+
+  test('devuelve sólo las filas del período, track y tipo pedidos', () => {
+    const filas = filasDeCelda(detalle, { bucketKey: '2026-08', track: 'ARS', tipo: 'esperado' });
+    expect(filas.map((r) => r.cuota_id)).toEqual(['b', 'a']); // ordenadas por fecha
+  });
+
+  test('el desglose de una celda suma exactamente el total de esa celda', () => {
+    const filas = filasDeCelda(detalle, { bucketKey: '2026-08', track: 'ARS', tipo: 'esperado' });
+    expect(totalPorTrack(filas).ARS).toBe(350);
+  });
+
+  test('no mezcla el track de dólares con el de pesos', () => {
+    const usd = filasDeCelda(detalle, { bucketKey: '2026-08', track: 'USD', tipo: 'esperado' });
+    expect(usd.map((r) => r.cuota_id)).toEqual(['d']);
+  });
+
+  test('separa esperado de cobrado', () => {
+    const cobrado = filasDeCelda(detalle, { bucketKey: '2026-08', track: 'ARS', tipo: 'cobrado' });
+    expect(cobrado.map((r) => r.cuota_id)).toEqual(['e']);
+  });
+
+  test('las filas sin bucket no aparecen en ninguna celda', () => {
+    const conBucket = ['2026-08', '2026-09'].flatMap((bucketKey) =>
+      filasDeCelda(detalle, { bucketKey, track: 'ARS', tipo: 'esperado' }));
+    expect(conBucket.map((r) => r.cuota_id)).not.toContain('f');
+  });
+
+  test('tolera un detalle vacío o ausente', () => {
+    expect(filasDeCelda(undefined, { bucketKey: 'x', track: 'ARS', tipo: 'esperado' })).toEqual([]);
+  });
+});
+
+describe('totalPorTrack', () => {
+  test('suma cada moneda por separado y cuenta las cuotas', () => {
+    const total = totalPorTrack([
+      fila({ monto: 100 }),
+      fila({ monto: 250.5 }),
+      fila({ monto: 30, track: 'USD' }),
+    ]);
+    expect(total).toEqual({ ARS: 350.5, USD: 30, cuotas: 3 });
+  });
+
+  test('sin filas devuelve ceros', () => {
+    expect(totalPorTrack([])).toEqual({ ARS: 0, USD: 0, cuotas: 0 });
+  });
+
+  test('no arrastra error de coma flotante', () => {
+    expect(totalPorTrack([fila({ monto: 0.1 }), fila({ monto: 0.2 })]).ARS).toBe(0.3);
+  });
+});
+
+describe('filasDeGestion', () => {
+  test('deja sólo las filas de esperado', () => {
+    const filas = filasDeGestion([fila({ cuota_id: 'a' }), fila({ cuota_id: 'b', tipo: 'cobrado' })]);
+    expect(filas.map((r) => r.cuota_id)).toEqual(['a']);
+  });
+
+  test('mantiene las vencidas aunque no pertenezcan a ningún período', () => {
+    const filas = filasDeGestion([fila({ cuota_id: 'v', bucket_key: null, vencida: true })]);
+    expect(filas).toHaveLength(1);
+  });
+});
+
+describe('filasRealizadoAnterior', () => {
+  const detalle = [
+    fila({ cuota_id: 'ant2', tipo: 'cobrado', bucket_key: null, realizado_anterior: true, fecha: '2026-03-10' }),
+    fila({ cuota_id: 'ant1', tipo: 'cobrado', bucket_key: null, realizado_anterior: true, fecha: '2026-01-05' }),
+    fila({ cuota_id: 'usd', tipo: 'cobrado', bucket_key: null, realizado_anterior: true, track: 'USD' }),
+    fila({ cuota_id: 'dentro', tipo: 'cobrado' }),
+    fila({ cuota_id: 'esp', bucket_key: null, vencida: true }),
+  ];
+
+  test('devuelve los cobros previos a la ventana del track, ordenados por fecha', () => {
+    expect(filasRealizadoAnterior(detalle, 'ARS').map((r) => r.cuota_id)).toEqual(['ant1', 'ant2']);
+  });
+
+  test('no mezcla tracks ni arrastra filas de esperado o dentro de la ventana', () => {
+    expect(filasRealizadoAnterior(detalle, 'USD').map((r) => r.cuota_id)).toEqual(['usd']);
+  });
+
+  test('su total explica el realizado anterior del agregado', () => {
+    expect(totalPorTrack(filasRealizadoAnterior(detalle, 'ARS')).ARS).toBe(200);
+  });
+});
+
+describe('claveDeFila', () => {
+  test('distingue la fila de esperado de la de cobrado de la misma cuota', () => {
+    expect(claveDeFila(fila({ cuota_id: 'x' }))).not.toBe(claveDeFila(fila({ cuota_id: 'x', tipo: 'cobrado' })));
+  });
+});

--- a/src/utils/planCobro/cashflowDetalle.js
+++ b/src/utils/planCobro/cashflowDetalle.js
@@ -1,0 +1,59 @@
+/**
+ * Desglose del Cash Flow y totales de la vista de Gestión (TAR-683/684).
+ *
+ * El backend etiqueta cada fila del `detalle` con el mismo `bucket_key` que usó
+ * para armar el agregado, así que acá NO se re-implementa el bucketing: sólo se
+ * filtra. Esa es la razón por la que la suma del desglose siempre coincide con la
+ * celda de la que se abrió.
+ *
+ * Cada fila del detalle trae:
+ *   tipo        'esperado' | 'cobrado'
+ *   bucket_key  clave del período del agregado, o null si no pertenece a ninguno
+ *   track       'ARS' | 'USD' (la moneda en la que se cobra la cuota)
+ *   monto       lo que esa fila aporta a su celda
+ *   vencida / realizado_anterior  por qué la fila no tiene bucket
+ */
+
+/** Filas que componen una celda del Cash Flow (un período × track × esperado/cobrado). */
+export function filasDeCelda(detalle, { bucketKey, track, tipo }) {
+  return (detalle || [])
+    .filter((r) => r.bucket_key === bucketKey && r.track === track && r.tipo === tipo)
+    .sort((a, b) => (a.fecha || '9999').localeCompare(b.fecha || '9999'));
+}
+
+/** Total por moneda de un conjunto de filas. Pesos y dólares nunca se suman entre sí. */
+export function totalPorTrack(filas) {
+  return (filas || []).reduce(
+    (acc, r) => {
+      const track = r.track === 'USD' ? 'USD' : 'ARS';
+      acc[track] = Math.round((acc[track] + (Number(r.monto) || 0)) * 100) / 100;
+      acc.cuotas += 1;
+      return acc;
+    },
+    { ARS: 0, USD: 0, cuotas: 0 },
+  );
+}
+
+/**
+ * Filas que se reclaman en la vista de Gestión: las de esperado. Las de cobrado
+ * viven en el desglose del Cash Flow y no son trabajo de cobranza pendiente.
+ * Las vencidas se siguen listando aunque no pertenezcan a ningún período.
+ */
+export function filasDeGestion(detalle) {
+  return (detalle || []).filter((r) => r.tipo === 'esperado');
+}
+
+/**
+ * Cobros anteriores a la ventana del Cash Flow: el agregado los colapsa en
+ * `realizado_anterior` en vez de darles una fila, y esto explica cuáles son.
+ */
+export function filasRealizadoAnterior(detalle, track) {
+  return (detalle || [])
+    .filter((r) => r.tipo === 'cobrado' && r.realizado_anterior && r.track === track)
+    .sort((a, b) => (a.fecha || '9999').localeCompare(b.fecha || '9999'));
+}
+
+/** Clave estable de una fila del detalle (una cuota puede aparecer como esperado y como cobrado). */
+export function claveDeFila(fila) {
+  return `${fila.tipo}-${fila.cuota_id}`;
+}


### PR DESCRIPTION
Frontend de la épica del Plan de Cobros. Va con fedemaidan/sorby_bot_wa#301 — **ese va primero**, este depende de las filas de `cobrado` que agrega el detalle del backend.

Closes fedemaidan/sorby_bot_wa#295 (junto con el PR de backend).

## Qué hace

- **Desglosable** — el Cash Flow abre en modo tabla y cada período se expande a las cuotas que lo componen: una tabla de esperado (con botón Cobrar) y otra de cobrado (sin botón, no hay nada que cobrar ahí). El "realizado anterior" también se puede abrir.
- **Accionable** — botón Cobrar en cada fila del desglose y de Gestión, montando el `CobroCuotaDialog` que ya existía, sin tocarlo.
- **Total del mes** — barra fija al pie de Gestión con el total de **todas** las cuotas del mes filtrado, no sólo las de la página visible. ARS y USD en líneas separadas, con la cantidad de cuotas.
- **Compuesto** — el detalle del plan muestra presupuesto base / adicionales / total, con el cobrado y el pendiente de cada uno, plegado bajo el "Ver detalle" de la card del total junto con la lista de anexos.

## Arquitectura

El repo no tiene React Testing Library, así que toda la lógica vive fuera de los componentes: `src/utils/planCobro/cashflowDetalle.js` son funciones puras (`filasDeCelda`, `totalPorTrack`, `filasDeGestion`, `filasRealizadoAnterior`) y los componentes sólo dibujan.

El filtrado del desglose usa el `bucket_key` que calculó el backend, así que la suma cierra con la celda por construcción — el front no recalcula buckets.

## Tests

`src/utils/planCobro` → 39 pass. Incluyen que el desglose de una celda suma exactamente su total, que no se mezclan los tracks ARS/USD y que no se arrastra error de coma flotante.

`next build` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)